### PR TITLE
fixed more filter button issue in search form

### DIFF
--- a/templates/search-form/more-buttons.php
+++ b/templates/search-form/more-buttons.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 <div class="directorist-search-form-action">
 
-	<?php if ( $searchform->has_more_filters_button ): ?>
+	<?php if ( $searchform->has_more_filters_button && ! empty( $searchform->form_data[1]['fields'] ) ) : ?>
 
 		<div class="directorist-search-form-action__filter">
 			<a href="#" class="directorist-btn directorist-btn-lg directorist-filter-btn directorist-modal-btn directorist-modal-btn--advanced">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Before: When all fields are removed from the advanced search form builder (https://prnt.sc/O5Ux9fDQiiAc), the "More Filters" option is still displayed in the search form (https://prnt.sc/5L9e-vsCOEHL)
2. After: The "More Filters" option is now hidden (https://prnt.sc/v_kuAa3PXQ7M).
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
