### PR TITLE
add an option to show only listing categories using the directorist categories widget

### DIFF
--- a/includes/widgets/all-categories.php
+++ b/includes/widgets/all-categories.php
@@ -33,6 +33,7 @@ class All_Categories extends \WP_Widget {
             'hide_empty'            => 1,
             'show_count'            => 1,
             'single_only'           => 1,
+            'listing_cats'          => 1,
 		];
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
@@ -88,6 +89,10 @@ class All_Categories extends \WP_Widget {
 				'label'   => esc_html__( 'Display only on single listing', 'directorist' ),
 				'type'    => 'checkbox',
 			],
+            'listing_cats' => [
+                'label'   => esc_html__( 'Display only Listing Categories', 'directorist' ),
+                'type'    => 'checkbox',
+            ],
         ];
 
 		Widget_Fields::create( $fields, $instance, $this );
@@ -105,6 +110,7 @@ class All_Categories extends \WP_Widget {
         $instance['show_count']         = ! empty( $new_instance['show_count'] ) ? 1 : 0;
         $instance['single_only']        = ! empty( $new_instance['single_only'] ) ? 1 : 0;
         $instance['max_number']         = ! empty( $new_instance['max_number'] ) ? $new_instance['max_number'] : '';
+        $instance['listing_cats']       = ! empty( $new_instance['listing_cats'] ) ? 1 : 0;
 
 		return $instance;
 	}
@@ -133,6 +139,7 @@ class All_Categories extends \WP_Widget {
             'max_number'     => !empty( $instance['max_number'] ) ? $instance['max_number'] : '',
             'show_count'     => !empty( $instance['show_count'] ) ? 1 : 0,
             'single_only'    => !empty( $instance['single_only'] ) ? 1 : 0,
+            'listing_cats'    => !empty( $instance['listing_cats'] ) ? 1 : 0,
             'pad_counts'     => true,
             'immediate_category' => ! empty( $instance['immediate_category'] ) ? 1 : 0,
             'active_term_id' => 0,
@@ -187,6 +194,10 @@ class All_Categories extends \WP_Widget {
             'child_of'     => 0,
             'number'       => !empty($settings['max_number']) ? $settings['max_number'] : ''
         );
+
+        if($settings['listing_cats']) {
+            $args['object_ids'] = get_the_ID();
+        }
 
         $terms = get_terms( $args );
         $parent = $args['parent'];
@@ -255,6 +266,10 @@ class All_Categories extends \WP_Widget {
             'hierarchical' => ! empty( $settings['hide_empty'] ) ? true : false,
             'number'       => !empty($settings['max_number']) ? $settings['max_number'] : ''
         );
+        
+        if($settings['listing_cats']) {
+            $args['object_ids'] = get_the_ID();
+        }
 
         $terms = get_terms( $args );
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [x] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Add the Directorist - Categories widget to Listing Right Sidebar
2. Turn on the Display only Listing Categories
3. Check on frontend to see if its showing only categories that are assigned to that particular listing. 

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
