### PR TITLE
Refactor listing image getter functions

### DIFF
--- a/includes/classes/class-helper.php
+++ b/includes/classes/class-helper.php
@@ -109,10 +109,10 @@ if ( ! class_exists( 'ATBDP_Helper' ) ) :
 			$blur_background   = $is_blur;
 			$background_color  = get_directorist_option( 'prv_background_color', 'gainsboro' );
 
-			$listing_img     = get_post_meta( get_the_ID(), '_listing_img', true );
+			$listing_img     = directorist_get_listing_gallery_images( get_the_ID() );
 			$listing_img_src = atbdp_get_image_source( $listing_img[0], 'medium' );
 
-			$listing_prv_img = get_post_meta( get_the_ID(), '_listing_prv_img', true );
+			$listing_prv_img = directorist_get_listing_preview_image( get_the_ID() );
 			$prv_image_src   = atbdp_get_image_source( $listing_prv_img, 'medium' );
 
 			$default_image_src = get_directorist_option( 'default_preview_image', DIRECTORIST_ASSETS . 'images/grid.jpg' );

--- a/includes/classes/class-listing-db.php
+++ b/includes/classes/class-listing-db.php
@@ -31,9 +31,9 @@ class ATBDP_Listing_DB {
     public function atbdp_delete_attachment($id){
 
         if( 'at_biz_dir' === get_post_type( $id ) ){
-            $listing_img = get_post_meta($id, '_listing_img', true);
+            $listing_img = directorist_get_listing_gallery_images( $id );
             $listing_img = !empty($listing_img) ? $listing_img : array();
-            $listing_prv_img = get_post_meta($id, '_listing_prv_img', true);
+            $listing_prv_img = directorist_get_listing_preview_image( $id );
 
             if ( is_array( $listing_img ) ) {
                 array_unshift($listing_img, $listing_prv_img);

--- a/includes/classes/class-listing.php
+++ b/includes/classes/class-listing.php
@@ -296,7 +296,7 @@ if (!class_exists('ATBDP_Listing')):
                     <meta property="og:description" content="<?php echo esc_attr( wp_trim_words($post->post_content, 150) ); ?>" />
                 <?php }
 
-                $images = get_post_meta($post->ID, '_listing_prv_img', true);
+                $images = directorist_get_listing_preview_image( $post->ID );
                 if (!empty($images)) {
                     $thumbnail = atbdp_get_image_source($images, 'full');
 

--- a/includes/classes/class-listings-export.php
+++ b/includes/classes/class-listings-export.php
@@ -256,32 +256,32 @@ class Listings_Exporter {
 
     // updateListingImageModuleFieldsData
     public static function updateListingImageModuleFieldsData( array $row = [], string $field_key = '', array $field_args = [] ) {
+        $preview_image  = directorist_get_listing_preview_image( get_the_ID() );
+        $gallery_images = directorist_get_listing_gallery_images( get_the_ID() );
 
-        $image_urls          = [];
-        $_listing_prv_img_id = directorist_get_listing_preview_image( get_the_ID() );
-        $_listing_img_id     = directorist_get_listing_gallery_images( get_the_ID() );
-
-        if ( empty( $_listing_prv_img_id ) && empty( $_listing_img_id ) ) {
+        if ( empty( $preview_image ) && empty( $gallery_images ) ) {
             return $row;
         }
 
-        if ( ! empty( $_listing_prv_img_id ) ) {
-            $preview_image_url = wp_get_attachment_image_url( $_listing_prv_img_id, 'full' );
-            $image_urls[] = $preview_image_url;
-        }
+		$image_urls = [];
+		$image_url  = wp_get_attachment_image_url( $preview_image, 'full' );
 
-        if ( ! empty( $_listing_img_id ) && is_array( $_listing_img_id ) ) {
-            foreach ( $_listing_img_id as $_img_id ) {
+		if ( $image_url ) {
+			$image_urls[] = $image_url;
+		}
 
-                if ( $_img_id === $_listing_prv_img_id ) { continue; }
+        foreach ( $gallery_images as $image ) {
+			if ( $image === $preview_image ) {
+				continue;
+			}
+			
+			$image_url = wp_get_attachment_image_url( $image, 'full' );
+			if ( $image_url ) {
+				$image_urls[] = $image_url;
+			}
+		}
 
-                $image_url = wp_get_attachment_image_url( $_img_id, 'full' );
-                $image_urls[] = $image_url;
-            }
-        }
-
-        $image_urls = implode( ',', $image_urls );
-        $row[ $field_args['field_key'] ] = $image_urls;
+        $row[ $field_args['field_key'] ] = implode( ',', $image_urls );
 
         return $row;
     }

--- a/includes/classes/class-listings-export.php
+++ b/includes/classes/class-listings-export.php
@@ -258,8 +258,8 @@ class Listings_Exporter {
     public static function updateListingImageModuleFieldsData( array $row = [], string $field_key = '', array $field_args = [] ) {
 
         $image_urls          = [];
-        $_listing_prv_img_id = get_post_meta( get_the_ID(), '_listing_prv_img', true );
-        $_listing_img_id     = get_post_meta( get_the_ID(), '_listing_img', true );
+        $_listing_prv_img_id = directorist_get_listing_preview_image( get_the_ID() );
+        $_listing_img_id     = directorist_get_listing_gallery_images( get_the_ID() );
 
         if ( empty( $_listing_prv_img_id ) && empty( $_listing_img_id ) ) {
             return $row;

--- a/includes/classes/class-seo.php
+++ b/includes/classes/class-seo.php
@@ -986,12 +986,12 @@ if ( ! class_exists( 'ATBDP_SEO' ) ) :
             if ( empty( $seo_meta['image'] ) ) {
                 $listing_img_id = directorist_get_listing_preview_image( get_the_ID() );
 
-                if ( empty( $listing_img_id ) || ! is_string( $listing_img_id ) || ! is_numeric( $listing_img_id ) ) {
+                if ( ! $listing_img_id ) {
                     $listing_img_id = directorist_get_listing_gallery_images( get_the_ID() );
-                    $listing_img_id = ( ! empty( $listing_img_id ) ) ? $listing_img_id[0] : null;
+                    $listing_img_id = $listing_img_id[0] ?? null;
                 }
 
-                $seo_meta['image'] = ( ! empty($listing_img_id) || is_string( $listing_img_id ) || is_int( $listing_img_id )) ? wp_get_attachment_url($listing_img_id) : '';
+                $seo_meta['image'] = $listing_img_id ? wp_get_attachment_image_url( $listing_img_id, 'post-thumbnail' ) : '';
             }
 
             $seo_meta = ( is_array( $default_seo_meta ) ) ? array_merge( $default_seo_meta, $seo_meta ) : $seo_meta;

--- a/includes/classes/class-seo.php
+++ b/includes/classes/class-seo.php
@@ -984,10 +984,10 @@ if ( ! class_exists( 'ATBDP_SEO' ) ) :
             $seo_meta['image']       = get_the_post_thumbnail_url();
 
             if ( empty( $seo_meta['image'] ) ) {
-                $listing_img_id = get_post_meta( get_the_ID(), '_listing_prv_img', true);
+                $listing_img_id = directorist_get_listing_preview_image( get_the_ID() );
 
                 if ( empty( $listing_img_id ) || ! is_string( $listing_img_id ) || ! is_numeric( $listing_img_id ) ) {
-                    $listing_img_id = get_post_meta( get_the_ID(), '_listing_img', true );
+                    $listing_img_id = directorist_get_listing_gallery_images( get_the_ID() );
                     $listing_img_id = ( ! empty( $listing_img_id ) ) ? $listing_img_id[0] : null;
                 }
 

--- a/includes/custom-filters.php
+++ b/includes/custom-filters.php
@@ -20,10 +20,6 @@ function atbdp_directorist_button_classes($type='primary'){
  * @since 6.3.4
  * @return string image scource
  */
- function atbdp_get_image_source($id = null, $size = 'medium'){
-    // void if source id is empty
-    if ( empty( $id ) || ! ( is_string( $id ) || is_int( $id ) ) ) { return ''; }
-    $image_obj = wp_get_attachment_image_src($id, $size);
-    return is_array($image_obj) ? $image_obj[0] : '';
- }
-
+function atbdp_get_image_source( $id = null, $size = 'medium' ) {
+	return wp_get_attachment_image_url( $id, $size );
+}

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -4638,7 +4638,7 @@ function directorist_get_listing_directory( $listing_id = 0 ) {
 /**
  * Get listing preview image.
  *
- * @since 8.0.7
+ * @since 8.0.8
  *
  * @param int $listing_id Listing ID.
  * @return int
@@ -4656,7 +4656,7 @@ function directorist_get_listing_preview_image( $listing_id = 0 ) {
 /**
  * Get listing gallery images.
  *
- * @since 8.0.7
+ * @since 8.0.8
  *
  * @param int $listing_id Listing ID.
  * @return array

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -2450,21 +2450,14 @@ function atbdp_guest_submission($guest_email)
 }
 
 function atbdp_get_listing_attachment_ids( $listing_id ) {
-	$featured_image = get_post_meta( $listing_id, '_listing_prv_img', true );
+	$featured_image = directorist_get_listing_preview_image( $listing_id );
 	$attachment_ids = array();
 
 	if ( $featured_image ) {
 		$attachment_ids[] = (int) $featured_image;
 	}
 
-    $gallery_images = (array) get_post_meta( $listing_id, '_listing_img', true );
-
-	if ( empty( $gallery_images ) ) {
-		return $attachment_ids;
-	}
-
-	$gallery_images = wp_parse_id_list( $gallery_images );
-	$gallery_images = array_filter( $gallery_images );
+    $gallery_images = directorist_get_listing_gallery_images( $listing_id );
 
 	if ( empty( $gallery_images ) ) {
 		return $attachment_ids;
@@ -2744,8 +2737,8 @@ function atbdp_thumbnail_card($img_src = '', $_args = array())
 
     $thumbnail_img = '';
 
-    $listing_prv_img   = get_post_meta(get_the_ID(), '_listing_prv_img', true);
-    $listing_img       = get_post_meta(get_the_ID(), '_listing_img', true);
+    $listing_prv_img   = directorist_get_listing_preview_image( get_the_ID() );
+    $listing_img       = directorist_get_listing_gallery_images( get_the_ID() );
     $default_image_src = get_directorist_option('default_preview_image', DIRECTORIST_ASSETS . 'images/grid.jpg');
 
     if ( is_array( $listing_img ) && ! empty( $listing_img ) ) {
@@ -4640,4 +4633,43 @@ function directorist_get_distance_range( $miles ) {
  */
 function directorist_get_listing_directory( $listing_id = 0 ) {
 	return (int) get_post_meta( $listing_id, '_directory_type', true );
+}
+
+/**
+ * Get listing preview image.
+ *
+ * @since 8.0.7
+ *
+ * @param int $listing_id Listing ID.
+ * @return int
+ */
+function directorist_get_listing_preview_image( $listing_id = 0 ) {
+	$image = get_post_meta( $listing_id, '_listing_prv_img', true );
+
+	if ( empty( $image ) || ! is_numeric( $image ) ) {
+		return 0;
+	}
+
+	return $image;
+}
+
+/**
+ * Get listing gallery images.
+ *
+ * @since 8.0.7
+ *
+ * @param int $listing_id Listing ID.
+ * @return array
+ */
+function directorist_get_listing_gallery_images( $listing_id = 0 ) {
+	$images = get_post_meta( $listing_id, '_listing_img', true );
+
+	if ( empty( $images ) || ! is_array( $images ) ) {
+		return [];
+	}
+
+	$images = wp_parse_id_list( $images );
+	$images = array_filter( $images );
+
+	return $images;
 }

--- a/includes/model/ListingDashboard.php
+++ b/includes/model/ListingDashboard.php
@@ -187,8 +187,8 @@ class Directorist_Listing_Dashboard {
 
 		$default_image_src = Helper::default_preview_image_src( $type );
 		$image_quality     = get_directorist_option('preview_image_quality', 'directorist_preview');
-		$listing_prv_img   = get_post_meta($id, '_listing_prv_img', true);
-		$listing_img       = get_post_meta($id, '_listing_img', true);
+		$listing_prv_img   = directorist_get_listing_preview_image( $id );
+		$listing_img       = directorist_get_listing_gallery_images( $id );
 
 		if ( is_array( $listing_img ) && ! empty( $listing_img[0] ) ) {
 			$thumbnail_img = atbdp_get_image_source( $listing_img[0], $image_quality );
@@ -242,8 +242,8 @@ class Directorist_Listing_Dashboard {
 				$category_link = ! empty( $cats ) ? esc_url( ATBDP_Permalink::atbdp_get_category_page( $cats[0] ) ) : '#';
 				$post_link     = esc_url( get_post_permalink( $post->ID ) );
 
-				$listing_img     	= get_post_meta( $post->ID, '_listing_img', true );
-				$listing_prv_img 	= get_post_meta( $post->ID, '_listing_prv_img', true );
+				$listing_img     	= directorist_get_listing_gallery_images( $post->ID );
+				$listing_prv_img 	= directorist_get_listing_preview_image( $post->ID );
 				$default_image_src 	= Helper::default_preview_image_src( $listing_type );
 				$crop_width      	= get_directorist_option( 'crop_width', 360 );
 				$crop_height     	= get_directorist_option( 'crop_height', 300 );

--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -430,8 +430,8 @@ class Directorist_Listings {
 			'cats'                 => get_the_terms( $id, ATBDP_CATEGORY ),
 			'locs'                 => get_the_terms( $id, ATBDP_LOCATION ),
 			'featured'             => get_post_meta( $id, '_featured', true ),
-			'listing_img'          => get_post_meta( $id, '_listing_img', true ),
-			'listing_prv_img'      => get_post_meta( $id, '_listing_prv_img', true ),
+			'listing_img'          => directorist_get_listing_gallery_images( $id ),
+			'listing_prv_img'      => directorist_get_listing_preview_image( $id ),
 			'tagline'              => get_post_meta( $id, '_tagline', true ),
 			'category'             => get_post_meta( $id, '_admin_category_select', true ),
 			'post_view'            => directorist_get_listing_views_count( $id ),
@@ -1488,8 +1488,8 @@ class Directorist_Listings {
 
 				$ls_data['manual_lat']      = get_post_meta($listings_id, '_manual_lat', true);
 				$ls_data['manual_lng']      = get_post_meta($listings_id, '_manual_lng', true);
-				$ls_data['listing_img']     = get_post_meta($listings_id, '_listing_img', true);
-				$ls_data['listing_prv_img'] = get_post_meta($listings_id, '_listing_prv_img', true);
+				$ls_data['listing_img']     = directorist_get_listing_gallery_images( $listings_id );
+				$ls_data['listing_prv_img'] = directorist_get_listing_preview_image( $listings_id );
 				$ls_data['address']         = get_post_meta($listings_id, '_address', true);
 				$ls_data['phone'] 			= get_post_meta($listings_id, '_phone', true);
 				$ls_data['font_type']       = $this->options['font_type'];
@@ -1578,8 +1578,8 @@ class Directorist_Listings {
 					$ls_data['post_id']         = $listings_id;
 					$ls_data['manual_lat']      = get_post_meta($listings_id, '_manual_lat', true);
 					$ls_data['manual_lng']      = get_post_meta($listings_id, '_manual_lng', true);
-					$ls_data['listing_img']     = get_post_meta($listings_id, '_listing_img', true);
-					$ls_data['listing_prv_img'] = get_post_meta($listings_id, '_listing_prv_img', true);
+					$ls_data['listing_img']     = directorist_get_listing_gallery_images( $listings_id );
+					$ls_data['listing_prv_img'] = directorist_get_listing_preview_image( $listings_id );
 					$ls_data['phone'] 			= get_post_meta($listings_id, '_phone', true);
 					$ls_data['crop_width']      = $this->options['crop_width'];
 					$ls_data['crop_height']     = $this->options['crop_height'];
@@ -1657,8 +1657,8 @@ class Directorist_Listings {
 
 			$id = get_the_ID();
 			$image_quality     = get_directorist_option('preview_image_quality', 'directorist_preview');
-			$listing_prv_img   = get_post_meta($id, '_listing_prv_img', true);
-			$listing_img       = get_post_meta($id, '_listing_img', true);
+			$listing_prv_img   = directorist_get_listing_preview_image( $id );
+			$listing_img       = directorist_get_listing_gallery_images( $id );
 
 
 

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -272,8 +272,8 @@ class Directorist_Single_Listing {
 				$value = true;
 			}
 		} elseif( 'image_upload' === $data['widget_name'] ) {
-			$listing_img 	=  get_post_meta( $this->id, '_listing_img', true );
-			$preview_img   	= get_post_meta( $this->id, '_listing_prv_img', true);
+			$listing_img 	=  directorist_get_listing_gallery_images( $this->id );
+			$preview_img   	= directorist_get_listing_preview_image( $this->id );
 			if( $listing_img || $preview_img ) {
 				$value = true;
 			}
@@ -533,13 +533,13 @@ class Directorist_Single_Listing {
 		$image_size = apply_filters( 'directorist_single_listing_slider_image_size', 'large' );
 
 		// Get the preview images
-		$preview_img_id   = get_post_meta( $listing_id, '_listing_prv_img', true);
+		$preview_img_id   = directorist_get_listing_preview_image( $listing_id );
 		$preview_img_link = ! empty($preview_img_id) ? atbdp_get_image_source( $preview_img_id, $image_size ) : '';
 		$preview_img_alt  = get_post_meta($preview_img_id, '_wp_attachment_image_alt', true);
 		$preview_img_alt  = ( ! empty( $preview_img_alt )  ) ? $preview_img_alt : get_the_title( $preview_img_id );
 
 		// Get the gallery images
-		$listing_img  = get_post_meta( $listing_id, '_listing_img', true );
+		$listing_img  = directorist_get_listing_gallery_images( $listing_id );
 		$listing_imgs = ! empty( $listing_img ) ? ( ! is_array( $listing_img ) ? array( $listing_img ) : $listing_img ) : array();
 		$image_links  = array(); // define a link placeholder variable
 
@@ -1203,7 +1203,7 @@ class Directorist_Single_Listing {
 		$display_phone_map          = get_directorist_option( 'display_phone_map', 1 );
 		$display_favorite_badge_map = get_directorist_option( 'display_favorite_badge_map', 1 );
 
-		$listing_prv_img = get_post_meta($id, '_listing_prv_img', true);
+		$listing_prv_img = directorist_get_listing_preview_image( $id );
 		$default_image = get_directorist_option('default_preview_image', DIRECTORIST_ASSETS . 'images/grid.jpg');
 		$listing_prv_imgurl = !empty($listing_prv_img) ? atbdp_get_image_source($listing_prv_img, 'small') : '';
 		$listing_prv_imgurl = atbdp_image_cropping($listing_prv_img, 150, 150, true, 100)['url'];

--- a/includes/rest-api/Version1/class-listings-controller.php
+++ b/includes/rest-api/Version1/class-listings-controller.php
@@ -595,14 +595,14 @@ class Listings_Controller extends Posts_Controller {
 		if ( has_post_thumbnail( $listing ) ) {
 			$attachment_ids[] = get_post_thumbnail_id( $listing );
 		} else {
-			$thumbnail_id = get_post_meta( $listing->ID, '_listing_prv_img', true );
+			$thumbnail_id = directorist_get_listing_preview_image( $listing->ID );
 			if ( ! empty( $thumbnail_id ) ) {
 				$attachment_ids[] = (int) $thumbnail_id;
 			}
 		}
 
 		// Add gallery images.
-		$gallery_images = get_post_meta( $listing->ID, '_listing_img', true );
+		$gallery_images = directorist_get_listing_gallery_images( $listing->ID );
 		if ( ! empty( $gallery_images ) || is_array( $gallery_images ) ) {
 			$attachment_ids = array_merge( $attachment_ids, $gallery_images );
 		}

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -123,14 +123,12 @@ function directorist_get_listing_thumbnail_id( $listing = null ) {
 		return $thumbnail_id;
 	}
 
-	$thumbnail_id = (int) get_post_meta( $listing->ID, '_listing_prv_img', true );
+	$thumbnail_id = directorist_get_listing_preview_image( $listing->ID );
 	if ( $thumbnail_id ) {
 		return $thumbnail_id;
 	}
 
-	$gallery_image_ids = (array) get_post_meta( $listing->ID, '_listing_img', true );
-	$gallery_image_ids = wp_parse_id_list( $gallery_image_ids );
-	$gallery_image_ids = array_filter( $gallery_image_ids );
+	$gallery_image_ids = directorist_get_listing_gallery_images( $listing->ID );
 	if ( empty( $gallery_image_ids ) ) {
 		return false;
 	}

--- a/templates/widgets/featured-listing.php
+++ b/templates/widgets/featured-listing.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   7.3.0
- * @version 8.0.7
+ * @version 8.0.8
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;

--- a/templates/widgets/featured-listing.php
+++ b/templates/widgets/featured-listing.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   7.3.0
- * @version 7.7.0
+ * @version 8.0.7
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;

--- a/templates/widgets/featured-listing.php
+++ b/templates/widgets/featured-listing.php
@@ -45,8 +45,8 @@ $default_icon = 'las la-tags';
                 $review_count  = directorist_get_listing_review_count( get_the_ID() );
                 $review_text   = sprintf( _n( '%s review', $review_count > 0 ?  '%s reviews' : '%s review', $review_count, 'directorist' ), number_format_i18n( $review_count ) );
                 // get only one parent or high level term object
-                $listing_img = get_post_meta(get_the_ID(), '_listing_img', true);
-                $listing_prv_img = get_post_meta(get_the_ID(), '_listing_prv_img', true);
+                $listing_img = directorist_get_listing_gallery_images( get_the_ID() );
+                $listing_prv_img = directorist_get_listing_preview_image( get_the_ID() );
                 $listing_reviews = get_post_meta( get_the_ID(), '_directorist_reviews', true );
                 $price = get_post_meta(get_the_ID(), '_price', true);
                 $price_range = get_post_meta(get_the_ID(), '_price_range', true);

--- a/templates/widgets/popular-listings.php
+++ b/templates/widgets/popular-listings.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   7.3.0
- * @version 8.0.7
+ * @version 8.0.8
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;

--- a/templates/widgets/popular-listings.php
+++ b/templates/widgets/popular-listings.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   7.3.0
- * @version 8.0
+ * @version 8.0.7
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;

--- a/templates/widgets/popular-listings.php
+++ b/templates/widgets/popular-listings.php
@@ -24,8 +24,8 @@ $default_icon = 'las la-tags';
                 $id                     = get_the_ID();
                 $disable_single_listing = get_directorist_option( 'disable_single_listing' );
                 $top_category           = ATBDP()->taxonomy->get_one_high_level_term( $id, ATBDP_CATEGORY );
-                $listing_img            = get_post_meta( $id, '_listing_img', true );
-                $listing_prv_img        = get_post_meta( $id, '_listing_prv_img', true );
+                $listing_img            = directorist_get_listing_gallery_images( $id );
+                $listing_prv_img        = directorist_get_listing_preview_image( $id );
                 $cats                   = get_the_terms( $id, ATBDP_CATEGORY );
                 $post_link              = get_the_permalink( $id );
                 $review_rating          = directorist_get_listing_rating( get_the_ID() );
@@ -80,13 +80,13 @@ $default_icon = 'las la-tags';
 
                                 <span><?php atbdp_display_price( $price ); ?></span>
 
-                            <?php 
+                            <?php
                                 } else {
 
                                     $output = atbdp_display_price_range( $price_range );
                                     echo wp_kses_post( $output );
 
-                                } 
+                                }
                             ?>
                         </div>
                     </div>

--- a/templates/widgets/similar-listing.php
+++ b/templates/widgets/similar-listing.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   7.3.0
- * @version 8.0.7
+ * @version 8.0.8
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;

--- a/templates/widgets/similar-listing.php
+++ b/templates/widgets/similar-listing.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   7.3.0
- * @version 7.7.0
+ * @version 8.0.7
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;

--- a/templates/widgets/similar-listing.php
+++ b/templates/widgets/similar-listing.php
@@ -23,8 +23,8 @@ $default_icon = 'las la-tags';
 
       // get only one parent or high level term object
       $top_category = ATBDP()->taxonomy->get_one_high_level_term($related_listing->ID, ATBDP_CATEGORY);
-      $listing_img = get_post_meta($related_listing->ID, '_listing_img', true);
-      $listing_prv_img = get_post_meta($related_listing->ID, '_listing_prv_img', true);
+      $listing_img = directorist_get_listing_gallery_images( $related_listing->ID );
+      $listing_prv_img = directorist_get_listing_preview_image( $related_listing->ID );
       $review_rating = directorist_get_listing_rating( get_the_ID() );
       $review_count  = directorist_get_listing_review_count( get_the_ID() );
       $review_text   = sprintf( _n( '%s review', $review_count > 0 ?  '%s reviews' : '%s review', $review_count, 'directorist' ), number_format_i18n( $review_count ) );

--- a/views/admin-templates/listing-form/image_upload.php
+++ b/views/admin-templates/listing-form/image_upload.php
@@ -2,16 +2,15 @@
 /**
  * @author  AazzTech
  * @since   6.7
- * @version 6.7
+ * @version 8.0.7
  */
-$form                       = $listing_form;
-$p_id                		= $form->get_add_listing_id();
-$listing_imgs		 		= get_post_meta($p_id, '_listing_img', true);
-$listing_prv_img_id	 		= get_post_meta($p_id, '_listing_prv_img', true);
-$listing_prv_img 	 		= !empty($listing_prv_img_id) ? atbdp_get_image_source($listing_prv_img_id) : '';
-$display_prv_field 	 		= get_directorist_option('display_prv_field', 1);
-$display_gallery_field 		= get_directorist_option('display_gallery_field', 1);
-$image_links = []; // define a link placeholder variable
+$listing_id            = $listing_form->get_add_listing_id();
+$listing_imgs          = directorist_get_listing_gallery_images( $listing_id );
+$listing_prv_img_id    = directorist_get_listing_preview_image( $listing_id );
+$listing_prv_img       = !empty($listing_prv_img_id) ? atbdp_get_image_source($listing_prv_img_id) : '';
+$display_prv_field     = get_directorist_option('display_prv_field', 1);
+$display_gallery_field = get_directorist_option('display_gallery_field', 1);
+$image_links           = [];                                                                              // define a link placeholder variable
 if( !empty( $listing_imgs ) && is_array( $listing_imgs ) ) {
     foreach ($listing_imgs as $id) {
         $image_links[$id] = atbdp_get_image_source($id); // store the attachment id and url

--- a/views/admin-templates/listing-form/image_upload.php
+++ b/views/admin-templates/listing-form/image_upload.php
@@ -2,7 +2,7 @@
 /**
  * @author  AazzTech
  * @since   6.7
- * @version 8.0.7
+ * @version 8.0.8
  */
 $listing_id            = $listing_form->get_add_listing_id();
 $listing_imgs          = directorist_get_listing_gallery_images( $listing_id );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix
- Improvement
- Refactoring (no functional changes, no api changes)


## Description
Two utility functions were added to get the preview image and gallery images.
1. `directorist_get_listing_gallery_images`
2. `directorist_get_listing_preview_image`

* Refactored image export in listing exporter

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
