### PR TITLE
All Listing Slider Issue on Initial Load - Fixed

### DIFF
--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -1809,6 +1809,9 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
         var sliderRangeShow = sliderItem.querySelector('.directorist-custom-range-slider__range__show');
         var sliderRangeValue = sliderItem.querySelector('.directorist-custom-range-slider__wrap .directorist-custom-range-slider__range');
         var isRTL = document.dir === 'rtl';
+
+        // init rangeInitiLoad on initial Load
+        var rangeInitLoad = true;
         (_directoristCustomRan = directoristCustomRangeSlider) === null || _directoristCustomRan === void 0 || _directoristCustomRan.create(slider, {
           start: [0, sliderDefaultValue ? sliderDefaultValue : 100],
           connect: true,
@@ -1827,9 +1830,14 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
           sliderRangeShow && (sliderRangeShow.innerHTML = rangeValue);
           if (sliderRangeValue) {
             sliderRangeValue.setAttribute('value', rangeValue);
-            $(sliderRangeValue).trigger('change');
+            if (!rangeInitLoad) {
+              $(sliderRangeValue).trigger('change'); // Trigger change event
+            }
           }
         });
+
+        // false rangeInitLoad after call
+        rangeInitLoad = false;
         minInput.addEventListener('change', function () {
           var minValue = Math.round(parseInt(this.value, 10) / sliderStep) * sliderStep;
           var maxValue = Math.round(parseInt(maxInput.value, 10) / sliderStep) * sliderStep;

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -996,6 +996,9 @@ import './components/directoristSelect';
                 let sliderRangeValue = sliderItem.querySelector('.directorist-custom-range-slider__wrap .directorist-custom-range-slider__range');
                 let isRTL = document.dir === 'rtl';
 
+                // init rangeInitiLoad on initial Load
+                let rangeInitLoad = true;
+    
                 directoristCustomRangeSlider?.create(slider, {
                     start: [0, sliderDefaultValue ? sliderDefaultValue : 100],
                     connect: true,
@@ -1015,9 +1018,14 @@ import './components/directoristSelect';
                     sliderRangeShow && (sliderRangeShow.innerHTML = rangeValue);
                     if (sliderRangeValue) {
                         sliderRangeValue.setAttribute('value', rangeValue);
-                        $(sliderRangeValue).trigger('change'); 
+                        if (!rangeInitLoad) {
+                            $(sliderRangeValue).trigger('change'); // Trigger change event
+                        }
                     }
                 });
+
+                // false rangeInitLoad after call
+                rangeInitLoad = false;
 
                 minInput.addEventListener('change', function () {
                     let minValue = Math.round(parseInt(this.value, 10) / sliderStep) * sliderStep;
@@ -1043,6 +1051,7 @@ import './components/directoristSelect';
                     slider.directoristCustomRangeSlider.set([null, maxValue]);
                 });
             });
+
         }
 
         directorist_custom_range_slider();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

All Listing Slider is not working on initial load. The issue is caused for range-slider AJAX search. Fixed the issue by turn off change trigger on rang- slider initialization. 

**Before:** https://prnt.sc/2d5qETTeQpHy 
**After:** https://prnt.sc/YrSawIn06V7V | https://prnt.sc/4y7OFXXzc9QF

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
