### PR TITLE
Fixed updated sign-in/up option value

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1969,17 +1969,10 @@ function atbdp_is_page($atbdppages = '')
                 return true;
             }
             break;
-        case 'registration':
-            if (is_page() && get_the_ID() == get_directorist_option('custom_registration')) {
+        case 'signin_signup' || 'login' || 'registration':
+            if (is_page() && get_the_ID() == get_directorist_option('signin_signup_page')) {
                 return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_custom_registration')) {
-                return true;
-            }
-            break;
-        case 'login':
-            if (is_page() && get_the_ID() == get_directorist_option('user_login')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_user_login')) {
+            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_signin_signup')) {
                 return true;
             }
             break;

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1969,7 +1969,10 @@ function atbdp_is_page($atbdppages = '')
                 return true;
             }
             break;
-        case 'signin_signup' || 'login' || 'registration':
+        
+        case 'signin_signup':
+        case 'login':
+        case 'registration':
             if (is_page() && get_the_ID() == get_directorist_option('signin_signup_page')) {
                 return true;
             } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_signin_signup')) {

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1958,17 +1958,17 @@ if ( ! function_exists('atbdp_is_page') ) {
         // Check if the specified page type matches the current page.
         if ( isset( $page_map[ $page_type ] ) ) {
             $option    = $page_map[ $page_type ]['option'];
-            $shortcode = $page_map[ $page_type ]['shortcode'];
             $page_id   = get_directorist_option( $option );
 
-            // Verify the page ID or the presence of the shortcode in the page content.
             if ( is_page( $page_id ) ) {
-                $is_matching_page = ( get_the_ID() == $page_id );
-                $has_matching_shortcode = isset( $post->post_content ) && has_shortcode( $post->post_content, $shortcode );
+                return true;
+            }
 
-                if ( $is_matching_page || $has_matching_shortcode ) {
-                    return true;
-                }
+            $shortcode     = $page_map[ $page_type ]['shortcode'];
+            $has_shortcode = isset( $post->post_content ) && has_shortcode( $post->post_content, $shortcode );
+
+            if ( $has_shortcode ) {
+                return true;
             }
         }
 

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1882,109 +1882,98 @@ endif;
  * @since   1.0.0
  * @since   1.5.6 Added to check GD invoices and GD checkout pages.
  */
-function atbdp_is_page($atbdppages = '')
-{
-    global $post;
+if ( ! function_exists('atbdp_is_page') ) {
+    function atbdp_is_page( $page_type = '' ) {
+        global $post;
 
-    $atbdppages = preg_replace( '/[-]/', '_', $atbdppages );
+        // Normalize page type by replacing dashes with underscores for consistency.
+        $page_type = str_replace( '-', '_', $page_type );
 
-    switch ($atbdppages):
-        case 'home':
-            if (is_page() && get_the_ID() == get_directorist_option('search_listing')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_search_listing')) {
-                return true;
-            }
-            break;
-        case 'search_result':
-            if (is_page() && get_the_ID() == get_directorist_option('search_result_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_search_result')) {
-                return true;
-            }
-            break;
-        case 'add_listing':
-            if (is_page() && get_the_ID() == get_directorist_option('add_listing_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_add_listing')) {
-                return true;
-            }
-            break;
-        case 'all_listing':
-            if (is_page() && get_the_ID() == get_directorist_option('all_listing_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_all_listing')) {
-                return true;
-            }
-            break;
-        case 'dashboard':
-            if (is_page() && get_the_ID() == get_directorist_option('user_dashboard')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_user_dashboard')) {
-                return true;
-            }
-            break;
-        case 'author':
-            if (is_page() && get_the_ID() == get_directorist_option('author_profile_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_author_profile')) {
-                return true;
-            }
-            break;
-        case 'category':
-            if (is_page() && get_the_ID() == get_directorist_option('all_categories_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_all_categories')) {
-                return true;
-            }
-            break;
-        case 'single_listing':
-            return is_singular('at_biz_dir');
-            break;
-        case 'single_category':
-            if (is_page() && get_the_ID() == get_directorist_option('single_category_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_category')) {
-                return true;
-            }
-            break;
-        case 'all_locations':
-            if (is_page() && get_the_ID() == get_directorist_option('all_locations_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_all_locations')) {
-                return true;
-            }
-            break;
-        case 'single_location':
-            if (is_page() && get_the_ID() == get_directorist_option('single_location_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_location')) {
-                return true;
-            }
-            break;
-        case 'single_tag':
-            if (is_page() && get_the_ID() == get_directorist_option('single_tag_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_tag')) {
-                return true;
-            }
-            break;
-        
-        case 'signin_signup':
-        case 'login':
-        case 'registration':
-            if (is_page() && get_the_ID() == get_directorist_option('signin_signup_page')) {
-                return true;
-            } elseif (is_page() && isset($post->post_content) && has_shortcode($post->post_content, 'directorist_signin_signup')) {
-                return true;
-            }
-            break;
+        // Handle singular page types separately.
+        if ( $page_type === 'single_listing' ) {
+            return is_singular( 'at_biz_dir' );
+        }
 
-    endswitch;
+        // Map page types to their corresponding options and shortcodes.
+        $page_map = [
+            'home' => [
+                'option'    => 'search_listing',
+                'shortcode' => 'directorist_search_listing',
+            ],
+            'search_result' => [
+                'option'    => 'search_result_page',
+                'shortcode' => 'directorist_search_result',
+            ],
+            'add_listing' => [
+                'option'    => 'add_listing_page',
+                'shortcode' => 'directorist_add_listing',
+            ],
+            'all_listing' => [
+                'option'    => 'all_listing_page',
+                'shortcode' => 'directorist_all_listing',
+            ],
+            'dashboard' => [
+                'option'    => 'user_dashboard',
+                'shortcode' => 'directorist_user_dashboard',
+            ],
+            'author' => [
+                'option'    => 'author_profile_page',
+                'shortcode' => 'directorist_author_profile',
+            ],
+            'category' => [
+                'option'    => 'all_categories_page',
+                'shortcode' => 'directorist_all_categories',
+            ],
+            'single_category' => [
+                'option'    => 'single_category_page',
+                'shortcode' => 'directorist_category',
+            ],
+            'all_locations' => [
+                'option'    => 'all_locations_page',
+                'shortcode' => 'directorist_all_locations',
+            ],
+            'single_location' => [
+                'option'    => 'single_location_page',
+                'shortcode' => 'directorist_location',
+            ],
+            'single_tag' => [
+                'option'    => 'single_tag_page',
+                'shortcode' => 'directorist_tag',
+            ],
+            'signin_signup' => [
+                'option'    => 'signin_signup_page',
+                'shortcode' => 'directorist_signin_signup',
+            ],
+            'login' => [
+                'option'    => 'signin_signup_page',
+                'shortcode' => 'directorist_signin_signup',
+            ],
+            'registration' => [
+                'option'    => 'signin_signup_page',
+                'shortcode' => 'directorist_signin_signup',
+            ],
+        ];
 
-    //endif;
+        // Check if the specified page type matches the current page.
+        if ( isset( $page_map[ $page_type ] ) ) {
+            $option    = $page_map[ $page_type ]['option'];
+            $shortcode = $page_map[ $page_type ]['shortcode'];
+            $page_id   = get_directorist_option( $option );
 
-    return false;
+            // Verify the page ID or the presence of the shortcode in the page content.
+            if ( is_page( $page_id ) ) {
+                $is_matching_page = ( get_the_ID() == $page_id );
+                $has_matching_shortcode = isset( $post->post_content ) && has_shortcode( $post->post_content, $shortcode );
+
+                if ( $is_matching_page || $has_matching_shortcode ) {
+                    return true;
+                }
+            }
+        }
+
+        // Return false if no match is found.
+        return false;
+    }
 }
 
 /**

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1882,6 +1882,7 @@ endif;
  * @since   1.0.0
  * @since   1.5.6 Added to check GD invoices and GD checkout pages.
  */
+
 if ( ! function_exists('atbdp_is_page') ) {
     function atbdp_is_page( $page_type = '' ) {
         global $post;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
There were two different options login and registration.  In version 8, we merged both options. That is why the previous option does not function. And does not upodate the value of the current option.

1. prev: there was no options for setting sing-in/up page
2. Current: https://prnt.sc/gJlTn54X31Wd
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
