### PR TITLE
Fix: Update search form number field dropdown placeholder based on us…

### DIFF
--- a/assets/js/admin-main.js
+++ b/assets/js/admin-main.js
@@ -3261,9 +3261,9 @@ function convertToSelect2(selector) {
   !*** ./assets/src/scss/layout/admin/admin-style.scss ***!
   \*******************************************************/
 /*! no static exports found */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-throw new Error("Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):\nModuleError: Module Error (from ./node_modules/resolve-url-loader/index.js):\nresolve-url-loader: loader misconfiguration\n  \"engine\" option is not valid\n    at Object.emitError (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/webpack/lib/NormalModule.js:173:6)\n    at handleAsError (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/resolve-url-loader/index.js:214:12)\n    at Object.resolveUrlLoader (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/resolve-url-loader/index.js:156:12)");
+// extracted by mini-css-extract-plugin
 
 /***/ }),
 

--- a/assets/js/public-main.js
+++ b/assets/js/public-main.js
@@ -827,9 +827,9 @@ __webpack_require__.r(__webpack_exports__);
   !*** ./assets/src/scss/layout/public/main-style.scss ***!
   \*******************************************************/
 /*! no static exports found */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-throw new Error("Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):\nModuleError: Module Error (from ./node_modules/resolve-url-loader/index.js):\nresolve-url-loader: loader misconfiguration\n  \"engine\" option is not valid\n    at Object.emitError (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/webpack/lib/NormalModule.js:173:6)\n    at handleAsError (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/resolve-url-loader/index.js:214:12)\n    at Object.resolveUrlLoader (/Users/mac/Local Sites/directorist-v8/app/public/wp-content/plugins/directorist/node_modules/resolve-url-loader/index.js:156:12)");
+// extracted by mini-css-extract-plugin
 
 /***/ }),
 

--- a/assets/js/range-slider.js
+++ b/assets/js/range-slider.js
@@ -562,7 +562,7 @@ __webpack_require__.r(__webpack_exports__);
           - The provided value for the option;
           - A reference to the options object;
           - The name for the option;
-       The testing function returns false when an error is detected,
+        The testing function returns false when an error is detected,
       or true when everything is OK. It can also modify the option
       object, to make sure all values can be correctly looped elsewhere. */
   //region Defaults

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -1420,7 +1420,7 @@ __webpack_require__.r(__webpack_exports__);
           - The provided value for the option;
           - A reference to the options object;
           - The name for the option;
-       The testing function returns false when an error is detected,
+        The testing function returns false when an error is detected,
       or true when everything is OK. It can also modify the option
       object, to make sure all values can be correctly looped elsewhere. */
   //region Defaults

--- a/templates/search-form/custom-fields/number/dropdown.php
+++ b/templates/search-form/custom-fields/number/dropdown.php
@@ -18,7 +18,7 @@ $options = directorist_calculate_number_options( $data );
 			<label class="directorist-search-field__label"><?php echo esc_attr( $data['label'] ); ?></label>
 		<?php endif; ?>
 
-		<select name='custom_field[<?php echo esc_attr( $data['field_key'] ); ?>]' <?php echo ! empty( $data['required'] ) ? 'required="required"' : ''; ?> data-isSearch="true">
+		<select name='custom_field[<?php echo esc_attr( $data['field_key'] ); ?>]' <?php echo ! empty( $data['required'] ) ? 'required="required"' : ''; ?> data-isSearch="true" data-placeholder="<?php echo esc_attr( $data['placeholder'] ?? '' ); ?>">
 
 			<option value=""><?php echo esc_html( ! empty( $data['placeholder'] ) ? $data['placeholder'] : __( 'Select', 'directorist' ) )?></option>
 


### PR DESCRIPTION
…er-provided details

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Add number field in search form and then select dropdown . see the placeholder not changing according to builder data

Before
https://prnt.sc/80TIW-hUjuS4
After
https://prnt.sc/c6UJm3nAG1yw


## Any linked issues
Fixes #
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/489

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
