### PR TITLE
Add users query limit to published listings owner only

### DIFF
--- a/includes/model/All_Authors.php
+++ b/includes/model/All_Authors.php
@@ -99,6 +99,8 @@ class Directorist_All_Authors {
 			$args['role__in'] = array( $all_authors_select_role );
 		}
 
+		// $args['has_published_posts'] = [ ATBDP_POST_TYPE ];
+
 		if( ! empty( $_REQUEST['alphabet'] ) && 'ALL' != $_REQUEST['alphabet'] ) {
 			$args['search'] 		= sanitize_text_field( wp_unslash( $_REQUEST['alphabet'] ) ) . '*';
 			$args['search_columns'] = array('display_name');

--- a/includes/rest-api/Version1/class-users-controller.php
+++ b/includes/rest-api/Version1/class-users-controller.php
@@ -258,6 +258,9 @@ class Users_Controller extends Abstract_Controller {
 			$prepared_args['role'] = $request['role'];
 		}
 
+		// Limit users to having published listings only
+		$prepared_args['has_published_posts'] = [ ATBDP_POST_TYPE ];
+
 		/**
 		 * Filter arguments, before passing to WP_User_Query, when querying users via the REST API.
 		 *


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Improvement

## Description
Getting all users' data using the rest API is possible, but it is not a good practice. So in this PR, user query is limited to only users with published listings.

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
