### PR TITLE
Update: Single listing title tag from `<h2>` to `<h1>` for better SEO also Modal Heading 

### DIFF
--- a/assets/js/admin-main.js
+++ b/assets/js/admin-main.js
@@ -3261,9 +3261,9 @@ function convertToSelect2(selector) {
   !*** ./assets/src/scss/layout/admin/admin-style.scss ***!
   \*******************************************************/
 /*! no static exports found */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-throw new Error("Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):\nModuleError: Module Error (from ./node_modules/resolve-url-loader/index.js):\nresolve-url-loader: loader misconfiguration\n  \"engine\" option is not valid\n    at Object.emitError (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/webpack/lib/NormalModule.js:173:6)\n    at handleAsError (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/resolve-url-loader/index.js:214:12)\n    at Object.resolveUrlLoader (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/resolve-url-loader/index.js:156:12)");
+// extracted by mini-css-extract-plugin
 
 /***/ }),
 

--- a/assets/js/public-main.js
+++ b/assets/js/public-main.js
@@ -827,9 +827,9 @@ __webpack_require__.r(__webpack_exports__);
   !*** ./assets/src/scss/layout/public/main-style.scss ***!
   \*******************************************************/
 /*! no static exports found */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-throw new Error("Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):\nModuleError: Module Error (from ./node_modules/resolve-url-loader/index.js):\nresolve-url-loader: loader misconfiguration\n  \"engine\" option is not valid\n    at Object.emitError (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/webpack/lib/NormalModule.js:173:6)\n    at handleAsError (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/resolve-url-loader/index.js:214:12)\n    at Object.resolveUrlLoader (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/resolve-url-loader/index.js:156:12)");
+// extracted by mini-css-extract-plugin
 
 /***/ }),
 

--- a/assets/js/range-slider.js
+++ b/assets/js/range-slider.js
@@ -562,7 +562,7 @@ __webpack_require__.r(__webpack_exports__);
           - The provided value for the option;
           - A reference to the options object;
           - The name for the option;
-       The testing function returns false when an error is detected,
+        The testing function returns false when an error is detected,
       or true when everything is OK. It can also modify the option
       object, to make sure all values can be correctly looped elsewhere. */
   //region Defaults

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -1417,7 +1417,7 @@ __webpack_require__.r(__webpack_exports__);
           - The provided value for the option;
           - A reference to the options object;
           - The name for the option;
-       The testing function returns false when an error is detected,
+        The testing function returns false when an error is detected,
       or true when everything is OK. It can also modify the option
       object, to make sure all values can be correctly looped elsewhere. */
   //region Defaults

--- a/templates/single/fields/report.php
+++ b/templates/single/fields/report.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 				<header class="directorist-modal__header">
 
-					<h2 class="directorist-modal-title" id="directorist-report-abuse-modal__label"><?php esc_html_e('Report Abuse', 'directorist'); ?></h2>
+					<div class="directorist-modal-title" id="directorist-report-abuse-modal__label"><?php esc_html_e('Report Abuse', 'directorist'); ?></div>
 
 					<button class="directorist-modal-close directorist-modal-close-js" aria-label="Report Modal Close">
 						<span aria-hidden="true">&times;</span>

--- a/templates/single/header-parts/listing-title.php
+++ b/templates/single/header-parts/listing-title.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 if ( $display_title ): ?>
 
-    <h2 class="directorist-listing-details__listing-title"><?php echo esc_html( $listing->get_title() ); ?></h2>
+    <h1 class="directorist-listing-details__listing-title"><?php echo esc_html( $listing->get_title() ); ?></h1>
 
 <?php endif;
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.Go to Single Listing and see the title tag
2.Replace modal heading tag with a standard <div> element https://prnt.sc/9iODpHeupUC2

1. **Updated the Main Title Tag**
   - Changed the title tag from `<h2>` to `<h1>` for the main single listing title.
   - **Rationale**: Using `<h1>` improves SEO as the main title is typically expected to be the primary heading for the page.

2. **Removed Heading Tag from Modal Title**
   - The modal title is no longer wrapped in a heading tag.
   - **Rationale**: Modal titles are not intended to function as semantic headings and do not contribute to the page's SEO structure.

### **Testing**
- Verified the updated `<h1>` tag appears correctly on the single listing page.
- Confirmed modal titles display as intended without heading tags.

---

### **Impact**
- **SEO**: Improves the page's search engine optimization by adhering to better heading hierarchy practices.
- **UX**: No impact on the user interface, as visual styles remain unaffected.


## Any linked issues
Fixes #
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/609
## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
