### PR TITLE
Fixed: 58452 - Map Zoom Controls & Closing listing Issue

### DIFF
--- a/assets/css/admin-main.css
+++ b/assets/css/admin-main.css
@@ -11131,15 +11131,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-right-color: var(--directorist-color-white);
 }
 
-#map {
+.directorist-content-active #map {
   position: relative;
   width: 100%;
   height: 660px;
   border: none;
   z-index: 1;
 }
-
-#gmap_full_screen_button {
+.directorist-content-active #gmap_full_screen_button {
   position: absolute;
   top: 20px;
   right: 20px;
@@ -11162,18 +11161,17 @@ svg.leaflet-image-layer.leaflet-interactive path {
   background-color: var(--directorist-color-white);
   cursor: pointer;
 }
-#gmap_full_screen_button i::after {
+.directorist-content-active #gmap_full_screen_button i::after {
   width: 22px;
   height: 22px;
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   background-color: var(--directorist-color-dark);
 }
-#gmap_full_screen_button .fullscreen-disable {
+.directorist-content-active #gmap_full_screen_button .fullscreen-disable {
   display: none;
 }
-
-#progress {
+.directorist-content-active #progress {
   display: none;
   position: absolute;
   z-index: 1000;
@@ -11188,15 +11186,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-radius: 4px;
   padding: 2px;
 }
-
-#progress-bar {
+.directorist-content-active #progress-bar {
   width: 0;
   height: 100%;
   background-color: #76A6FC;
   border-radius: 4px;
 }
