### PR TITLE
Refactored atbdp_is_page() function

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -1960,7 +1960,7 @@ if ( ! function_exists('atbdp_is_page') ) {
             $option    = $page_map[ $page_type ]['option'];
             $page_id   = get_directorist_option( $option );
 
-            if ( is_page( $page_id ) ) {
+            if ( $page_id && is_page( $page_id ) ) {
                 return true;
             }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
This PR improves the atbdp_is_page() function by making sure is_page($page_id) does not return true if $page_id is empty or false. Previously, if no page was specified in Directorist settings, get_directorist_option($option) may return an empty value, that result is_page() to act falsely.


Steps to Reproduce the Issue
1.	Do not assign a “Login Page” in Directorist settings.
2.	Call atbdp_is_page('login').
3.	Mistakenly returns true on any page because $page_id is empty.


## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
