### PR TITLE
Fix: Corrected missing location field position to ensure the arrow icon functions properly.

### DIFF
--- a/templates/search-form/fields/location.php
+++ b/templates/search-form/fields/location.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   6.6
- * @version 8.0.9
+ * @version 8.3.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) exit;
@@ -13,7 +13,7 @@ if ( $location_source == 'listing' ) {
 	$selected_item = $searchform::get_selected_location_option_data();
 	?>
 
-	<div class="directorist-search-field <?php echo esc_attr( $empty_label ); ?>">
+	<div class="directorist-search-field directorist-form-group <?php echo esc_attr( $empty_label ); ?>">
 		<div class="directorist-select directorist-search-location directorist-search-field__input">
 
 			<?php if ( ! empty( $data['label'] ) ) : ?>


### PR DESCRIPTION
… arrow icon to not work properly.

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.The position of the location field was missing, which caused the arrow icon to not work properly.
Location: https://prnt.sc/NRyG0O34YSps

Before
https://prnt.sc/GYe6GL388RBB
After
https://prnt.sc/-nTF6pVTDU2K


## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