-
-.gm-fullscreen-control {
+.directorist-content-active .gm-fullscreen-control {
   width: 50px !important;
   height: 50px !important;
   margin: 20px !important;
@@ -11204,33 +11200,27 @@ svg.leaflet-image-layer.leaflet-interactive path {
   -webkit-box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
-
-.gmnoprint {
+.directorist-content-active .gmnoprint {
   border-radius: 5px;
 }
-
-.gm-style-cc,
-.gm-style-mtc-bbw,
-button.gm-svpc {
+.directorist-content-active .gm-style-cc,
+.directorist-content-active .gm-style-mtc-bbw,
+.directorist-content-active button.gm-svpc {
   display: none;
 }
-
-.italic {
+.directorist-content-active .italic {
   font-style: italic;
 }
-
-.buttonsTable {
+.directorist-content-active .buttonsTable {
   border: 1px solid grey;
   border-collapse: collapse;
 }
-
-.buttonsTable td,
-.buttonsTable th {
+.directorist-content-active .buttonsTable td,
+.directorist-content-active .buttonsTable th {
   padding: 8px;
   border: 1px solid grey;
 }
-
-.version-disabled {
+.directorist-content-active .version-disabled {
   text-decoration: line-through;
 }
 

--- a/assets/css/admin-main.css
+++ b/assets/css/admin-main.css
@@ -11205,8 +11205,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
 
-.gmnoprint,
-.gm-style-cc {
+.gmnoprint {
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.gm-style-cc,
+.gm-style-mtc-bbw,
+button.gm-svpc {
   display: none;
 }
 

--- a/assets/css/admin-main.css
+++ b/assets/css/admin-main.css
@@ -11207,7 +11207,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .gmnoprint {
   border-radius: 5px;
-  overflow: hidden;
 }
 
 .gm-style-cc,

--- a/assets/css/admin-main.rtl.css
+++ b/assets/css/admin-main.rtl.css
@@ -11205,8 +11205,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
 
-.gmnoprint,
-.gm-style-cc {
+.gmnoprint {
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.gm-style-cc,
+.gm-style-mtc-bbw,
+button.gm-svpc {
   display: none;
 }
 

--- a/assets/css/admin-main.rtl.css
+++ b/assets/css/admin-main.rtl.css
@@ -11207,7 +11207,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .gmnoprint {
   border-radius: 5px;
-  overflow: hidden;
 }
 
 .gm-style-cc,

--- a/assets/css/admin-main.rtl.css
+++ b/assets/css/admin-main.rtl.css
@@ -11131,15 +11131,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-left-color: var(--directorist-color-white);
 }
 
-#map {
+.directorist-content-active #map {
   position: relative;
   width: 100%;
   height: 660px;
   border: none;
   z-index: 1;
 }
-
-#gmap_full_screen_button {
+.directorist-content-active #gmap_full_screen_button {
   position: absolute;
   top: 20px;
   left: 20px;
@@ -11162,18 +11161,17 @@ svg.leaflet-image-layer.leaflet-interactive path {
   background-color: var(--directorist-color-white);
   cursor: pointer;
 }
-#gmap_full_screen_button i::after {
+.directorist-content-active #gmap_full_screen_button i::after {
   width: 22px;
   height: 22px;
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   background-color: var(--directorist-color-dark);
 }
-#gmap_full_screen_button .fullscreen-disable {
+.directorist-content-active #gmap_full_screen_button .fullscreen-disable {
   display: none;
 }
-
-#progress {
+.directorist-content-active #progress {
   display: none;
   position: absolute;
   z-index: 1000;
@@ -11188,15 +11186,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-radius: 4px;
   padding: 2px;
 }
-
-#progress-bar {
+.directorist-content-active #progress-bar {
   width: 0;
   height: 100%;
   background-color: #76A6FC;
   border-radius: 4px;
 }
-
-.gm-fullscreen-control {
+.directorist-content-active .gm-fullscreen-control {
   width: 50px !important;
   height: 50px !important;
   margin: 20px !important;
@@ -11204,33 +11200,27 @@ svg.leaflet-image-layer.leaflet-interactive path {
   -webkit-box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
-
-.gmnoprint {
+.directorist-content-active .gmnoprint {
   border-radius: 5px;
 }
-
-.gm-style-cc,
-.gm-style-mtc-bbw,
-button.gm-svpc {
+.directorist-content-active .gm-style-cc,
+.directorist-content-active .gm-style-mtc-bbw,
+.directorist-content-active button.gm-svpc {
   display: none;
 }
-
-.italic {
+.directorist-content-active .italic {
   font-style: italic;
 }
-
-.buttonsTable {
+.directorist-content-active .buttonsTable {
   border: 1px solid grey;
   border-collapse: collapse;
 }
-
-.buttonsTable td,
-.buttonsTable th {
+.directorist-content-active .buttonsTable td,
+.directorist-content-active .buttonsTable th {
   padding: 8px;
   border: 1px solid grey;
 }
-
-.version-disabled {
+.directorist-content-active .version-disabled {
   text-decoration: line-through;
 }
 

--- a/assets/css/all-listings.css
+++ b/assets/css/all-listings.css
@@ -6205,7 +6205,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .gmnoprint {
   border-radius: 5px;
-  overflow: hidden;
 }
 
 .gm-style-cc,

--- a/assets/css/all-listings.css
+++ b/assets/css/all-listings.css
@@ -6203,8 +6203,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
 
-.gmnoprint,
-.gm-style-cc {
+.gmnoprint {
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.gm-style-cc,
+.gm-style-mtc-bbw,
+button.gm-svpc {
   display: none;
 }
 

--- a/assets/css/all-listings.css
+++ b/assets/css/all-listings.css
@@ -6129,15 +6129,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-right-color: var(--directorist-color-white);
 }
 
-#map {
+.directorist-content-active #map {
   position: relative;
   width: 100%;
   height: 660px;
   border: none;
   z-index: 1;
 }
-
-#gmap_full_screen_button {
+.directorist-content-active #gmap_full_screen_button {
   position: absolute;
   top: 20px;
   right: 20px;
@@ -6160,18 +6159,17 @@ svg.leaflet-image-layer.leaflet-interactive path {
   background-color: var(--directorist-color-white);
   cursor: pointer;
 }
-#gmap_full_screen_button i::after {
+.directorist-content-active #gmap_full_screen_button i::after {
   width: 22px;
   height: 22px;
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   background-color: var(--directorist-color-dark);
 }
-#gmap_full_screen_button .fullscreen-disable {
+.directorist-content-active #gmap_full_screen_button .fullscreen-disable {
   display: none;
 }
-
-#progress {
+.directorist-content-active #progress {
   display: none;
   position: absolute;
   z-index: 1000;
@@ -6186,15 +6184,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-radius: 4px;
   padding: 2px;
 }
-
-#progress-bar {
+.directorist-content-active #progress-bar {
   width: 0;
   height: 100%;
   background-color: #76A6FC;
   border-radius: 4px;
 }
-
-.gm-fullscreen-control {
+.directorist-content-active .gm-fullscreen-control {
   width: 50px !important;
   height: 50px !important;
   margin: 20px !important;
@@ -6202,33 +6198,27 @@ svg.leaflet-image-layer.leaflet-interactive path {
   -webkit-box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
-
-.gmnoprint {
+.directorist-content-active .gmnoprint {
   border-radius: 5px;
 }
-
-.gm-style-cc,
-.gm-style-mtc-bbw,
-button.gm-svpc {
+.directorist-content-active .gm-style-cc,
+.directorist-content-active .gm-style-mtc-bbw,
+.directorist-content-active button.gm-svpc {
   display: none;
 }
-
-.italic {
+.directorist-content-active .italic {
   font-style: italic;
 }
-
-.buttonsTable {
+.directorist-content-active .buttonsTable {
   border: 1px solid grey;
   border-collapse: collapse;
 }
-
-.buttonsTable td,
-.buttonsTable th {
+.directorist-content-active .buttonsTable td,
+.directorist-content-active .buttonsTable th {
   padding: 8px;
   border: 1px solid grey;
 }
-
-.version-disabled {
+.directorist-content-active .version-disabled {
   text-decoration: line-through;
 }
 

--- a/assets/css/all-listings.rtl.css
+++ b/assets/css/all-listings.rtl.css
@@ -6205,7 +6205,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .gmnoprint {
   border-radius: 5px;
-  overflow: hidden;
 }
 
 .gm-style-cc,

--- a/assets/css/all-listings.rtl.css
+++ b/assets/css/all-listings.rtl.css
@@ -6129,15 +6129,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-left-color: var(--directorist-color-white);
 }
 
-#map {
+.directorist-content-active #map {
   position: relative;
   width: 100%;
   height: 660px;
   border: none;
   z-index: 1;
 }
-
-#gmap_full_screen_button {
+.directorist-content-active #gmap_full_screen_button {
   position: absolute;
   top: 20px;
   left: 20px;
@@ -6160,18 +6159,17 @@ svg.leaflet-image-layer.leaflet-interactive path {
   background-color: var(--directorist-color-white);
   cursor: pointer;
 }
-#gmap_full_screen_button i::after {
+.directorist-content-active #gmap_full_screen_button i::after {
   width: 22px;
   height: 22px;
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   background-color: var(--directorist-color-dark);
 }
-#gmap_full_screen_button .fullscreen-disable {
+.directorist-content-active #gmap_full_screen_button .fullscreen-disable {
   display: none;
 }
-
-#progress {
+.directorist-content-active #progress {
   display: none;
   position: absolute;
   z-index: 1000;
@@ -6186,15 +6184,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-radius: 4px;
   padding: 2px;
 }
-
-#progress-bar {
+.directorist-content-active #progress-bar {
   width: 0;
   height: 100%;
   background-color: #76A6FC;
   border-radius: 4px;
 }
-
-.gm-fullscreen-control {
+.directorist-content-active .gm-fullscreen-control {
   width: 50px !important;
   height: 50px !important;
   margin: 20px !important;
@@ -6202,33 +6198,27 @@ svg.leaflet-image-layer.leaflet-interactive path {
   -webkit-box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
-
-.gmnoprint {
+.directorist-content-active .gmnoprint {
   border-radius: 5px;
 }
-
-.gm-style-cc,
-.gm-style-mtc-bbw,
-button.gm-svpc {
+.directorist-content-active .gm-style-cc,
+.directorist-content-active .gm-style-mtc-bbw,
+.directorist-content-active button.gm-svpc {
   display: none;
 }
-
-.italic {
+.directorist-content-active .italic {
   font-style: italic;
 }
-
-.buttonsTable {
+.directorist-content-active .buttonsTable {
   border: 1px solid grey;
   border-collapse: collapse;
 }
-
-.buttonsTable td,
-.buttonsTable th {
+.directorist-content-active .buttonsTable td,
+.directorist-content-active .buttonsTable th {
   padding: 8px;
   border: 1px solid grey;
 }
-
-.version-disabled {
+.directorist-content-active .version-disabled {
   text-decoration: line-through;
 }
 

--- a/assets/css/all-listings.rtl.css
+++ b/assets/css/all-listings.rtl.css
@@ -6203,8 +6203,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
 
-.gmnoprint,
-.gm-style-cc {
+.gmnoprint {
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.gm-style-cc,
+.gm-style-mtc-bbw,
+button.gm-svpc {
   display: none;
 }
 

--- a/assets/css/public-main.css
+++ b/assets/css/public-main.css
@@ -6205,7 +6205,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .gmnoprint {
   border-radius: 5px;
-  overflow: hidden;
 }
 
 .gm-style-cc,

--- a/assets/css/public-main.css
+++ b/assets/css/public-main.css
@@ -6203,8 +6203,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
 
-.gmnoprint,
-.gm-style-cc {
+.gmnoprint {
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.gm-style-cc,
+.gm-style-mtc-bbw,
+button.gm-svpc {
   display: none;
 }
 

--- a/assets/css/public-main.css
+++ b/assets/css/public-main.css
@@ -6129,15 +6129,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-right-color: var(--directorist-color-white);
 }
 
-#map {
+.directorist-content-active #map {
   position: relative;
   width: 100%;
   height: 660px;
   border: none;
   z-index: 1;
 }
-
-#gmap_full_screen_button {
+.directorist-content-active #gmap_full_screen_button {
   position: absolute;
   top: 20px;
   right: 20px;
@@ -6160,18 +6159,17 @@ svg.leaflet-image-layer.leaflet-interactive path {
   background-color: var(--directorist-color-white);
   cursor: pointer;
 }
-#gmap_full_screen_button i::after {
+.directorist-content-active #gmap_full_screen_button i::after {
   width: 22px;
   height: 22px;
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   background-color: var(--directorist-color-dark);
 }
-#gmap_full_screen_button .fullscreen-disable {
+.directorist-content-active #gmap_full_screen_button .fullscreen-disable {
   display: none;
 }
-
-#progress {
+.directorist-content-active #progress {
   display: none;
   position: absolute;
   z-index: 1000;
@@ -6186,15 +6184,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-radius: 4px;
   padding: 2px;
 }
-
-#progress-bar {
+.directorist-content-active #progress-bar {
   width: 0;
   height: 100%;
   background-color: #76A6FC;
   border-radius: 4px;
 }
-
-.gm-fullscreen-control {
+.directorist-content-active .gm-fullscreen-control {
   width: 50px !important;
   height: 50px !important;
   margin: 20px !important;
@@ -6202,33 +6198,27 @@ svg.leaflet-image-layer.leaflet-interactive path {
   -webkit-box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
-
-.gmnoprint {
+.directorist-content-active .gmnoprint {
   border-radius: 5px;
 }
-
-.gm-style-cc,
-.gm-style-mtc-bbw,
-button.gm-svpc {
+.directorist-content-active .gm-style-cc,
+.directorist-content-active .gm-style-mtc-bbw,
+.directorist-content-active button.gm-svpc {
   display: none;
 }
-
-.italic {
+.directorist-content-active .italic {
   font-style: italic;
 }
-
-.buttonsTable {
+.directorist-content-active .buttonsTable {
   border: 1px solid grey;
   border-collapse: collapse;
 }
-
-.buttonsTable td,
-.buttonsTable th {
+.directorist-content-active .buttonsTable td,
+.directorist-content-active .buttonsTable th {
   padding: 8px;
   border: 1px solid grey;
 }
-
-.version-disabled {
+.directorist-content-active .version-disabled {
   text-decoration: line-through;
 }
 

--- a/assets/css/public-main.rtl.css
+++ b/assets/css/public-main.rtl.css
@@ -6205,7 +6205,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .gmnoprint {
   border-radius: 5px;
-  overflow: hidden;
 }
 
 .gm-style-cc,

--- a/assets/css/public-main.rtl.css
+++ b/assets/css/public-main.rtl.css
@@ -6129,15 +6129,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-left-color: var(--directorist-color-white);
 }
 
-#map {
+.directorist-content-active #map {
   position: relative;
   width: 100%;
   height: 660px;
   border: none;
   z-index: 1;
 }
-
-#gmap_full_screen_button {
+.directorist-content-active #gmap_full_screen_button {
   position: absolute;
   top: 20px;
   left: 20px;
@@ -6160,18 +6159,17 @@ svg.leaflet-image-layer.leaflet-interactive path {
   background-color: var(--directorist-color-white);
   cursor: pointer;
 }
-#gmap_full_screen_button i::after {
+.directorist-content-active #gmap_full_screen_button i::after {
   width: 22px;
   height: 22px;
   -webkit-transition: all 0.3s ease-in-out;
   transition: all 0.3s ease-in-out;
   background-color: var(--directorist-color-dark);
 }
-#gmap_full_screen_button .fullscreen-disable {
+.directorist-content-active #gmap_full_screen_button .fullscreen-disable {
   display: none;
 }
-
-#progress {
+.directorist-content-active #progress {
   display: none;
   position: absolute;
   z-index: 1000;
@@ -6186,15 +6184,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
   border-radius: 4px;
   padding: 2px;
 }
-
-#progress-bar {
+.directorist-content-active #progress-bar {
   width: 0;
   height: 100%;
   background-color: #76A6FC;
   border-radius: 4px;
 }
-
-.gm-fullscreen-control {
+.directorist-content-active .gm-fullscreen-control {
   width: 50px !important;
   height: 50px !important;
   margin: 20px !important;
@@ -6202,33 +6198,27 @@ svg.leaflet-image-layer.leaflet-interactive path {
   -webkit-box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
-
-.gmnoprint {
+.directorist-content-active .gmnoprint {
   border-radius: 5px;
 }
-
-.gm-style-cc,
-.gm-style-mtc-bbw,
-button.gm-svpc {
+.directorist-content-active .gm-style-cc,
+.directorist-content-active .gm-style-mtc-bbw,
+.directorist-content-active button.gm-svpc {
   display: none;
 }
-
-.italic {
+.directorist-content-active .italic {
   font-style: italic;
 }
-
-.buttonsTable {
+.directorist-content-active .buttonsTable {
   border: 1px solid grey;
   border-collapse: collapse;
 }
-
-.buttonsTable td,
-.buttonsTable th {
+.directorist-content-active .buttonsTable td,
+.directorist-content-active .buttonsTable th {
   padding: 8px;
   border: 1px solid grey;
 }
-
-.version-disabled {
+.directorist-content-active .version-disabled {
   text-decoration: line-through;
 }
 

--- a/assets/css/public-main.rtl.css
+++ b/assets/css/public-main.rtl.css
@@ -6203,8 +6203,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
           box-shadow: 0px 2px 20px rgba(0, 0, 0, 0.26) !important;
 }
 
-.gmnoprint,
-.gm-style-cc {
+.gmnoprint {
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.gm-style-cc,
+.gm-style-mtc-bbw,
+button.gm-svpc {
   display: none;
 }
 

--- a/assets/js/google-map.js
+++ b/assets/js/google-map.js
@@ -560,7 +560,7 @@ __webpack_require__.r(__webpack_exports__);
         map.markers.push(marker);
         // if marker contains HTML, add it to an infoWindow
         if ($marker.html()) {
-          // map info window close button
+          //map info window close button
           google.maps.event.addListener(infowindow, 'domready', function () {
             var closeBtn = $('.iw-close-btn').get();
             google.maps.event.addDomListener(closeBtn[0], 'click', function () {
@@ -574,7 +574,7 @@ __webpack_require__.r(__webpack_exports__);
               var marker_childrens = $($marker).children();
               if (marker_childrens.length) {
                 var marker_content = marker_childrens[0];
-                $(marker_content).addClass('map-info-wrapper--show');
+                $(marker_content).toggleClass('map-info-wrapper--show');
               }
               infowindow.setContent($marker.html());
               infowindow.open(map, marker);

--- a/assets/js/range-slider.js
+++ b/assets/js/range-slider.js
@@ -562,7 +562,7 @@ __webpack_require__.r(__webpack_exports__);
           - The provided value for the option;
           - A reference to the options object;
           - The name for the option;
-       The testing function returns false when an error is detected,
+        The testing function returns false when an error is detected,
       or true when everything is OK. It can also modify the option
       object, to make sure all values can be correctly looped elsewhere. */
   //region Defaults

--- a/assets/src/js/global/map-scripts/map-view.js
+++ b/assets/src/js/global/map-scripts/map-view.js
@@ -221,7 +221,7 @@ import {
                 map.markers.push(marker);
                 // if marker contains HTML, add it to an infoWindow
                 if ($marker.html()) {
-                    // map info window close button
+                    //map info window close button
                     google.maps.event.addListener(infowindow, 'domready', function () {
                         const closeBtn = $('.iw-close-btn').get();
                         google.maps.event.addDomListener(closeBtn[0], 'click', function () {
@@ -236,7 +236,7 @@ import {
 
                             if (marker_childrens.length) {
                                 let marker_content = marker_childrens[0];
-                                $(marker_content).addClass('map-info-wrapper--show');
+                                $(marker_content).toggleClass('map-info-wrapper--show');
                             }
 
                             infowindow.setContent($marker.html());

--- a/assets/src/scss/component/openstreet-map/_openstreet.scss
+++ b/assets/src/scss/component/openstreet-map/_openstreet.scss
@@ -61,8 +61,14 @@
     box-shadow: 0px 2px 20px rgba(0,0,0,0.26) !important;
 }
 
-.gmnoprint,
-.gm-style-cc {
+.gmnoprint{
+    border-radius: 5px;
+    overflow: hidden;
+}
+
+.gm-style-cc,
+.gm-style-mtc-bbw,
+button.gm-svpc{
     display: none;
 }
 

--- a/assets/src/scss/component/openstreet-map/_openstreet.scss
+++ b/assets/src/scss/component/openstreet-map/_openstreet.scss
@@ -63,7 +63,6 @@
 
 .gmnoprint{
     border-radius: 5px;
-    overflow: hidden;
 }
 
 .gm-style-cc,

--- a/assets/src/scss/component/openstreet-map/_openstreet.scss
+++ b/assets/src/scss/component/openstreet-map/_openstreet.scss
@@ -1,91 +1,95 @@
-#map {
-    position: relative;
-	width: 100%;
-	height: 660px;
-	border: none;
-    z-index: 1;
-}
 
-#gmap_full_screen_button {
-    position: absolute;
-    top: 20px;
-    right: 20px;
-    z-index: 999;
-    width: 50px;
-    height: 50px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 10px;
-    background-color: var(--directorist-color-white);
-    cursor: pointer;
-    i::after {
-      width: 22px;
-      height: 22px;
-      transition: all 0.3s ease-in-out;
-      background-color: var(--directorist-color-dark);
+.directorist-content-active{
+    #map {
+        position: relative;
+        width: 100%;
+        height: 660px;
+        border: none;
+        z-index: 1;
     }
-    .fullscreen-disable {
-      display: none;
+    
+    #gmap_full_screen_button {
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        z-index: 999;
+        width: 50px;
+        height: 50px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 10px;
+        background-color: var(--directorist-color-white);
+        cursor: pointer;
+        i::after {
+          width: 22px;
+          height: 22px;
+          transition: all 0.3s ease-in-out;
+          background-color: var(--directorist-color-dark);
+        }
+        .fullscreen-disable {
+          display: none;
+        }
     }
-}
-
-#progress {
-    display: none;
-    position: absolute;
-    z-index: 1000;
-    left: 400px;
-    top: 300px;
-    width: 200px;
-    height: 20px;
-    margin-top: -20px;
-    margin-left: -100px;
-    background-color: var(--directorist-color-white);
-    background-color: rgba(255, 255, 255, 0.7);
-    border-radius: 4px;
-    padding: 2px;
-}
-
-#progress-bar {
-    width: 0;
-    height: 100%;
-    background-color: #76A6FC;
-    border-radius: 4px;
-}
-
-.gm-fullscreen-control {
-    width: 50px !important;
-    height: 50px !important;
-    margin: 20px !important;
-    border-radius: 10px !important;
-    box-shadow: 0px 2px 20px rgba(0,0,0,0.26) !important;
-}
-
-.gmnoprint{
-    border-radius: 5px;
-}
-
-.gm-style-cc,
-.gm-style-mtc-bbw,
-button.gm-svpc{
-    display: none;
-}
-
-.italic {
-    font-style: italic;
-}
-
-.buttonsTable {
-    border: 1px solid grey;
-    border-collapse: collapse;
-}
-
-.buttonsTable td,
-.buttonsTable th {
-    padding: 8px;
-    border: 1px solid grey;
-}
-
-.version-disabled {
-    text-decoration: line-through;
+    
+    #progress {
+        display: none;
+        position: absolute;
+        z-index: 1000;
+        left: 400px;
+        top: 300px;
+        width: 200px;
+        height: 20px;
+        margin-top: -20px;
+        margin-left: -100px;
+        background-color: var(--directorist-color-white);
+        background-color: rgba(255, 255, 255, 0.7);
+        border-radius: 4px;
+        padding: 2px;
+    }
+    
+    #progress-bar {
+        width: 0;
+        height: 100%;
+        background-color: #76A6FC;
+        border-radius: 4px;
+    }
+    
+    .gm-fullscreen-control {
+        width: 50px !important;
+        height: 50px !important;
+        margin: 20px !important;
+        border-radius: 10px !important;
+        box-shadow: 0px 2px 20px rgba(0,0,0,0.26) !important;
+    }
+    
+    .gmnoprint{
+        border-radius: 5px;
+    }
+    
+    .gm-style-cc,
+    .gm-style-mtc-bbw,
+    button.gm-svpc{
+        display: none;
+    }
+    
+    .italic {
+        font-style: italic;
+    }
+    
+    .buttonsTable {
+        border: 1px solid grey;
+        border-collapse: collapse;
+    }
+    
+    .buttonsTable td,
+    .buttonsTable th {
+        padding: 8px;
+        border: 1px solid grey;
+    }
+    
+    .version-disabled {
+        text-decoration: line-through;
+    }
+    
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

**1.Navigate to the Directorist Settings Panel and select Google Map: https://img001.prntscr.com/file/img001/B18CsbHkRGuh6l9qwmDxag.png . Then, visit any All Listings page, select Google Map,** and you'll notice the Zoom-In and Zoom-Out controls are missing.
**[Before](https://img001.prntscr.com/file/img001/pwPPQic5S0O-xsAWOxL0cQ.png)**
**[After](https://img001.prntscr.com/file/img001/9hLzAKrHTdShSBlwJ9Zh-A.png)**


**3. When you click on a listing icon on the map, the info window appears but cannot be closed**
**[Before](https://www.loom.com/share/17e911a99a964e16910d7c2881705289?sid=e82dbe7d-a74b-4c4a-b041-503f3fc16174)**
**[After](https://www.loom.com/share/c8fe26cfbaac45cca13131d63d12a5bc?sid=17c676b8-c5c8-4fdb-bf53-b4ea60a9a19c)**


## Any linked issues
Fixes #
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/453
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/349
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/402
https://taiga-sovware-u10698.vm.elestio.app/project/directorist-1/issue/175
Google Map- Zoom in Zoom out #2144
Google Maps zoom in/out buttons. #2123

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
