### PR TITLE
Enforce using correct node/npm version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 
 /package-lock.json export-ignore
 /package.json export-ignore
+/.npmrc export-ignore
 
 /pot.js export-ignore
 /postcss.config.js export-ignore

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true


### PR DESCRIPTION
npm install/update command will throw error unless correct node engine version(specified in package.json) is used
Ref: https://stackoverflow.com/questions/29349684/how-can-i-specify-the-required-node-js-version-in-package-json