### PR TITLE
File Upload input type Changed button to file

### DIFF
--- a/templates/listing-form/custom-fields/file.php
+++ b/templates/listing-form/custom-fields/file.php
@@ -125,7 +125,7 @@ $multiple           = false;
 			}
 			?>
 			" id="<?php echo esc_attr( $id ); ?>plupload-upload-ui">
-				<input id="<?php echo esc_attr( $id ); ?>plupload-browse-button" type="button"
+				<input id="<?php echo esc_attr( $id ); ?>plupload-browse-button" type="file"
 					   value="<?php esc_attr_e( 'Select Files', 'directorist' ); ?>" class="directorist-btn"/>
 				<label for="<?php echo esc_attr( $id ); ?>plupload-browse-button" class="plupload-browse-button-label"><?php directorist_icon( 'far fa-image' ); ?></label>
 				<span class="plupload-browse-img-size">1600×1200 or larger</span>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

In iPhone devices safari browser, file upload not works. When changes input type **button** to **file**, then it works. 

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
