### PR TITLE
Fix for pagination in multilingual (wpml) directory

### DIFF
--- a/includes/classes/class-rewrite.php
+++ b/includes/classes/class-rewrite.php
@@ -60,6 +60,9 @@ class ATBDP_Rewrite {
 	protected function get_page_slug( $page_id, $default_slug ) {
 		$home_url = home_url( '/' );
 		$slug     = str_replace( $home_url, '', get_permalink( $page_id ) );
+		if(function_exists('wpml_get_current_language') && $home_url != ($site_url = site_url().'/')) {
+            $slug     = str_replace( $site_url, '', $slug );
+        }
 		$slug     = rtrim( $slug, '/' );
 		$slug     = preg_match( '/([?])/', $slug ) ? $default_slug : $slug;
 


### PR DESCRIPTION
In our wpml setup we have languages in separate "directories" (like "site", "site/pt-pr", "site/pt-br', "site/ru", "site/uk"). 

So when (at line 62) we attempt to remove home_url ("site/uk") from link ("site/permalink") it doesn't find the string and leaves the whole site address inside "pages" rewrite rule. 

Leading to 404 when we our non english speaking visitors are trying to see page 2 of directory.