### PR TITLE
Fix: date time format on archive and single listing page

### DIFF
--- a/templates/archive/custom-fields/date.php
+++ b/templates/archive/custom-fields/date.php
@@ -6,6 +6,8 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
+
+$date_format = get_option( 'date_format' );
 ?>
 
-<div class="directorist-listing-card-date"><?php directorist_icon( $icon );?><?php $listings->print_label( $label ); ?><?php echo esc_html( $value ); ?></div>
+<div class="directorist-listing-card-date"><?php directorist_icon( $icon );?><?php $listings->print_label( $label ); ?><?php echo esc_html( date( $date_format, strtotime( esc_html( $value ) ) ) ); ?></div>

--- a/templates/archive/custom-fields/time.php
+++ b/templates/archive/custom-fields/time.php
@@ -6,6 +6,8 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
+
+$time_format = get_option( 'time_format' );
 ?>
 
-<div class="directorist-listing-card-time"><?php directorist_icon( $icon ); ?><?php $listings->print_label( $label ); ?><?php echo esc_html( $value ); ?></div>
+<div class="directorist-listing-card-time"><?php directorist_icon( $icon ); ?><?php $listings->print_label( $label ); ?><?php echo esc_html( date( $time_format, strtotime( esc_html( $value ) ) ) ); ?></div>

--- a/templates/single/custom-fields/time.php
+++ b/templates/single/custom-fields/time.php
@@ -6,6 +6,8 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
+
+$time_format = get_option( 'time_format' );
 ?>
 
 <div class="directorist-single-info directorist-single-info-time">
@@ -15,6 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 		<span class="directorist-single-info__label--text"><?php echo esc_html( $data['label'] ); ?></span>
 	</div>
 
-	<div class="directorist-single-info__value"><?php echo esc_html( date( 'h:i A', strtotime( esc_html( $value ) ) ) ); ?></div>
+	<div class="directorist-single-info__value"><?php echo esc_html( date( $time_format, strtotime( esc_html( $value ) ) ) ); ?></div>
 
 </div>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Date time format was not following the Wordpress default date time format.
We received a good number of requests from customers.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
