### PR TITLE
Fix listing directory update on quick and bulk edit screen

### DIFF
--- a/includes/classes/class-custom-post.php
+++ b/includes/classes/class-custom-post.php
@@ -163,15 +163,13 @@ if ( ! class_exists( 'ATBDP_Custom_Post' ) ) :
 				return;
 			}
 
-			?>
-
-			<?php if ( 'directory_type' === $column_name ) : ?>
+			if ( 'directory_type' === $column_name ) : ?>
 				<fieldset class="inline-edit-col-right" style="margin-top: 0;">
 					<div class="inline-edit-group wp-clearfix">
 						<?php wp_nonce_field( directorist_get_nonce_key(), 'directorist_nonce' ); ?>
 						<label class="inline-edit-directory-type alignleft">
 							<span class="title"><?php esc_html_e( 'Directory', 'directorist' ); ?></span>
-							<select name="directory_type">
+							<select name="directorist_directory_type">
 								<option value="">— <?php esc_html_e( 'Select type', 'directorist' ); ?> —</option>
 								<?php
 								$listing_types = directorist_get_directories();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
Try to update the directory type from listings by quick editing or bulk editing screen.

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
