### PR TITLE
Fix: Background Image Process 

### DIFF
--- a/includes/classes/class-background-image-process.php
+++ b/includes/classes/class-background-image-process.php
@@ -80,6 +80,11 @@ class Background_Image_Process extends Background_Process {
 			header( 'X-WP-Upload-Attachment-ID: ' . $image_id );
 		}
 
+		// Ensure the required file is included before calling the function
+		if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
+		
 		\wp_update_attachment_metadata( $image_id, \wp_generate_attachment_metadata( $image_id, $image[ $image_id ] ) );
 	}
 

--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -372,9 +372,15 @@
             }
             $attachment = array( 'post_title' => basename($upload['file']), 'post_content' => '', 'post_type' => 'attachment', 'post_mime_type' => $type, 'guid' => $upload['url'] );
             $id = wp_insert_attachment( $attachment, $upload['file'], $post_id );
-            wp_update_attachment_metadata( $id, wp_generate_attachment_metadata($id, $upload['file']) );
-            return $id;
 
+            // Ensure the required file is included before calling the function
+            if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+                require_once ABSPATH . 'wp-admin/includes/image.php';
+            }
+
+            wp_update_attachment_metadata( $id, wp_generate_attachment_metadata($id, $upload['file']) );
+            
+            return $id;
         }
 
 


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
The error is caused by the function wp_generate_attachment_metadata() not being available when called inside task(). This function is defined in wp-admin/includes/image.php, which is not always loaded automatically in background processes.


## Any linked issues
Fixes https://wordpress.org/support/topic/directorist-causing-503-errors/

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
