### PR TITLE
fixed advance field hide issue on archive page

### DIFF
--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -1129,6 +1129,15 @@ class Directorist_Listings {
 			Helper::add_shortcode_comment( $atts['shortcode'] );
 		}
 
+		$search_field_atts = array_filter( $this->atts, function( $key ) {
+			return substr( $key, 0, 7 ) == 'filter_';
+		}, ARRAY_FILTER_USE_KEY );
+
+		$args = array(
+			'listings'   => $this,
+			'searchform' => new Directorist_Listing_Search_Form( $this->type, $this->current_listing_type, $search_field_atts ),
+		);
+
 		switch ( $this->sidebar ) {
 			case 'left_sidebar':
 				$template = 'sidebar-archive-contents';
@@ -1144,7 +1153,13 @@ class Directorist_Listings {
 		}
 
 		// Load the template
-		Helper::get_template( $template, array( 'listings' => $this ), 'listings_archive' );
+		Helper::get_template( $template, 
+			array(
+				'listings'   => $this,
+				'searchform' => new Directorist_Listing_Search_Form( $this->type, $this->current_listing_type, $search_field_atts ),
+			),
+			 'listings_archive',
+		);
 
 		return ob_get_clean();
 	}

--- a/includes/model/SearchForm.php
+++ b/includes/model/SearchForm.php
@@ -238,7 +238,7 @@ class Directorist_Listing_Search_Form {
 
 	public function build_search_data( $data ) {
 		$search_form_fields = get_term_meta( $this->listing_type, 'search_form_fields', true );
-		return $search_form_fields['fields'][ $data ];
+		return isset( $search_form_fields['fields'][ $data ] ) ? $search_form_fields['fields'][ $data ] : null;
 	}
 
 	/**

--- a/templates/sidebar-archive-contents.php
+++ b/templates/sidebar-archive-contents.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 8.0
+ * @version 8.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -39,11 +39,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 				<?php endif; ?>
 
 				<div class="listing-with-sidebar__contents">
-					<aside class="listing-with-sidebar__sidebar <?php echo esc_attr( $listings->sidebar_class() ); ?>">
-						<?php
-							$listings->advance_search_form_template();
-						?>
-					</aside>
+					<?php if( isset( $searchform->form_data[1]['fields'] ) && ! empty( $searchform->form_data[1]['fields'] ) ) : ?>
+						<aside class="listing-with-sidebar__sidebar <?php echo esc_attr( $listings->sidebar_class() ); ?>">
+							<?php
+								$listings->advance_search_form_template();
+							?>
+						</aside>
+					<?php endif; ?>
 					<section class="listing-with-sidebar__listing">
 						<?php
 							$listings->archive_view_template();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. before: When all fields are removed from the advanced search section:
    - It gives an undefined array key error: "Undefined array key 'radius_search'" at wp- 
     content/plugins/directorist/includes/model/SearchForm.php:241.

     - It displays an empty section: [Screenshot](https://prnt.sc/Wk1Q5Ulj_HZv).
2. After : https://prnt.sc/JXTDpbINBEbh
3.

## Any linked issues
Fixes #
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/595
## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
