### PR TITLE
Small fix for global posts leading to "directorist_author_profile" shortcut-page

### DIFF
--- a/includes/model/ListingAuthor.php
+++ b/includes/model/ListingAuthor.php
@@ -52,19 +52,20 @@ class Directorist_Listing_Author {
 	// extract_user_id
 	public function extract_user_id( $user_id = '' ) {
 		$user_id = urldecode($user_id); //decode the URL to remove encoded spaces, special characters
-		$extracted_user_id = ( is_numeric( $user_id ) ) ? $user_id : get_current_user_id();
-
+		
+		if(is_numeric( $user_id )) {
+            return intval( $user_id );
+        }
 		if ( is_string( $user_id ) && ! empty( $user_id ) ) {
-			$user = get_user_by( 'login', $user_id );
-
-			if ( $user ) {
-				$extracted_user_id = $user->ID;
-			}
+            if($user = \WP_User::get_data_by( 'login', $user_id )) {
+                return $user->ID;
+            }
+            if($user = \WP_User::get_data_by( 'slug', $user_id )) {
+                return $user->ID;
+            }
 		}
-
-		$extracted_user_id = intval( $extracted_user_id );
-
-		return $extracted_user_id;
+        
+		return get_current_user_id();
 	}
 
 	public function prepare_data() {


### PR DESCRIPTION
In our theme (typer) url to author profile is taken not from login but from "user_nicename".

So everything I needed to do is to add is get_user_by( 'slug', $user_id) in addition to existing get_user_by( 'login', $user_id).

But if "get user_by()" doesn't find matching user (with \WP_User::get_data_by( $field, $user_id )) it just returns current user (making "get_current_user_id()" in the function redundant).

So I made a small refactor to make code cleaner and add slug check