### PR TITLE
Fix csv importer application/csv mimetype issue

### DIFF
--- a/includes/classes/class-tools.php
+++ b/includes/classes/class-tools.php
@@ -823,11 +823,11 @@ use Directorist\Listings_CSV_Importer as Importer;
 			}
 
 			$mime_type = mime_content_type( $file );
-			if ( ! in_array( $mime_type, array( 'text/csv','text/plain' ), true ) ) {
+			if ( ! in_array( $mime_type, array( 'text/csv','text/plain', 'application/csv' ), true ) ) {
 				return new WP_Error(
 					'invalid_csv_file',
 					sprintf(
-						'Invalid file type. Only text/csv and text/plain are supported, given "%s".',
+						'Invalid file type. Only text/plain, text/csv, and application/csv are supported, given "%s".',
 						$mime_type
 					)
 				);


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- Bugfix

## Description
Valid mime types for a CSV file is text/csv, application/csv, text/plain.
application/csv was missing.

## Any linked issues
Fixes #

## Checklist

- My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
