### PR TITLE
used default role set on WordPress Settings as the role on user registration

### DIFF
--- a/includes/classes/class-user.php
+++ b/includes/classes/class-user.php
@@ -154,6 +154,7 @@ if ( ! class_exists( 'ATBDP_User' ) ) :
 		 */
 		private function complete_registration($username, $password, $email, $website, $first_name, $last_name, $bio) {
 			global $reg_errors, $username, $password, $email, $website, $first_name, $last_name,  $bio;
+			$default_role = get_option( 'default_role', 'subscriber' );
 			$reg_errors = new WP_Error;
 			if ( 1 > count( $reg_errors->get_error_messages() ) ) {
 				$userdata = array(
@@ -164,7 +165,7 @@ if ( ! class_exists( 'ATBDP_User' ) ) :
 					'first_name'  => $first_name,
 					'last_name'   => $last_name,
 					'description' => $bio,
-					'role'        => 'subscriber', // @since 7.0.6.3
+					'role'        => $default_role, // @since 7.0.6.3
 				);
 
 				return wp_insert_user( $userdata ); // return inserted user id or a WP_Error


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Set a default role on Settings > General
2. Create a new account, it should now have the role on Settings (instead of Subscriber regardless of whatever its on Settings)
3.

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
