### PR TITLE
Refactored default expiration date with utility function

### DIFF
--- a/includes/classes/class-metabox.php
+++ b/includes/classes/class-metabox.php
@@ -168,7 +168,7 @@ class ATBDP_Metabox {
 	{
 		// show expiration date and featured listing.
 		$directory_type         = isset( $term_id ) ? $term_id : default_directory_type();
-		$expiration				= get_term_meta( $directory_type, 'default_expiration', true );
+		$expiration				= directorist_get_default_expiration( $directory_type );
 		$expire_in_days         = ! empty( $expiration ) ? $expiration : '90';
 		$f_active               = directorist_is_featured_listing_enabled();
 		$never_expire           = get_post_meta( $listing_id, '_never_expire', true );
@@ -309,7 +309,7 @@ class ATBDP_Metabox {
 		if(ATBDP_POST_TYPE !=$post->post_type) return; // vail if it is not our post type
 		// show expiration date and featured listing.
 		$directory_type         = default_directory_type();
-		$expiration				= get_term_meta( $directory_type, 'default_expiration', true );
+		$expiration				= directorist_get_default_expiration( $directory_type );
 		$expire_in_days         = ! empty( $expiration ) ? $expiration : '90';
 		$f_active               = directorist_is_featured_listing_enabled();
 		$never_expire           = get_post_meta($post->ID, '_never_expire', true);

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -972,19 +972,22 @@ if (!function_exists('calc_listing_expiry_date')) {
      * @since    3.1.0
      *
      */
-    function calc_listing_expiry_date($start_date = NULL, $expire = NULL, $directory_type = '' )
-    {
-        $type = $directory_type ? $directory_type : default_directory_type();
-        $exp_days = get_term_meta( $type, 'default_expiration', true );
-        $exp_days = !empty( $exp_days ) ? $exp_days : 0;
-        $expired_date = !empty($expire) ? $expire : $exp_days;
-        // Current time
-        $start_date = !empty($start_date) ? $start_date : current_time('mysql');
-        // Calculate new date
-        $date = new DateTime($start_date);
-        $date->add(new DateInterval("P{$expired_date}D")); // set the interval in days
-        return $date->format('Y-m-d H:i:s');
+    function calc_listing_expiry_date( $start_date = null, $expire_date = null, $directory_id = 0 ) {
+		if ( empty( $expire_date ) ) {
+			if ( ! $directory_id ) {
+				$directory_id = directorist_get_default_directory();
+			}
 
+			$expire_date = directorist_get_default_expiration( $directory_id );
+		}
+
+		$start_date  = ! empty( $start_date ) ? $start_date : current_time( 'mysql' );
+
+        // Calculate new date
+        $date = new \DateTime($start_date);
+        $date->add( new DateInterval( "P{$expire_date}D" ) ); // set the interval in days
+
+        return $date->format( 'Y-m-d H:i:s' );
     }
 }
 

--- a/includes/rest-api/Version1/class-builder-controller.php
+++ b/includes/rest-api/Version1/class-builder-controller.php
@@ -96,7 +96,7 @@ class Builder_Controller extends Abstract_Controller {
 	public function prepare_item_for_response( $item, $request ) {
 		// Created date.
 		$date_created = get_term_meta( $item->term_id, '_created_date', true );
-		$expiration   = get_term_meta( $item->term_id, 'default_expiration', true );
+		$expiration   = directorist_get_default_expiration( $item->term_id );
 		$new_status   = get_term_meta( $item->term_id, 'new_listing_status', true );
 		$edit_status  = directorist_get_listing_edit_status( $item->term_id );
 		$is_default   = get_term_meta( $item->term_id, '_default', true );

--- a/includes/rest-api/Version1/class-directories-controller.php
+++ b/includes/rest-api/Version1/class-directories-controller.php
@@ -43,7 +43,7 @@ class Directories_Controller extends Terms_Controller {
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$date_created = get_term_meta( $item->term_id, '_created_date', true );
-		$expiration   = get_term_meta( $item->term_id, 'default_expiration', true );
+		$expiration   = directorist_get_default_expiration( $item->term_id );
 		$new_status   = get_term_meta( $item->term_id, 'new_listing_status', true );
 		$edit_status  = directorist_get_listing_edit_status( $item->term_id );
 		$is_default   = get_term_meta( $item->term_id, '_default', true );


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Refactoring (no functional changes, no api changes)

## Description
Refactored `default_expiration` term meta call with utility function to keep every call in sync. Also refactored the `calc_listing_expiry_date()` function.

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
