### PR TITLE
Fixed: Sidebar Hover Vibration and Excessive Spacing in Add Listing Section

### DIFF
--- a/assets/css/admin-main.css
+++ b/assets/css/admin-main.css
@@ -9739,7 +9739,7 @@ body.stop-scrolling {
   width: 270px;
   min-height: 36px;
   padding: 7px 16px;
-  border: none;
+  border: 1px solid transparent;
   outline: none;
   cursor: pointer;
   font-size: 14px;

--- a/assets/css/admin-main.css
+++ b/assets/css/admin-main.css
@@ -9715,8 +9715,8 @@ body.stop-scrolling {
   height: -moz-fit-content;
   height: fit-content;
   max-height: 100vh;
-  min-width: 290px;
-  max-width: 290px;
+  min-width: 270px;
+  max-width: 270px;
   overflow-y: auto;
   padding: 10px;
   margin: -10px;

--- a/assets/css/admin-main.rtl.css
+++ b/assets/css/admin-main.rtl.css
@@ -9739,7 +9739,7 @@ body.stop-scrolling {
   width: 270px;
   min-height: 36px;
   padding: 7px 16px;
-  border: none;
+  border: 1px solid transparent;
   outline: none;
   cursor: pointer;
   font-size: 14px;

--- a/assets/css/admin-main.rtl.css
+++ b/assets/css/admin-main.rtl.css
@@ -9715,8 +9715,8 @@ body.stop-scrolling {
   height: -moz-fit-content;
   height: fit-content;
   max-height: 100vh;
-  min-width: 290px;
-  max-width: 290px;
+  min-width: 270px;
+  max-width: 270px;
   overflow-y: auto;
   padding: 10px;
   margin: -10px;

--- a/assets/css/all-listings.css
+++ b/assets/css/all-listings.css
@@ -4748,7 +4748,7 @@ body.stop-scrolling {
   width: 270px;
   min-height: 36px;
   padding: 7px 16px;
-  border: none;
+  border: 1px solid transparent;
   outline: none;
   cursor: pointer;
   font-size: 14px;

--- a/assets/css/all-listings.css
+++ b/assets/css/all-listings.css
@@ -4724,8 +4724,8 @@ body.stop-scrolling {
   height: -moz-fit-content;
   height: fit-content;
   max-height: 100vh;
-  min-width: 290px;
-  max-width: 290px;
+  min-width: 270px;
+  max-width: 270px;
   overflow-y: auto;
   padding: 10px;
   margin: -10px;

--- a/assets/css/all-listings.rtl.css
+++ b/assets/css/all-listings.rtl.css
@@ -4748,7 +4748,7 @@ body.stop-scrolling {
   width: 270px;
   min-height: 36px;
   padding: 7px 16px;
-  border: none;
+  border: 1px solid transparent;
   outline: none;
   cursor: pointer;
   font-size: 14px;

--- a/assets/css/all-listings.rtl.css
+++ b/assets/css/all-listings.rtl.css
@@ -4724,8 +4724,8 @@ body.stop-scrolling {
   height: -moz-fit-content;
   height: fit-content;
   max-height: 100vh;
-  min-width: 290px;
-  max-width: 290px;
+  min-width: 270px;
+  max-width: 270px;
   overflow-y: auto;
   padding: 10px;
   margin: -10px;

--- a/assets/css/public-main.css
+++ b/assets/css/public-main.css
@@ -4748,7 +4748,7 @@ body.stop-scrolling {
   width: 270px;
   min-height: 36px;
   padding: 7px 16px;
-  border: none;
+  border: 1px solid transparent;
   outline: none;
   cursor: pointer;
   font-size: 14px;

--- a/assets/css/public-main.css
+++ b/assets/css/public-main.css
@@ -4724,8 +4724,8 @@ body.stop-scrolling {
   height: -moz-fit-content;
   height: fit-content;
   max-height: 100vh;
-  min-width: 290px;
-  max-width: 290px;
+  min-width: 270px;
+  max-width: 270px;
   overflow-y: auto;
   padding: 10px;
   margin: -10px;

--- a/assets/css/public-main.rtl.css
+++ b/assets/css/public-main.rtl.css
@@ -4748,7 +4748,7 @@ body.stop-scrolling {
   width: 270px;
   min-height: 36px;
   padding: 7px 16px;
-  border: none;
+  border: 1px solid transparent;
   outline: none;
   cursor: pointer;
   font-size: 14px;

--- a/assets/css/public-main.rtl.css
+++ b/assets/css/public-main.rtl.css
@@ -4724,8 +4724,8 @@ body.stop-scrolling {
   height: -moz-fit-content;
   height: fit-content;
   max-height: 100vh;
-  min-width: 290px;
-  max-width: 290px;
+  min-width: 270px;
+  max-width: 270px;
   overflow-y: auto;
   padding: 10px;
   margin: -10px;

--- a/assets/src/scss/component/_add-listing.scss
+++ b/assets/src/scss/component/_add-listing.scss
@@ -1441,7 +1441,7 @@
       width: 270px;
       min-height: 36px;
       padding: 7px 16px;
-      border: none;
+      border: 1px solid transparent;
       outline: none;
       cursor: pointer;
       font-size: 14px;

--- a/assets/src/scss/component/_add-listing.scss
+++ b/assets/src/scss/component/_add-listing.scss
@@ -1424,8 +1424,8 @@
     flex-direction: column;
     height: fit-content;
     max-height: 100vh;
-    min-width: 290px;
-    max-width: 290px;
+    min-width: 270px;
+    max-width: 270px;
     overflow-y: auto;
     padding: 10px;
     margin: -10px;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.Go to the Add Listing page to observe these issues.

**Issue: The Add Listing sidebar vibrates when hovering over the section menu**
**Before**
https://www.loom.com/share/2dadf7eb00f6468689029afc4aaec0c0?sid=cf9c7ab7-3887-45d9-a9c4-3b4e8e2c6329
**After**
https://www.loom.com/share/879408abf00b44fbbd1911924157e88c?sid=b647cc48-89e5-45c4-aab0-21523c1304fb

**To much space between sidebar and Add listing cards**
**_Before_**
https://prnt.sc/rPCyZxPK3Mq5
**_After_**
https://prnt.sc/-o2gQwMA0JEL



## Any linked issues
Fixes #
https://taiga-sovware-u10698.vm.elestio.app/project/directorist-1/issue/204

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
