### PR TITLE
Fix: Taxonomy pagination improvements

### DIFF
--- a/includes/model/ListingTaxonomy.php
+++ b/includes/model/ListingTaxonomy.php
@@ -128,7 +128,7 @@ class Directorist_Listing_Taxonomy {
 		$total_terms 	= wp_count_terms( $this->tax, array_merge( $args, ['number' => 0, 'offset' => 0] ) );
 		
 		$this->terms 			= array_slice( $all_terms, $offset, $this->per_page) ;
-		$this->total_pages		= ceil( $total_terms / $this->per_page );
+		$this->total_pages		= ( $this->per_page > 0 ) ? ceil( $total_terms / $this->per_page ) : 1;
 		$this->current_page 	= $current_page; // Store current page for reference
 
 	}

--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -316,6 +316,15 @@ class ATBDP_Order
 
         global $post;
         $listing_id = get_post_meta($post_id, '_listing_id', true);
+        $author_id  = $listing_id ? get_post_field( 'post_author', $listing_id ) : '';
+        
+        if ( $author_id && ( $post->post_author != $author_id ) ) {
+            wp_update_post( array(
+                'ID' => $post_id,
+                'post_author' => $author_id
+            ) );
+        }
+
         switch ($column) {
             case 'ID' :
                 ?>
@@ -323,7 +332,6 @@ class ATBDP_Order
                 <?php
                 break;
             case 'details' :
-                $listing_id = get_post_meta($post_id, '_listing_id', true);
                 ?>
                 <p>
                     <a href="<?php echo esc_url( get_edit_post_link( $listing_id ) ); ?>"><?php echo esc_html( get_the_title( $listing_id ) ) ; ?></a>

--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -316,15 +316,6 @@ class ATBDP_Order
 
         global $post;
         $listing_id = get_post_meta($post_id, '_listing_id', true);
-        $author_id  = $listing_id ? get_post_field( 'post_author', $listing_id ) : '';
-        
-        if ( $author_id && ( $post->post_author != $author_id ) ) {
-            wp_update_post( array(
-                'ID' => $post_id,
-                'post_author' => $author_id
-            ) );
-        }
-
         switch ($column) {
             case 'ID' :
                 ?>

--- a/includes/payments/class-order.php
+++ b/includes/payments/class-order.php
@@ -323,6 +323,7 @@ class ATBDP_Order
                 <?php
                 break;
             case 'details' :
+                $listing_id = get_post_meta($post_id, '_listing_id', true);
                 ?>
                 <p>
                     <a href="<?php echo esc_url( get_edit_post_link( $listing_id ) ); ?>"><?php echo esc_html( get_the_title( $listing_id ) ) ; ?></a>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [x] Improvement

## Description
This PR fixes a critical issue where `DivisionByZeroError` occurs in the `Directorist_Listing_Taxonomy` class when `$this->per_page` is null or 0, causing a fatal error during taxonomy pagination calculation.

Added a safety check in the `set_terms()` method to ensure we never divide by zero when calculating total pages.

Internal-> 1008 Fatal Error (DivisionByZeroError) Directorist


## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
