### PR TITLE
Refactor and fix edit listing email sending time

### DIFF
--- a/includes/asset-loader/localized_data.php
+++ b/includes/asset-loader/localized_data.php
@@ -124,7 +124,7 @@ class Localized_Data {
 
 		$listing_id           = 0;
 		$current_url          = ( ! empty( $_SERVER['REQUEST_URI'] ) ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		$current_listing_type = isset( $_GET['directory_type'] ) ? sanitize_text_field( wp_unslash( $_GET['directory_type'] ) ) : get_post_meta( $listing_id, '_directory_type', true );
+		$current_listing_type = isset( $_GET['directory_type'] ) ? sanitize_text_field( wp_unslash( $_GET['directory_type'] ) ) : directorist_get_listing_directory( $listing_id );
 
 		if( ! empty( $current_listing_type ) && ! is_numeric( $current_listing_type ) ) {
 			$term = get_term_by( 'slug', $current_listing_type, ATBDP_TYPE );

--- a/includes/class-helper.php
+++ b/includes/class-helper.php
@@ -21,7 +21,7 @@ class Helper {
 
 	public static function get_directory_type_term_data( $post_id = '', string $term_key = '' ) {
 		$post_id        = ( ! empty( $post_id ) ) ? $post_id : get_the_ID();
-		$directory_type = get_post_meta( $post_id, '_directory_type', true );
+		$directory_type = directorist_get_listing_directory( $post_id );
 		$directory_type = ( ! empty( $directory_type ) ) ? $directory_type : default_directory_type();
 
 		return get_term_meta( $directory_type, $term_key, true );

--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -968,7 +968,7 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 			// Updating listing
 			wp_update_post( $post_array );
 
-			$directory_type = get_post_meta( $listing_id, '_directory_type', true );
+			$directory_type = directorist_get_listing_directory( $listing_id );
 			// Update the post_meta into the database
 			// TODO: Status has been migrated, remove related code.
 			// $old_status = get_post_meta( $listing_id, '_listing_status', true );

--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -409,15 +409,8 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 				self::upload_images( $listing_id, $posted_data );
 
 				$permalink = get_permalink( $listing_id );
-				// no pay extension own yet let treat as general user
 
-				$redirect_page     = get_directorist_option( 'edit_listing_redirect', 'view_listing' );
-
-				if ( 'view_listing' === $redirect_page ) {
-					$data['redirect_url'] = $permalink;
-				} else {
-					$data['redirect_url'] = add_query_arg( 'listing_id', $listing_id, ATBDP_Permalink::get_dashboard_page_link() );
-				}
+				$data['redirect_url'] = $permalink;
 
 				if ( (bool) get_directorist_option( 'submission_confirmation', 1 ) ) {
 					$data['redirect_url'] = add_query_arg( 'notice', true, $data['redirect_url'] );
@@ -441,7 +434,7 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 					}
 				}
 
-				$data['success'] = true;
+				$data['success']     = true;
 				$data['success_msg'] = __( 'Your listing submission is completed! Redirecting...', 'directorist' );
 				$data['preview_url'] = $permalink;
 
@@ -463,9 +456,14 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 					$data['redirect_url'] = Helper::escape_query_strings_from_url( $posted_data['redirect_url'] );
 				}
 
-				$data['redirect_url'] = urlencode( wp_nonce_url( $data['redirect_url'], 'directorist_listing_form_redirect_url_' . $listing_id, '_token' ) );
+				if ( $preview_enable ) {
+					$data['redirect_url'] = wp_nonce_url( $data['redirect_url'], 'directorist_listing_form_redirect_url_' . $listing_id, '_token' );
+				}
+
+				$data['redirect_url'] = urlencode( $data['redirect_url'] );
 
 				wp_send_json( apply_filters( 'atbdp_listing_form_submission_info', $data ) );
+
 			} catch (Exception $e ) {
 				return wp_send_json( array(
 					'error'     => true,

--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -411,20 +411,17 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 				$permalink = get_permalink( $listing_id );
 				// no pay extension own yet let treat as general user
 
-				$submission_notice = get_directorist_option( 'submission_confirmation', 1 );
 				$redirect_page     = get_directorist_option( 'edit_listing_redirect', 'view_listing' );
 
 				if ( 'view_listing' === $redirect_page ) {
-					$redirect_url = $permalink;
+					$data['redirect_url'] = $permalink;
 				} else {
-					$redirect_url = add_query_arg( 'listing_id', $listing_id, ATBDP_Permalink::get_dashboard_page_link() );
+					$data['redirect_url'] = add_query_arg( 'listing_id', $listing_id, ATBDP_Permalink::get_dashboard_page_link() );
 				}
 
 				if ( (bool) get_directorist_option( 'submission_confirmation', 1 ) ) {
-					$redirect_url = urlencode( add_query_arg( 'notice', true, $redirect_url ) );
+					$data['redirect_url'] = add_query_arg( 'notice', true, $data['redirect_url'] );
 				}
-
-				$data['redirect_url'] = $redirect_url;
 
 				$is_listing_featured = ( ! empty( $posted_data['listing_type'] ) && ( 'featured' === $posted_data['listing_type'] ) );
 				$should_monetize     = ( directorist_is_monetization_enabled() && directorist_is_featured_listing_enabled() && $is_listing_featured );
@@ -465,6 +462,8 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 				if ( ! empty( $posted_data['redirect_url'] ) ) {
 					$data['redirect_url'] = Helper::escape_query_strings_from_url( $posted_data['redirect_url'] );
 				}
+
+				$data['redirect_url'] = urlencode( wp_nonce_url( $data['redirect_url'], 'directorist_listing_form_redirect_url_' . $listing_id, '_token' ) );
 
 				wp_send_json( apply_filters( 'atbdp_listing_form_submission_info', $data ) );
 			} catch (Exception $e ) {

--- a/includes/classes/class-email.php
+++ b/includes/classes/class-email.php
@@ -14,11 +14,12 @@ if ( ! class_exists( 'ATBDP_Email' ) ) :
 			add_action( 'atbdp_listing_inserted', array( $this, 'notify_admin_listing_submitted' ) );
 			add_action( 'atbdp_listing_inserted', array( $this, 'notify_owner_listing_submitted' ) );
 			/*Fire up emails for updated/edited listings */
-			add_action( 'atbdp_listing_updated', array( $this, 'notify_admin_listing_edited' ) );
-			add_action( 'atbdp_listing_updated', array( $this, 'notify_owner_listing_edited' ) );
+			add_action( 'atbdp_listing_updated', array( $this, 'send_email_after_listing_updated' ), 10, 2 );
+			add_action( 'directorist_listing_status_updated', array( $this, 'send_email_after_listing_preview_status_updated' ), 10, 2 );
 			/*Fire up emails for published listings */
 			add_action( 'atbdp_listing_published', array( $this, 'notify_admin_listing_published' ) );
 			add_action( 'atbdp_listing_published', array( $this, 'notify_owner_listing_published' ) );
+
 			/*Fire up emails for created order*/
 			add_action( 'atbdp_order_created', array( $this, 'notify_admin_order_created' ), 10, 2 );
 			add_action( 'atbdp_order_created', array( $this, 'notify_owner_order_created' ), 10, 2 );
@@ -43,6 +44,24 @@ if ( ! class_exists( 'ATBDP_Email' ) ) :
 			/*Fire up emails when a general user apply for become author user*/
 			add_action( 'atbdp_become_author', array( $this, 'notify_admin_become_author' ) );
 			// add_action('atbdp_become_author', array($this, 'notify_owner_become_author'));
+		}
+
+		public function send_email_after_listing_preview_status_updated( $listing_id, $args ) {
+			$directory_id = directorist_get_listing_directory( $listing_id );
+
+			if ( directorist_is_preview_enabled( $directory_id ) && $args['edited'] ) {
+				$this->notify_admin_listing_edited( $listing_id );
+				$this->notify_owner_listing_edited( $listing_id );
+			}
+		}
+
+		public function send_email_after_listing_updated( $listing_id ) {
+			$directory_id = directorist_get_listing_directory( $listing_id );
+
+			if ( ! directorist_is_preview_enabled( $directory_id ) ) {
+				$this->notify_admin_listing_edited( $listing_id );
+				$this->notify_owner_listing_edited( $listing_id );
+			}
 		}
 
 		  /**
@@ -1214,7 +1233,7 @@ We look forward to seeing you soon'
 			To activate your account simply click on the link below and verify your email address within 24 hours. For your safety, you will not be able to access your account until verification of your email has been completed.
 
 			==CONFIRM_EMAIL_ADDRESS_URL==
-            
+
             <p align="center">If you did not sign up for this account you can ignore this email.</p>'
 			);
 

--- a/includes/classes/class-email.php
+++ b/includes/classes/class-email.php
@@ -714,7 +714,7 @@ This email is sent automatically for information purpose only. Please do not res
 			$user = $this->get_owner( $listing_id );
 			$subject = $this->replace_in_content( get_directorist_option( 'email_sub_edit_listing' ), null, $listing_id, $user );
 			$to = $user->user_email;
-			$directory_type = get_post_meta( $listing_id, '_directory_type', true );
+			$directory_type = directorist_get_listing_directory( $listing_id );
 			$edited_status  = directorist_get_listing_edit_status( $directory_type );
 			if ( 'publish' === $edited_status ) {
 				$body = $this->replace_in_content( get_directorist_option( 'email_tmpl_edit_listing' ), null, $listing_id, $user );

--- a/includes/classes/class-listing.php
+++ b/includes/classes/class-listing.php
@@ -133,6 +133,10 @@ if (!class_exists('ATBDP_Listing')):
 				return;
 			}
 
+			if ( ! $this->validate_nonce( $listing_id ) ) {
+				return;
+			}
+
 			// Retrieve directory ID and validate or set it if not numeric
 			$directory_id = $this->get_or_set_directory_id( $listing_id );
 			if ( ! $directory_id ) {
@@ -152,6 +156,20 @@ if (!class_exists('ATBDP_Listing')):
 
 			// Trigger custom action after updating listing status
 			do_action( 'directorist_listing_status_updated', $listing_id, $args );
+		}
+
+		protected function validate_nonce( $listing_id ) {
+			if ( ! isset( $_GET['_token'] ) ) {
+				return false;
+			}
+
+			$nonce = wp_unslash( $_GET['_token'] );
+
+			if ( ! wp_verify_nonce( $nonce, 'directorist_listing_form_redirect_url_' . $listing_id ) ) {
+				return false;
+			}
+
+			return true;
 		}
 
 		protected function get_listing_id_from_request() {

--- a/includes/classes/class-listing.php
+++ b/includes/classes/class-listing.php
@@ -146,16 +146,13 @@ if (!class_exists('ATBDP_Listing')):
 			// Prepare status for post update
 			$args = $this->prepare_post_update_args( $listing_id, $directory_id );
 
-			// If the post status is already the same, don't update it
-			if ( get_post_status( $listing_id ) === $args['post_status'] ) {
-				return;
-			}
-
 			// Update post status
 			wp_update_post( $args );
 
 			// Trigger custom action after updating listing status
 			do_action( 'directorist_listing_status_updated', $listing_id, $args );
+
+			wp_safe_redirect( remove_query_arg( [ '_token', 'edited', 'post_id', 'reviewed' ] ) );
 		}
 
 		protected function validate_nonce( $listing_id ) {

--- a/includes/classes/class-listing.php
+++ b/includes/classes/class-listing.php
@@ -171,7 +171,7 @@ if (!class_exists('ATBDP_Listing')):
 		}
 
 		protected function get_or_set_directory_id( $listing_id ) {
-			$directory_id = get_post_meta( $listing_id, '_directory_type', true );
+			$directory_id = directorist_get_listing_directory( $listing_id );
 
 			// Check if directory_id is numeric, if not try to retrieve and set it
 			if ( ! is_numeric( $directory_id ) ) {
@@ -227,7 +227,7 @@ if (!class_exists('ATBDP_Listing')):
 				return;
 			};
 
-            $directory_type = get_post_meta( $listing_id, '_directory_type', true );
+            $directory_type = directorist_get_listing_directory( $listing_id );
             $post_status = get_term_meta( $directory_type, 'new_listing_status', true );
 
             $order_meta = get_post_meta( $order_id );

--- a/includes/classes/class-metabox.php
+++ b/includes/classes/class-metabox.php
@@ -226,7 +226,7 @@ class ATBDP_Metabox {
         wp_enqueue_script( 'atbdp-markerclusterer' );
 		$all_types     	= directory_types();
 		$default     	= default_directory_type();
-		$current_type   =  get_post_meta( $post->ID, '_directory_type', true );
+		$current_type   = directorist_get_listing_directory( $post->ID );
 		$value 			= $current_type ? $current_type : $default;
 		wp_nonce_field( 'listing_info_action', 'listing_info_nonce' );
 

--- a/includes/classes/class-permalink.php
+++ b/includes/classes/class-permalink.php
@@ -33,7 +33,7 @@ class ATBDP_Permalink {
 		}
 
 		$directory_slug = '';
-		$directory_id   = (int) get_post_meta( $post_id, '_directory_type', true );
+		$directory_id   = directorist_get_listing_directory( $post_id );
 
         if ( $directory_id ) {
             $directory_term = get_term( $directory_id, ATBDP_DIRECTORY_TYPE );

--- a/includes/directorist-directory-functions.php
+++ b/includes/directorist-directory-functions.php
@@ -302,6 +302,13 @@ function directorist_get_category_custom_field_relations( $directory_id ) {
 	return $relations;
 }
 
+/**
+ * Check if the given directory has preview mode enabled.
+ *
+ * @param  int $directory_id
+ *
+ * @return bool
+ */
 function directorist_is_preview_enabled( $directory_id ) {
 	return (bool) directorist_get_directory_meta( $directory_id, 'preview_mode' );
 }

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -289,10 +289,8 @@ function atbdp_get_listing_status_after_submission( array $args = [] ) {
     // Set default values and sanitize input parameters
     $args = array_merge( [
         'id'     => 0,
-        'edited' => 'no',  // Default to 'no' if not set
+        'edited' => false,  // Default to false if not set
     ], $args);
-
-    $args['edited'] = filter_var( $args['edited'], FILTER_VALIDATE_BOOLEAN );
 
     $listing_id            = $args['id'];
     $listing_status        = $args['edited'] ? $args['edit_status'] : $args['create_status'];
@@ -4638,4 +4636,16 @@ function directorist_get_distance_range( $miles ) {
     }
 
     return array( 'min' => $min_distance, 'max' => $max_distance );
+}
+
+/**
+ * Get listing directory id.
+ *
+ * @since 8.0.3
+ * @param  int  $listing_id
+ *
+ * @return int
+ */
+function directorist_get_listing_directory( $listing_id = 0 ) {
+	return (int) get_post_meta( $listing_id, '_directory_type', true );
 }

--- a/includes/model/ListingDashboard.php
+++ b/includes/model/ListingDashboard.php
@@ -176,15 +176,14 @@ class Directorist_Listing_Dashboard {
 	}
 
 	public function get_listing_type() {
-		$id   = get_the_ID();
-		$type = get_post_meta( $id, '_directory_type', true );
+		$type = directorist_get_listing_directory( get_the_ID() );
 		$term = get_term( $type );
 		return !empty( $term->name ) ? $term->name : '';
 	}
 
 	public function get_listing_thumbnail() {
 		$id                = get_the_ID();
-		$type              = get_post_meta( $id, '_directory_type', true );
+		$type              = directorist_get_listing_directory( $id );
 
 		$default_image_src = Helper::default_preview_image_src( $type );
 		$image_quality     = get_directorist_option('preview_image_quality', 'directorist_preview');
@@ -226,7 +225,7 @@ class Directorist_Listing_Dashboard {
 
 		if ( $fav_listings->have_posts() ){
 			foreach ( $fav_listings->posts as $post ) {
-				$listing_type  = get_post_meta( $post->ID, '_directory_type', true );
+				$listing_type  = directorist_get_listing_directory( $post->ID );
 				$title         = ! empty( $post->post_title ) ? $post->post_title : __( 'Untitled', 'directorist' );
 				$cats          = get_the_terms( $post->ID, ATBDP_CATEGORY );
 				$category      = get_post_meta( $post->ID, '_admin_category_select', true );

--- a/includes/model/ListingForm.php
+++ b/includes/model/ListingForm.php
@@ -570,9 +570,9 @@ class Directorist_Listing_Form {
 		if ( ! is_admin() && $this->all_fields_only_for_admin( $section_data['fields'] ) ) {
 			return; // Exit if all fields are only for admin
 		}
-		
+
 		$load_section = apply_filters( 'directorist_section_template', true, $args );
-		
+
 		if( $load_section && ! empty( $section_data['fields'] ) ) {
 			Helper::get_template( 'listing-form/section', $args );
 		}
@@ -583,14 +583,14 @@ class Directorist_Listing_Form {
 		if ( empty( $fields ) ) {
 			return false;
 		}
-	
+
 		// Check if all fields have 'only_for_admin' set to 1 or true
 		foreach ( $fields as $field ) {
 			if ( empty( $field['only_for_admin'] ) ) {
 				return false; // If any field is not for admin, return false
 			}
 		}
-	
+
 		return true; // All fields are for admin
 	}
 
@@ -757,7 +757,7 @@ class Directorist_Listing_Form {
 	public function get_current_listing_type() {
 		$listing_types      = $this->get_listing_types();
 		$listing_type_count = count( $listing_types );
-		$get_listing_type   = get_post_meta( $this->add_listing_id, '_directory_type', true );
+		$get_listing_type   = directorist_get_listing_directory( $this->add_listing_id );
 
 		if ( $listing_type_count == 1 ) {
 			$type = array_key_first( $listing_types );

--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -953,7 +953,7 @@ class Directorist_Listings {
 				/**
 				 * Filters the custom field meta query used in Directorist search functionality.
 				 *
-				 * This filter allows customization of the meta query for specific search criteria 
+				 * This filter allows customization of the meta query for specific search criteria
 				 * by modifying the meta query parameters, key, and values.
 				 *
 				 * @since 8.0
@@ -1050,7 +1050,7 @@ class Directorist_Listings {
 				'compare' => 'LIKE'
 			);
 		}
-		
+
 		if ( 'address' == $this->radius_search_based_on && ! empty( $_REQUEST['miles'] ) && ! empty( $_REQUEST['address'] ) && ! empty( $_REQUEST['cityLat'] ) && ! empty( $_REQUEST['cityLng'] ) ) {
 			$distance =	directorist_get_distance_range( $_REQUEST['miles'] );
 ;			$args['atbdp_geo_query'] = array(
@@ -1506,7 +1506,7 @@ class Directorist_Listings {
 					$ls_data['prv_image'] = atbdp_get_image_source( $ls_data['listing_prv_img'], 'large' );
 				}
 
-				$listing_type  				= get_post_meta( $listings_id, '_directory_type', true );
+				$listing_type  				= directorist_get_listing_directory( $listings_id );
 				$ls_data['default_image'] 	= Helper::default_preview_image_src( $listing_type );
 
 				if ( ! empty( $ls_data['listing_img'][0] ) ) {
@@ -1592,7 +1592,7 @@ class Directorist_Listings {
 					$cat_icon = directorist_icon( $this->loop_map_cat_icon(), false );
 					$ls_data['cat_icon'] = json_encode( $cat_icon );
 
-					$listing_type  			= get_post_meta( $listings_id, '_directory_type', true );
+					$listing_type  			= directorist_get_listing_directory( $listings_id );
 					$ls_data['default_img'] = Helper::default_preview_image_src( $listing_type );
 
 					if (!empty($ls_data['listing_prv_img'])) {
@@ -1675,11 +1675,11 @@ class Directorist_Listings {
 				}
 				return $image;
 			}
-			
+
 			$thumbnail_img_id = array_filter($thumbnail_img_id, function($value) {
 				return is_numeric($value);
 			});
-			
+
 			$image_count = count( $thumbnail_img_id );
 
 			if ( 1 === (int) $image_count ) {

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -937,12 +937,11 @@ class Directorist_Single_Listing {
 			return '';
 		}
 
-		$listing_id = isset( $_GET['post_id'] ) ? absint( $_GET['post_id'] ) : 0;
-		if ( $listing_id && ! directorist_is_listing_post_type( $listing_id ) ) {
+		if ( ! directorist_is_listing_post_type( get_the_ID() ) ) {
 			return;
 		}
 
-		if ( get_post_status( $listing_id ) === 'publish' ) {
+		if ( get_post_status( get_the_ID() ) === 'publish' ) {
 			$message = get_directorist_option(
 				'publish_confirmation_msg',
 				__( 'Congratulations! Your listing has been approved/published. Now it is publicly available.', 'directorist' )

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -527,7 +527,7 @@ class Directorist_Single_Listing {
 		$listing_id    = $this->id;
 		$listing_title = get_the_title( $listing_id );
 
-		$type          = (int) get_post_meta( $this->id, '_directory_type', true );
+		$type          = directorist_get_listing_directory( $this->id );
 		$default_image = Helper::default_preview_image_src( $type );
 
 		$image_size = apply_filters( 'directorist_single_listing_slider_image_size', 'large' );

--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -490,7 +490,7 @@ class ATBDP_Order
     {
         $old_status     = get_post_meta( $post_id, '_payment_status', true);
         $listing_id     = get_post_meta( $post_id, '_listing_id', true);
-        $directory_type = get_post_meta( $listing_id, '_directory_type', true );
+        $directory_type = directorist_get_listing_directory( $listing_id );
 		$new_l_status 	= get_term_meta( $directory_type, 'new_listing_status', true );
         $new_status     = str_replace('set_to_', '', $action);
         $new_status     = sanitize_key($new_status);

--- a/includes/rest-api/Version1/class-listings-controller.php
+++ b/includes/rest-api/Version1/class-listings-controller.php
@@ -752,7 +752,7 @@ class Listings_Controller extends Posts_Controller {
 					$base_data['tagline'] = get_post_meta( $listing->ID, '_tagline', true );
 					break;
 				case 'directory':
-					$base_data['directory'] = (int) get_post_meta( $listing->ID, '_directory_type', true );
+					$base_data['directory'] = directorist_get_listing_directory( $listing->ID );
 					break;
 				case 'date_expired':
 					$base_data['date_expired'] = directorist_rest_prepare_date_response( get_post_meta( $listing->ID, '_expiry_date', true ) );
@@ -837,7 +837,7 @@ class Listings_Controller extends Posts_Controller {
 	}
 
 	protected function get_related_listings_ids( $listing_id ) {
-		$directory_type = (int) get_post_meta( $listing_id, '_directory_type', true );
+		$directory_type = directorist_get_listing_directory( $listing_id );
 		$number         = get_directorist_type_option( $directory_type, 'similar_listings_number_of_listings_to_show', 2 );
 		$same_author    = get_directorist_type_option( $directory_type, 'listing_from_same_author', false );
 		$logic          = get_directorist_type_option( $directory_type, 'similar_listings_logics', 'OR' );

--- a/templates/payment/checkout.php
+++ b/templates/payment/checkout.php
@@ -117,7 +117,7 @@ use \Directorist\Helper;
                     </div>
                 </div>
             </div>
-            
+
 
             <?php if ( $subtotal > 0 ) : ?>
             <div class="directorist-card directorist-mt-30 directorist-payment-gateways directorist-mb-15 directorist-checkout-card directorist-checkout-payment" id="directorist_payment_gateways">
@@ -140,7 +140,7 @@ use \Directorist\Helper;
             <p id="atbdp_checkout_errors" class="text-danger"></p>
 
             <?php wp_nonce_field('checkout_action', 'checkout_nonce');
-            $directory_type 	 = get_post_meta( $listing_id, '_directory_type', true );
+            $directory_type 	 = directorist_get_listing_directory( $listing_id );
 		    $new_l_status 	     = get_term_meta( $directory_type, 'new_listing_status', true );
             $monitization        = directorist_is_monetization_enabled();
             $featured_enabled    = directorist_is_featured_listing_enabled();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix
- Improvement
- Refactoring (no functional changes, no api changes)

## Description
A listing edit email is sent when the edited listing is not even submitted after the preview when the preview is enabled.

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
