### PR TITLE
Fix map popup showing default 'grid' image if no image found rather than using image set on directory builder

### DIFF
--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -1418,7 +1418,12 @@ class Directorist_Listings {
 					$icon_type = substr($cat_icon, 0,2);
 					$fa_or_la = ('la' == $icon_type) ? "la " : "fa ";
 					$ls_data['cat_icon'] = ('none' == $cat_icon) ? 'fa fa-map-marker' : $fa_or_la . $cat_icon ;
-					$ls_data['default_img'] = atbdp_image_cropping(DIRECTORIST_ASSETS . 'images/grid.jpg', $ls_data['crop_width'], $ls_data['crop_height'], true, 100)['url'];
+
+					$directory_type = get_post_meta($listings_id, "_directory_type", true);
+					$general_config = get_term_meta( $directory_type, 'general_config', true );
+					$preview_image_dir_type = isset($general_config['preview_image']) && !empty($general_config['preview_image']) ? $general_config['preview_image']: '';
+					$default_image = !empty($preview_image_dir_type) ? $preview_image_dir_type:get_directorist_option('default_preview_image', DIRECTORIST_ASSETS . 'images/grid.jpg');
+					$ls_data['default_img'] = atbdp_image_cropping($default_image, $ls_data['crop_width'], $ls_data['crop_height'], true, 100)['url'];
 
 					if (!empty($ls_data['listing_prv_img'])) {
 						$ls_data['prv_image']   = atbdp_get_image_source($ls_data['listing_prv_img'], 'large');


### PR DESCRIPTION
Fix map popup showing default 'grid' image if no image found rather than using an image set on directory builder