### PR TITLE
Fix: Update Order Author to Match Listing Author

### DIFF
--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -316,6 +316,15 @@ class ATBDP_Order
 
         global $post;
         $listing_id = get_post_meta($post_id, '_listing_id', true);
+        $author_id  = $listing_id ? get_post_field( 'post_author', $listing_id ) : '';
+        
+        if ( $author_id && ( $post->post_author != $author_id ) ) {
+            wp_update_post( array(
+                'ID' => $post_id,
+                'post_author' => $author_id
+            ) );
+        }
+
         switch ($column) {
             case 'ID' :
                 ?>
@@ -323,7 +332,6 @@ class ATBDP_Order
                 <?php
                 break;
             case 'details' :
-                $listing_id = get_post_meta($post_id, '_listing_id', true);
                 ?>
                 <p>
                     <a href="<?php echo esc_url( get_edit_post_link( $listing_id ) ); ?>"><?php echo esc_html( get_the_title( $listing_id ) ) ; ?></a>

--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -25,6 +25,7 @@ class ATBDP_Order
     public function __construct()
     {
         add_action('init', array($this, 'register_custom_post_type'));
+        add_action('save_post_at_biz_dir', array($this, 'sync_order_author_on_listing_update'), 10, 3);
 
         add_action('admin_footer-edit.php', array($this, 'admin_footer_edit'));
         add_action('restrict_manage_posts', array($this, 'restrict_manage_posts'));
@@ -39,6 +40,45 @@ class ATBDP_Order
 
         add_filter('post_row_actions', array($this, 'set_payment_receipt_link'), 10, 2);
 
+    }
+
+    /**
+     * Sync order author with listing author
+     *
+     * @param int $post_id Post ID.
+     * @param WP_Post $post Post object.
+     * @param bool $update Whether this is an existing post being updated.
+     */
+    public function sync_order_author_on_listing_update( $listing_id, $post, $update ) {
+        // Bail early if this is an autosave
+        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+            return;
+        }
+
+        // Only proceed if this is an update
+        if (!$update) {
+            return;
+        }
+
+        // Get all orders associated with this listing
+        $orders = get_posts(array(
+            'post_type' => 'atbdp_orders',
+            'meta_key' => '_listing_id',
+            'meta_value' => $listing_id,
+            'posts_per_page' => -1,
+        ));
+
+        // Update each order's author
+        foreach ($orders as $order) {
+            if ($order->post_author === $post->post_author) {
+                continue;
+            }
+
+            wp_update_post(array(
+                'ID' => $order->ID,
+                'post_author' => $post->post_author,
+            ));
+        }
     }
 
     /**
@@ -316,14 +356,6 @@ class ATBDP_Order
 
         global $post;
         $listing_id = get_post_meta($post_id, '_listing_id', true);
-        $author_id  = $listing_id ? get_post_field( 'post_author', $listing_id ) : '';
-        
-        if ( $author_id && ( $post->post_author != $author_id ) ) {
-            wp_update_post( array(
-                'ID' => $post_id,
-                'post_author' => $author_id
-            ) );
-        }
 
         switch ($column) {
             case 'ID' :

--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -45,39 +45,49 @@ class ATBDP_Order
     /**
      * Sync order author with listing author
      *
-     * @param int $post_id Post ID.
+     * @param int $listing_id Post ID.
      * @param WP_Post $post Post object.
      * @param bool $update Whether this is an existing post being updated.
      */
     public function sync_order_author_on_listing_update( $listing_id, $post, $update ) {
-        // Bail early if this is an autosave
-        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
             return;
         }
 
-        // Only proceed if this is an update
-        if (!$update) {
+        if ( ! $update ) {
             return;
         }
 
-        // Get all orders associated with this listing
-        $orders = get_posts(array(
-            'post_type' => 'atbdp_orders',
-            'meta_key' => '_listing_id',
-            'meta_value' => $listing_id,
-            'posts_per_page' => -1,
-        ));
+        global $wpdb;
 
-        // Update each order's author
-        foreach ($orders as $order) {
-            if ($order->post_author === $post->post_author) {
-                continue;
+        // Get all orders associated with this listing using direct SQL query
+        $orders = $wpdb->get_results( $wpdb->prepare(
+            "SELECT ID, post_author
+            FROM {$wpdb->posts} p
+            INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+            WHERE p.post_type = 'atbdp_orders'
+            AND pm.meta_key = '_listing_id'
+            AND pm.meta_value = %d",
+            $listing_id
+        ) );
+
+        if ( ! empty( $orders ) ) {
+            $order_ids = array();
+            foreach ( $orders as $order ) {
+                if ( $order->post_author !== $post->post_author ) {
+                    $order_ids[] = $order->ID;
+                }
             }
 
-            wp_update_post(array(
-                'ID' => $order->ID,
-                'post_author' => $post->post_author,
-            ));
+            if ( ! empty( $order_ids ) ) {
+                $order_ids_string = implode( ',', array_map( 'absint', $order_ids ) );
+                $wpdb->query( $wpdb->prepare(
+                    "UPDATE {$wpdb->posts}
+                    SET post_author = %d
+                    WHERE ID IN ({$order_ids_string})",
+                    $post->post_author
+                ) );
+            }
         }
     }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
This PR fixes an issue where the order post author may not match the associated listing author. 

### Changes Made
- Added logic to check if the order's post author matches the listing author
- If there's a mismatch, update the order's post author to match the listing author
- This ensures proper ownership and access control for orders

### Testing Instructions
1. Create a new listing as User A
2. Assign User B to that listing.
3. Verify that the order's author is automatically updated to User B
4. Check that the order appears correctly in User B's dashboard

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
