### PR TITLE
Fix: Text Confusion for Price Range

### DIFF
--- a/templates/listing-form/fields/pricing.php
+++ b/templates/listing-form/fields/pricing.php
@@ -44,8 +44,8 @@ $currency_symbol         = atbdp_currency_symbol( directorist_get_currency() );
 		<select class="directorist-form-element directory_field directory_pricing_field" id="price_range" name="price_range">
 			<option value=""><?php echo esc_html( ! empty( $data['price_range_placeholder'] ) ? $data['price_range_placeholder'] : '' ); ?></option>
 			<option value="skimming"<?php selected( $price_range, 'skimming' ); ?>><?php echo esc_html( sprintf( __( 'Ultra High (%s)', 'directorist' ), str_repeat( $currency_symbol, 4 ) ) );?></option>
-			<option value="moderate" <?php selected( $price_range, 'moderate' ); ?>><?php echo esc_html( sprintf( __( 'Expensive (%s)', 'directorist' ), str_repeat( $currency_symbol, 3 ) ) );?></option>
-			<option value="economy" <?php selected( $price_range, 'economy' ); ?>><?php echo esc_html( sprintf( __( 'Moderate (%s)', 'directorist' ), str_repeat( $currency_symbol, 2 ) ) ); ?></option>
+			<option value="moderate" <?php selected( $price_range, 'moderate' ); ?>><?php echo esc_html( sprintf( __( 'Moderate (%s)', 'directorist' ), str_repeat( $currency_symbol, 3 ) ) );?></option>
+			<option value="economy" <?php selected( $price_range, 'economy' ); ?>><?php echo esc_html( sprintf( __( 'Economy (%s)', 'directorist' ), str_repeat( $currency_symbol, 2 ) ) ); ?></option>
 			<option value="bellow_economy" <?php selected( $price_range, 'bellow_economy' ); ?>><?php echo esc_html( sprintf( __( 'Cheap (%s)', 'directorist' ), str_repeat( $currency_symbol, 1 ) ) ); ?></option>
 		</select>
 	<?php } ?>

--- a/templates/listing-form/fields/pricing.php
+++ b/templates/listing-form/fields/pricing.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 7.4.2
+ * @version 8.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Select Modarete as a price range from Listing Form
2. Visit the Single Listing page
3. You will see the diff

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
