### PR TITLE
fixed more filter button hide issue on mobile view

### DIFF
--- a/templates/search-form/form-box.php
+++ b/templates/search-form/form-box.php
@@ -29,11 +29,14 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 		<?php echo esc_html( $searchform->search_button_text );?>
 
 	</a>
-	<a href="#" class="directorist-search-form-action__modal__btn-advanced directorist-modal-btn directorist-modal-btn--advanced">
 
-		<?php directorist_icon( 'fas fa-sliders-h' ); ?>
+	<?php if ( $searchform->has_more_filters_button ): ?>
+		<a href="#" class="directorist-search-form-action__modal__btn-advanced directorist-modal-btn directorist-modal-btn--advanced">
 
-	</a>
+			<?php directorist_icon( 'fas fa-sliders-h' ); ?>
+
+		</a>
+	<?php endif ?>
 </div>
 
 <div class="directorist-search-modal directorist-search-modal--advanced">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Disable 'Display More Filters' from Settings -> Search -> Search Listing
2. before : https://prnt.sc/n54dc98xQ3Y0
3. after : https://prnt.sc/h743esioi4XF

## Any linked issues
Fixes #
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/432
## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
