### PR TITLE
Fix and refactor listing view count

### DIFF
--- a/assets/src/js/public/components/listing-track.js
+++ b/assets/src/js/public/components/listing-track.js
@@ -2,12 +2,12 @@
     window.addEventListener('load', () => {
 
         if ($('.directorist-single-contents-area').length > 0) {
-            var listing_id  = $('.directorist-single-contents-area').data('id');  // listing id
+            var listing_id  = directorist.current_page_id;  // listing id
             var storage_key = 'directorist_listing_views';                        // Key for session storage
-        
+
             // Check if the user has already viewed this listing during the session.
             var viewed_listings = JSON.parse( sessionStorage.getItem( storage_key ) ) || {};
-        
+
             if ( !viewed_listings[listing_id] ) {
                 // Send an AJAX request to track the view for this specific listing.
                 $.ajax({


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix


## Description
When `.directorist-single-contents-area` element doesn't contain the listing id the whole listing view count system doesn't work!

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
