### PR TITLE
Fixed: missing space in the listing card heading title when the author l…

### DIFF
--- a/assets/css/all-listings.css
+++ b/assets/css/all-listings.css
@@ -17643,6 +17643,9 @@ input.directorist-toggle-input:checked + .directorist-toggle-input-label span.di
      object-fit: cover;
   border-radius: 10px;
 }
+.map-listing-card-single__author + .map-listing-card-single__content {
+  padding-top: 0;
+}
 .map-listing-card-single__author a {
   width: 42px;
   height: 42px;
@@ -17662,7 +17665,7 @@ input.directorist-toggle-input:checked + .directorist-toggle-input-label span.di
   border-radius: 100%;
 }
 .map-listing-card-single__content {
-  padding: 0 10px 10px;
+  padding: 15px 10px 10px;
 }
 .map-listing-card-single__content__title {
   font-size: 16px;

--- a/assets/css/all-listings.rtl.css
+++ b/assets/css/all-listings.rtl.css
@@ -17642,6 +17642,9 @@ input.directorist-toggle-input:checked + .directorist-toggle-input-label span.di
      object-fit: cover;
   border-radius: 10px;
 }
+.map-listing-card-single__author + .map-listing-card-single__content {
+  padding-top: 0;
+}
 .map-listing-card-single__author a {
   width: 42px;
   height: 42px;
@@ -17661,7 +17664,7 @@ input.directorist-toggle-input:checked + .directorist-toggle-input-label span.di
   border-radius: 100%;
 }
 .map-listing-card-single__content {
-  padding: 0 10px 10px;
+  padding: 15px 10px 10px;
 }
 .map-listing-card-single__content__title {
   font-size: 16px;

--- a/assets/css/public-main.css
+++ b/assets/css/public-main.css
@@ -17643,6 +17643,9 @@ input.directorist-toggle-input:checked + .directorist-toggle-input-label span.di
      object-fit: cover;
   border-radius: 10px;
 }
+.map-listing-card-single__author + .map-listing-card-single__content {
+  padding-top: 0;
+}
 .map-listing-card-single__author a {
   width: 42px;
   height: 42px;
@@ -17662,7 +17665,7 @@ input.directorist-toggle-input:checked + .directorist-toggle-input-label span.di
   border-radius: 100%;
 }
 .map-listing-card-single__content {
-  padding: 0 10px 10px;
+  padding: 15px 10px 10px;
 }
 .map-listing-card-single__content__title {
   font-size: 16px;

--- a/assets/css/public-main.rtl.css
+++ b/assets/css/public-main.rtl.css
@@ -17642,6 +17642,9 @@ input.directorist-toggle-input:checked + .directorist-toggle-input-label span.di
      object-fit: cover;
   border-radius: 10px;
 }
+.map-listing-card-single__author + .map-listing-card-single__content {
+  padding-top: 0;
+}
 .map-listing-card-single__author a {
   width: 42px;
   height: 42px;
@@ -17661,7 +17664,7 @@ input.directorist-toggle-input:checked + .directorist-toggle-input-label span.di
   border-radius: 100%;
 }
 .map-listing-card-single__content {
-  padding: 0 10px 10px;
+  padding: 15px 10px 10px;
 }
 .map-listing-card-single__content__title {
   font-size: 16px;

--- a/assets/js/range-slider.js
+++ b/assets/js/range-slider.js
@@ -562,7 +562,7 @@ __webpack_require__.r(__webpack_exports__);
           - The provided value for the option;
           - A reference to the options object;
           - The name for the option;
-       The testing function returns false when an error is detected,
+        The testing function returns false when an error is detected,
       or true when everything is OK. It can also modify the option
       object, to make sure all values can be correctly looped elsewhere. */
   //region Defaults

--- a/assets/src/scss/component/listings/_listing-map.scss
+++ b/assets/src/scss/component/listings/_listing-map.scss
@@ -237,6 +237,9 @@
     }
   }
   @include e(author) {
+    + .map-listing-card-single__content{
+      padding-top: 0;
+    }
     a {
       width: 42px;
       height: 42px;
@@ -254,7 +257,7 @@
     }
   }
   @include e(content) {
-    padding: 0 10px 10px;
+    padding: 15px 10px 10px;
     @include e(title) {
       font-size: 16px;
       font-weight: 500;


### PR DESCRIPTION
Missing space in the listing card heading title when the author image hidden 

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.Go to the single listing page, click on the map, and the listing card will appear. If you manually remove the author, you will notice spacing issues https://prnt.sc/2pxNEMXHF_qz
2.
3.

Before
https://prnt.sc/4pVqfnngx_cp

After
https://prnt.sc/4JcdLYPvh9aI

## Any linked issues
Fixes #


## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
