### PR TITLE
Fixed listing preview title preview filter too few arguments issue

### DIFF
--- a/includes/classes/class-listing.php
+++ b/includes/classes/class-listing.php
@@ -62,8 +62,8 @@ if (!class_exists('ATBDP_Listing')):
 			add_filter( 'the_title', array( $this, 'add_preview_prefix_in_title' ), 10, 2 );
         }
 
-		public function add_preview_prefix_in_title( $title, $listing_id ) {
-			if ( is_admin() || ! directorist_is_listing_post_type( $listing_id ) || ! isset( $_GET['preview'] ) ) {
+		public function add_preview_prefix_in_title( $title = '', $listing_id = 0 ) {
+			if ( is_admin() || ! isset( $_GET['preview'] ) || ! directorist_is_listing_post_type( $listing_id ) ) {
 				return $title;
 			}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
We are prefixing the listing title with "Preview:" instead of the default "Private:" on the listing preview screen using the "the_title" filter hook. But it seems in some cases the filter hook doesn't have all the required arguments hence the user will experience "too few arguments" php fatal error.

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
