### PR TITLE
added an option to set default view type per directory

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1596,7 +1596,7 @@ function atbdp_get_listings_orderby_options($sort_by_items)
  * @since    4.0.0
  *
  */
-function atbdp_get_listings_current_view_name($view)
+function atbdp_get_listings_current_view_name($view, $directory_type)
 {
 
 
@@ -1609,9 +1609,12 @@ function atbdp_get_listings_current_view_name($view)
         array_push($allowed_views, 'listings_with_map');
     }
     if (!in_array($view, $allowed_views)) {
-        $listing_view = get_directorist_option('default_listing_view');
-        $listings_settings = !empty($listing_view) ? $listing_view : 'grid';
-        $view = $listings_settings;
+        $view = get_term_meta($directory_type, 'default_view_type', true);
+        if(empty($view)) {
+            $listing_view = get_directorist_option('default_listing_view');
+            $listings_settings = !empty($listing_view) ? $listing_view : 'grid';
+            $view = $listings_settings;
+        }
     }
 
 

--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -239,7 +239,7 @@ class Directorist_Listings {
 
 	public function prepare_atts_data() {
 		$defaults = array(
-			'view'                     => $this->options['listing_view'],
+			'view'                     => !empty(get_term_meta($this->get_current_listing_type(), 'default_view_type', true)) ? get_term_meta($this->get_current_listing_type(), 'default_view_type', true) : $this->options['listing_view'],
 			'_featured'                => 1,
 			'filterby'                 => '',
 			'orderby'                  => $this->options['order_listing_by'],
@@ -271,7 +271,7 @@ class Directorist_Listings {
 		$defaults  = apply_filters( 'atbdp_all_listings_params', $defaults );
 		$this->params = shortcode_atts( $defaults, $this->atts );
 
-		$this->view                     = atbdp_get_listings_current_view_name( $this->params['view'] );
+		$this->view                     = atbdp_get_listings_current_view_name( $this->params['view'], $this->get_current_listing_type() );
 		$this->_featured                = $this->params['_featured'];
 		$this->filterby                 = $this->params['filterby'];
 		$this->orderby                  = $this->params['orderby'];

--- a/includes/modules/multi-directory-setup/class-multi-directory-manager.php
+++ b/includes/modules/multi-directory-setup/class-multi-directory-manager.php
@@ -4506,6 +4506,25 @@ class Multi_Directory_Manager
                     ],
                 ],
             ] ),
+            'default_view_type' => [
+                'label' => __('Default View Type', 'directorist'),
+                'type'  => 'select',
+                'value' => 'grid',
+                'options' => [
+                    [
+                        'label' => __('Grid', 'directorist'),
+                        'value' => 'grid',
+                    ],
+                    [
+                        'label' => __('List', 'directorist'),
+                        'value' => 'list',
+                    ],
+                    [
+                        'label' => __('Map', 'directorist'),
+                        'value' => 'map',
+                    ],
+                ],
+            ],
 
         ]);
 
@@ -4685,6 +4704,17 @@ class Multi_Directory_Manager
                                 'description' => '<a target="_blank" href="https://directorist.com/documentation/directorist/form-and-layout-builder/multiple-directories/"> '. __( 'Need help?', 'directorist' ) .' </a>' . __( 'Read the documentation or open a ticket in our helpdesk.', 'directorist' ),
                                 'fields' => [
                                     'listings_card_list_view'
+                                ],
+                            ],
+                        ],
+                    ],
+                    'settings' => [
+                        'label' => __( 'Settings', 'directorist' ),
+                        'sections' => [
+                            'listings_default_view' => [
+                                'title' => __('Default View', 'directorist'),
+                                'fields' => [
+                                    'default_view_type'
                                 ],
                             ],
                         ],


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [x] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Go to Directory Builder > All Listings Layout > Settings
2. Set a view type
3. Now this should be respected regardless of what is set on Settings > All Listings
4. However, what it won't respect is what is set on the shortcode, shortcode one will get preference. 

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
