### PR TITLE
fixed translate issue with WP 6.7

### DIFF
--- a/directorist-base.php
+++ b/directorist-base.php
@@ -358,6 +358,10 @@ final class Directorist_Base
 	// add_polylang_swicher_support
 	public function add_polylang_swicher_support() {
 
+		if ( is_admin() && get_transient( '_directorist_setup_page_redirect' ) ) {
+			directorist_redirect_to_admin_setup_wizard();
+		}
+		
 		// beta plugin lookup
 		$plugin_data = get_plugin_data( plugin_dir_path( __FILE__ ) . 'directorist-base.php' );
 
@@ -643,9 +647,6 @@ final class Directorist_Base
 		load_textdomain( 'directorist', WP_LANG_DIR . '/plugins/directorist-' . $locale . '.mo' );
 	
 		load_plugin_textdomain( 'directorist', false, ATBDP_LANG_DIR );
-		if ( is_admin() && get_transient( '_directorist_setup_page_redirect' ) ) {
-			directorist_redirect_to_admin_setup_wizard();
-		}
 	}
 
 	/**

--- a/directorist-base.php
+++ b/directorist-base.php
@@ -636,9 +636,12 @@ final class Directorist_Base
 	}
 
 	public function load_textdomain() {
-		// Load from global languages directory
-		load_textdomain( 'directorist', WP_LANG_DIR . '/plugins/directorist-' . get_locale() . '.mo' );
-
+		// Determine the current locale
+		$locale = determine_locale();
+		// Allow filters to modify the locale
+		$locale = apply_filters( 'plugin_locale', $locale, 'directorist' );
+		load_textdomain( 'directorist', WP_LANG_DIR . '/plugins/directorist-' . $locale . '.mo' );
+	
 		load_plugin_textdomain( 'directorist', false, ATBDP_LANG_DIR );
 		if ( is_admin() && get_transient( '_directorist_setup_page_redirect' ) ) {
 			directorist_redirect_to_admin_setup_wizard();

--- a/directorist-base.php
+++ b/directorist-base.php
@@ -194,7 +194,7 @@ final class Directorist_Base
 			self::$instance = new Directorist_Base();
 			self::$instance->setup_constants();
 
-			add_action('plugins_loaded', array(self::$instance, 'load_textdomain'));
+			add_action('init', array(self::$instance, 'load_textdomain'));
 			add_action('plugins_loaded', array(self::$instance, 'add_polylang_swicher_support') );
 			add_action('widgets_init', array(self::$instance, 'register_widgets'));
 			add_filter('widget_display_callback', array(self::$instance, 'custom_widget_body_wrapper'), 10, 3);
@@ -635,10 +635,11 @@ final class Directorist_Base
 		}
 	}
 
-	public function load_textdomain()
-	{
+	public function load_textdomain() {
+		// Load from global languages directory
+		load_textdomain( 'directorist', WP_LANG_DIR . '/plugins/directorist-' . get_locale() . '.mo' );
 
-		load_plugin_textdomain('directorist', false, ATBDP_LANG_DIR);
+		load_plugin_textdomain( 'directorist', false, ATBDP_LANG_DIR );
 		if ( is_admin() && get_transient( '_directorist_setup_page_redirect' ) ) {
 			directorist_redirect_to_admin_setup_wizard();
 		}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Translation not working in WP 6.7
2. Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the directorist domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.) in /Users/mac/Local Sites/directorist-v8/app/public/wp-includes/functions.php on line 6114
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
