### PR TITLE
Hide the search field when the filter button is disabled in the popup layout.

### DIFF
--- a/templates/archive-contents.php
+++ b/templates/archive-contents.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 7.7.0
+ * @version 8.0.11
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -11,10 +11,21 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 <div <?php $listings->wrapper_class(); $listings->data_atts(); ?>>
 	<div class="directorist-archive-contents__top">
 		<?php
-			$listings->mobile_view_filter_template();
+			// Display mobile view filter button if enabled
+			if ( ! empty( $listings->options['listing_filters_button'] ) ) {
+				$listings->mobile_view_filter_template();
+			}
+
+			// Render directory type navigation template
 			$listings->directory_type_nav_template();
+
+			// Render header bar template
 			$listings->header_bar_template();
-			$listings->full_search_form_template();
+
+			// Display full search form if filters button is enabled
+			if ( ! empty( $listings->options['listing_filters_button'] ) ) {
+				$listings->full_search_form_template();
+			}
 		?>
 	</div>
 	<div class="directorist-archive-contents__listings">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.
2.
3.

## Any linked issues
Fixes #
Before: When the 'Display Filters Button' was disabled, all search fields were shown.
https://www.loom.com/share/9ece983533324a448a69a6bd8e09f259?sid=008ebeff-5774-4396-84f7-078775991d5f

After: When the 'Display Filters Button' is disabled, all search fields are now hidden.
https://www.loom.com/share/20394f030f904562b5bb0f4417865c74?sid=7b789a4a-f84f-42b2-9fc8-75d77a7b483a
## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
