### PR TITLE
fixed fatal error issue when update the plugin from v7 to v8. added all listings & search result layout during  migration for no sidebar  selection

### DIFF
--- a/includes/classes/class-upgrade.php
+++ b/includes/classes/class-upgrade.php
@@ -69,9 +69,11 @@ class ATBDP_Upgrade
 		);
 	
 		if ( $account ) {
-			$options['signin_signup_page'] = (int) $account;
-			$options['marker_shape_color'] 	= '#444752';
-			$options['marker_icon_color'] 	= '#ffffff';
+			$options['signin_signup_page'] 		= (int) $account;
+			$options['marker_shape_color'] 		= '#444752';
+			$options['marker_icon_color'] 		= '#ffffff';
+			$options['all_listing_layout'] 		= 'no_sidebar';
+			$options['search_result_layout'] 	= 'no_sidebar';
 			
 			update_option( 'atbdp_option', $options );
 		}
@@ -125,6 +127,14 @@ class ATBDP_Upgrade
 			$description = ! empty( $header_contents['options']['content_settings']['listing_description']['enable'] ) ? $header_contents['options']['content_settings']['listing_description']['enable'] : false;
 			$tagline     = ! empty( $header_contents['options']['content_settings']['listing_title']['enable_tagline'] ) ? $header_contents['options']['content_settings']['listing_title']['enable_tagline'] : false;
 			$contents    = get_term_meta( $directory_type->term_id, 'single_listings_contents', true );
+
+			// Initialize contents if empty
+			if ( empty( $contents ) ) {
+				$contents = [
+					'fields' => [],
+					'groups' => [],
+				];
+			}
 	
 			if ( $description ) {
 	
@@ -261,17 +271,20 @@ class ATBDP_Upgrade
 
 	private function search_field_label_migration( $directory_id ) {
 		$search_fields = get_term_meta( $directory_id, 'search_form_fields', true );
-		$fields        = empty( $search_fields['fields'] ) ? [] : $search_fields['fields'];
+		$search_fields = is_array( $search_fields ) ? $search_fields : [];
+		$fields        = isset( $search_fields['fields'] ) && is_array( $search_fields['fields'] ) ? $search_fields['fields'] : [];
 
 		foreach ( $fields as $key => $field ) {
-			$placeholder    = empty( $field['placeholder'] ) ? '' : $field['placeholder'];
-			$label          = empty( $field['label'] ) ? $placeholder : $field['label'];
+			$placeholder    = ! empty( $field['placeholder'] ) ? $field['placeholder'] : '';
+			$label          = ! empty( $field['label'] ) ? $field['label'] : $placeholder;
 			$field['label'] = $label;
 
 			$search_fields['fields'][ $key ] = $field;
 		}
 
-		update_term_meta( $directory_id, 'search_form_fields', $search_fields );
+		if ( ! empty( $search_fields ) ) {
+			update_term_meta( $directory_id, 'search_form_fields', $search_fields );
+		}
 	}
 
 	public function support_themes_hook( $data ) {

--- a/includes/classes/class-upgrade.php
+++ b/includes/classes/class-upgrade.php
@@ -275,8 +275,8 @@ class ATBDP_Upgrade
 		$fields        = isset( $search_fields['fields'] ) && is_array( $search_fields['fields'] ) ? $search_fields['fields'] : [];
 
 		foreach ( $fields as $key => $field ) {
-			$placeholder    = ! empty( $field['placeholder'] ) ? $field['placeholder'] : '';
-			$label          = ! empty( $field['label'] ) ? $field['label'] : $placeholder;
+			$placeholder    = empty( $field['placeholder'] ) ? '' : $field['placeholder'];
+			$label          = empty( $field['label'] ) ? $placeholder : $field['label'];
 			$field['label'] = $label;
 
 			$search_fields['fields'][ $key ] = $field;

--- a/includes/modules/multi-directory-setup/class-multi-directory-manager.php
+++ b/includes/modules/multi-directory-setup/class-multi-directory-manager.php
@@ -93,6 +93,14 @@ class Multi_Directory_Manager {
         $old_review_settings = get_term_meta( $term_id, 'review_config', true );
         $new_review_builder  = get_term_meta( $term_id, 'single_listings_contents', true );
 
+        // If no value is found, initialize the new review builder structure
+        if ( empty( $new_review_builder ) ) {
+            $new_review_builder = [
+                'fields' => [],
+                'groups' => [],
+            ];
+        }
+
         // Update review_cookies_consent in the 'groups' array if the review widget exists
         if ( ! empty( $old_review_settings['review_cookies_consent'] ) && is_array( $new_review_builder['groups'] ) ) {
             foreach ( $new_review_builder['groups'] as &$group ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Some users face a fatal error when migrating from version 7 to version 8. This issue causes missing content in the Single Listing Builder in version 7, missing fields or groups in the review section of the Single Listing Builder in version 7, and missing fields as an array in the search field.

2. Set the default value to "Popup Filter" in the All Listings and Search Results layout for existing users (v7).
3.

## Any linked issues
Fixes #
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/380
issue no 2.

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
