### PR TITLE
Fix: Single and Multiple Condition Handling in Form Builder

### DIFF
--- a/assets/js/account.js
+++ b/assets/js/account.js
@@ -311,7 +311,6 @@ jQuery(function ($) {
       $this.removeClass('directorist-btn-loading'); // Removed loading class
       return; // Stop submission if validation fails
     }
-
     var formData = new FormData(form);
     formData.append('action', 'directorist_register_form');
     formData.append('params', JSON.stringify(directorist_signin_signup_params));

--- a/assets/js/add-listing.js
+++ b/assets/js/add-listing.js
@@ -109,9 +109,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _components_debounce__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./components/debounce */ "./assets/src/js/global/components/debounce.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 // General Components
 // import { cacheCategoryCustomFields, getCategoryCustomFieldsCache } from '../global/components/cache-category-custom-fields';
 // import loadCategoryCustomFields from '../global/components/load-category-custom-fields';
@@ -531,7 +531,6 @@ $(function () {
     renderCategoryCustomFields();
     // cacheCategoryCustomFields();
   });
-
   window.addEventListener('directorist-type-change', function () {
     renderCategoryCustomFields();
     // cacheCategoryCustomFields();
@@ -1183,7 +1182,6 @@ function defaultAddListing() {
         requestAnimationFrame(scrollAnimation); // Continue the scrollAnimation
       }
     }
-
     function easeInOutQuad(t, b, c, d) {
       t /= d / 2;
       if (t < 1) return c / 2 * t * t + b;
@@ -1288,9 +1286,9 @@ function debounce(func, wait, immediate) {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 var $ = jQuery;
 window.addEventListener('load', waitAndInit);
 window.addEventListener('directorist-search-form-nav-tab-reloaded', waitAndInit);
@@ -1526,7 +1524,6 @@ function initSelect2() {
   // Not found in any template
   '.bdas-category-search' // Not found in any template
   ];
-
   selectors.forEach(function (selector) {
     return Object(_lib_helper__WEBPACK_IMPORTED_MODULE_1__["convertToSelect2"])(selector);
   });
@@ -1653,7 +1650,6 @@ function maybeLazyLoadTaxonomyTermsSelect2(args) {
       if (level > 1) {
         $state.addClass('item-level-' + level); // Add class for the level (e.g., level-1, level-2, etc.)
       }
-
       $state.html(combinedText); // Set the combined content (icon + text)
 
       return $state;
@@ -2018,10 +2014,10 @@ window.addEventListener('load', function () {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayLikeToArray(arr, len) {
-  if (len == null || len > arr.length) len = arr.length;
-  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
-  return arr2;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
 }
 module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -2034,8 +2030,8 @@ module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exp
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayWithHoles(arr) {
-  if (Array.isArray(arr)) return arr;
+function _arrayWithHoles(r) {
+  if (Array.isArray(r)) return r;
 }
 module.exports = _arrayWithHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -2049,19 +2045,13 @@ module.exports = _arrayWithHoles, module.exports.__esModule = true, module.expor
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -2130,8 +2120,8 @@ var arrayWithHoles = __webpack_require__(/*! ./arrayWithHoles.js */ "./node_modu
 var iterableToArrayLimit = __webpack_require__(/*! ./iterableToArrayLimit.js */ "./node_modules/@babel/runtime/helpers/iterableToArrayLimit.js");
 var unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js");
 var nonIterableRest = __webpack_require__(/*! ./nonIterableRest.js */ "./node_modules/@babel/runtime/helpers/nonIterableRest.js");
-function _slicedToArray(arr, i) {
-  return arrayWithHoles(arr) || iterableToArrayLimit(arr, i) || unsupportedIterableToArray(arr, i) || nonIterableRest();
+function _slicedToArray(r, e) {
+  return arrayWithHoles(r) || iterableToArrayLimit(r, e) || unsupportedIterableToArray(r, e) || nonIterableRest();
 }
 module.exports = _slicedToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -2145,17 +2135,17 @@ module.exports = _slicedToArray, module.exports.__esModule = true, module.export
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -2168,11 +2158,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -2186,11 +2176,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -2204,13 +2194,12 @@ module.exports = _typeof, module.exports.__esModule = true, module.exports["defa
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _unsupportedIterableToArray(o, minLen) {
-  if (!o) return;
-  if (typeof o === "string") return arrayLikeToArray(o, minLen);
-  var n = Object.prototype.toString.call(o).slice(8, -1);
-  if (n === "Object" && o.constructor) n = o.constructor.name;
-  if (n === "Map" || n === "Set") return Array.from(o);
-  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
 }
 module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/admin-builder-archive.js
+++ b/assets/js/admin-builder-archive.js
@@ -182,9 +182,9 @@ window.addEventListener('load', function () {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 window.addEventListener('load', function () {
   var axios = __webpack_require__(/*! axios */ "./node_modules/axios/index.js").default;
   var $ = jQuery;
@@ -643,7 +643,6 @@ function initializeDropdownField() {
       });
       return titles; // Return the array of titles
     }
-
     return [];
   }
 }

--- a/assets/js/admin-import-export.js
+++ b/assets/js/admin-import-export.js
@@ -155,7 +155,7 @@ jQuery(document).ready(function ($) {
     var configFields = $('.directorist-listings-importer-config-field');
     var position = 0;
     var offset = 0;
-    var run_import = function run_import() {
+    var _run_import = function run_import() {
       var form_data = new FormData();
 
       // ajax action
@@ -221,7 +221,7 @@ jQuery(document).ready(function ($) {
           if (!response.done) {
             position = response.position;
             offset = response.offset;
-            run_import();
+            _run_import();
           } else {
             window.location = "".concat(response.redirect_url, "&listing-imported=").concat(response.imported_items.length, "&listing-failed=").concat(response.failed_items.length);
           }
@@ -232,7 +232,7 @@ jQuery(document).ready(function ($) {
         }
       });
     };
-    run_import();
+    _run_import();
   });
 
   /* csv upload */
@@ -252,19 +252,13 @@ jQuery(document).ready(function ($) {
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -278,17 +272,17 @@ module.exports = _defineProperty, module.exports.__esModule = true, module.expor
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -301,11 +295,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -319,11 +313,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/admin-main.js
+++ b/assets/js/admin-main.js
@@ -1556,9 +1556,9 @@ window.addEventListener('load', function () {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 window.addEventListener('load', function () {
   var $ = jQuery;
 
@@ -1732,7 +1732,7 @@ window.addEventListener('load', function () {
             };
 
             // Download Files
-            var download_files = function download_files(file_list, counter, callback) {
+            var _download_files = function download_files(file_list, counter, callback) {
               if (counter > file_list.length - 1) {
                 if (callback) {
                   callback();
@@ -1748,7 +1748,7 @@ window.addEventListener('load', function () {
               var list_checkbox = $(".atbdp-".concat(file_type, "-checkbox-item-").concat(file.item_id));
               var is_checked = list_checkbox.is(':checked');
               if (!is_checked) {
-                download_files(file_list, next_index, callback);
+                _download_files(file_list, next_index, callback);
                 return;
               }
               var form_data = {
@@ -1789,7 +1789,7 @@ window.addEventListener('load', function () {
                       files_download_states.failed_theme_downloads.push(file);
                     }
                   }
-                  download_files(file_list, next_index, callback);
+                  _download_files(file_list, next_index, callback);
                 },
                 error: function error(_error) {
                   console.log(_error);
@@ -1874,7 +1874,7 @@ window.addEventListener('load', function () {
               $(form_response_page).find('.account-connect__form-btn').append(finish_btn);
             };
             if (downloading_files.length) {
-              download_files(downloading_files, 0, after_download_callback);
+              _download_files(downloading_files, 0, after_download_callback);
             }
           });
         }
@@ -2320,7 +2320,7 @@ window.addEventListener('load', function () {
       install: '.file-install-btn',
       activate: '.plugin-active-btn'
     };
-    var bulk_task = function bulk_task(plugins, counter, callback) {
+    var _bulk_task = function bulk_task(plugins, counter, callback) {
       if (counter > plugins.length - 1) {
         if (callback) {
           callback();
@@ -2353,14 +2353,14 @@ window.addEventListener('load', function () {
           } else {
             action_btn.html('Failed');
           }
-          bulk_task(plugins, next_index, callback);
+          _bulk_task(plugins, next_index, callback);
         },
         error: function error(_error9) {
           // console.log(error);
         }
       });
     };
-    bulk_task(plugins_items, 0, after_plugins_install);
+    _bulk_task(plugins_items, 0, after_plugins_install);
   }
 
   // Ext Actions | Uninstall
@@ -2612,9 +2612,9 @@ function modalToggle() {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 var $ = jQuery;
 window.addEventListener('load', waitAndInit);
 window.addEventListener('directorist-search-form-nav-tab-reloaded', waitAndInit);
@@ -2850,7 +2850,6 @@ function initSelect2() {
   // Not found in any template
   '.bdas-category-search' // Not found in any template
   ];
-
   selectors.forEach(function (selector) {
     return Object(_lib_helper__WEBPACK_IMPORTED_MODULE_1__["convertToSelect2"])(selector);
   });
@@ -2977,7 +2976,6 @@ function maybeLazyLoadTaxonomyTermsSelect2(args) {
       if (level > 1) {
         $state.addClass('item-level-' + level); // Add class for the level (e.g., level-1, level-2, etc.)
       }
-
       $state.html(combinedText); // Set the combined content (icon + text)
 
       return $state;
@@ -3297,10 +3295,10 @@ function convertToSelect2(selector) {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayLikeToArray(arr, len) {
-  if (len == null || len > arr.length) len = arr.length;
-  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
-  return arr2;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
 }
 module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3314,8 +3312,8 @@ module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exp
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _arrayWithoutHoles(arr) {
-  if (Array.isArray(arr)) return arrayLikeToArray(arr);
+function _arrayWithoutHoles(r) {
+  if (Array.isArray(r)) return arrayLikeToArray(r);
 }
 module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3329,19 +3327,13 @@ module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3354,8 +3346,8 @@ module.exports = _defineProperty, module.exports.__esModule = true, module.expor
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _iterableToArray(iter) {
-  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+function _iterableToArray(r) {
+  if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r);
 }
 module.exports = _iterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3386,8 +3378,8 @@ var arrayWithoutHoles = __webpack_require__(/*! ./arrayWithoutHoles.js */ "./nod
 var iterableToArray = __webpack_require__(/*! ./iterableToArray.js */ "./node_modules/@babel/runtime/helpers/iterableToArray.js");
 var unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js");
 var nonIterableSpread = __webpack_require__(/*! ./nonIterableSpread.js */ "./node_modules/@babel/runtime/helpers/nonIterableSpread.js");
-function _toConsumableArray(arr) {
-  return arrayWithoutHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableSpread();
+function _toConsumableArray(r) {
+  return arrayWithoutHoles(r) || iterableToArray(r) || unsupportedIterableToArray(r) || nonIterableSpread();
 }
 module.exports = _toConsumableArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3401,17 +3393,17 @@ module.exports = _toConsumableArray, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -3424,11 +3416,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -3442,11 +3434,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3460,13 +3452,12 @@ module.exports = _typeof, module.exports.__esModule = true, module.exports["defa
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _unsupportedIterableToArray(o, minLen) {
-  if (!o) return;
-  if (typeof o === "string") return arrayLikeToArray(o, minLen);
-  var n = Object.prototype.toString.call(o).slice(8, -1);
-  if (n === "Object" && o.constructor) n = o.constructor.name;
-  if (n === "Map" || n === "Set") return Array.from(o);
-  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
 }
 module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/admin-multi-directory-builder.js
+++ b/assets/js/admin-multi-directory-builder.js
@@ -648,9 +648,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var vue__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! vue */ "./node_modules/vue/dist/vue.esm.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   watch: {
@@ -748,9 +748,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -992,9 +992,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 /* harmony import */ var _helpers__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 var axios = __webpack_require__(/*! axios */ "./node_modules/axios/index.js").default;
@@ -1651,9 +1651,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -2169,9 +2169,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 /* harmony import */ var _helpers__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./../helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -2327,9 +2327,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _helpers__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./../helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -2673,9 +2673,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -3101,7 +3101,6 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
         // const confirmation_status = this.getConfirmation( updateData );
         // if ( ! confirmation_status ) { return; }
       }
-
       updateData();
     },
     getConfirmation: function getConfirmation(callback) {
@@ -3271,9 +3270,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var vuex__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! vuex */ "./node_modules/vuex/dist/vuex.esm.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -3435,43 +3434,44 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
       }
       return isChangeable;
     },
-    checkShowIfCondition: function checkShowIfCondition(payloadArray) {
-      var result = {
-        status: false,
-        // Final status (true if all conditions pass)
-        failed_conditions: 0,
-        succeed_conditions: 0,
-        matched_data: []
-      };
-
-      // Normalize condition into an array
-      var conditions = Array.isArray(payloadArray.condition) ? payloadArray.condition : [payloadArray.condition];
-      var _iterator4 = _createForOfIteratorHelper(conditions),
-        _step4;
-      try {
-        for (_iterator4.s(); !(_step4 = _iterator4.n()).done;) {
-          var payload = _step4.value;
-          var state = this.checkSingleShowIfCondition({
-            condition: payload
-          });
-          if (state.status) {
-            result.succeed_conditions += 1;
-            result.matched_data.push(payload);
-          } else {
-            result.failed_conditions += 1;
+    checkShowIfCondition: function checkShowIfCondition(payload) {
+      // Handle both single and multiple conditions
+      if (payload.condition && Array.isArray(payload.condition)) {
+        // This is a multiple condition case
+        var result = {
+          status: false,
+          failed_conditions: 0,
+          succeed_conditions: 0,
+          matched_data: []
+        };
+        var _iterator4 = _createForOfIteratorHelper(payload.condition),
+          _step4;
+        try {
+          for (_iterator4.s(); !(_step4 = _iterator4.n()).done;) {
+            var condition = _step4.value;
+            var state = this.checkSingleCondition({
+              condition: condition
+            });
+            if (state.status) {
+              result.succeed_conditions += 1;
+              result.matched_data.push(condition);
+            } else {
+              result.failed_conditions += 1;
+            }
           }
+        } catch (err) {
+          _iterator4.e(err);
+        } finally {
+          _iterator4.f();
         }
-
-        // If all conditions pass, set status to true
-      } catch (err) {
-        _iterator4.e(err);
-      } finally {
-        _iterator4.f();
+        result.status = result.failed_conditions === 0;
+        return result;
+      } else {
+        // This is a single condition case
+        return this.checkSingleCondition(payload);
       }
-      result.status = result.failed_conditions === 0;
-      return result;
     },
-    checkSingleShowIfCondition: function checkSingleShowIfCondition(payload) {
+    checkSingleCondition: function checkSingleCondition(payload) {
       var args = {
         condition: null
       };
@@ -3539,14 +3539,6 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
               sub_condition_error++;
             }
             if (sub_condition_error) {
-              failed_cond_count++;
-              continue;
-            }
-            if (!this.checkComparison({
-              data_a: sub_condition_field,
-              data_b: sub_condition.value,
-              compare: sub_compare
-            })) {
               failed_cond_count++;
               continue;
             }
@@ -3772,9 +3764,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_1__);
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 /* harmony default export */ __webpack_exports__["default"] = ({
@@ -12496,9 +12488,9 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var vue__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! vue */ "./node_modules/vue/dist/vue.esm.js");
 /* harmony import */ var vuex__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! vuex */ "./node_modules/vuex/dist/vuex.esm.js");
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 vue__WEBPACK_IMPORTED_MODULE_0__["default"].use(vuex__WEBPACK_IMPORTED_MODULE_1__["default"]);
@@ -12713,9 +12705,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/typeof */ "./node_modules/@babel/runtime/helpers/typeof.js");
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__);
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 var isObject = function isObject(value) {
   return value && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(value) === 'object' && !Array.isArray(value);
 };
@@ -12758,10 +12750,10 @@ function findObjectItem(path, data, defaultValue) {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayLikeToArray(arr, len) {
-  if (len == null || len > arr.length) len = arr.length;
-  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
-  return arr2;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
 }
 module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12775,8 +12767,8 @@ module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exp
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _arrayWithoutHoles(arr) {
-  if (Array.isArray(arr)) return arrayLikeToArray(arr);
+function _arrayWithoutHoles(r) {
+  if (Array.isArray(r)) return arrayLikeToArray(r);
 }
 module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12789,33 +12781,28 @@ module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.ex
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
+function asyncGeneratorStep(n, t, e, r, o, a, c) {
   try {
-    var info = gen[key](arg);
-    var value = info.value;
-  } catch (error) {
-    reject(error);
-    return;
+    var i = n[a](c),
+      u = i.value;
+  } catch (n) {
+    return void e(n);
   }
-  if (info.done) {
-    resolve(value);
-  } else {
-    Promise.resolve(value).then(_next, _throw);
-  }
+  i.done ? t(u) : Promise.resolve(u).then(r, o);
 }
-function _asyncToGenerator(fn) {
+function _asyncToGenerator(n) {
   return function () {
-    var self = this,
-      args = arguments;
-    return new Promise(function (resolve, reject) {
-      var gen = fn.apply(self, args);
-      function _next(value) {
-        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);
+    var t = this,
+      e = arguments;
+    return new Promise(function (r, o) {
+      var a = n.apply(t, e);
+      function _next(n) {
+        asyncGeneratorStep(a, r, o, _next, _throw, "next", n);
       }
-      function _throw(err) {
-        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err);
+      function _throw(n) {
+        asyncGeneratorStep(a, r, o, _next, _throw, "throw", n);
       }
-      _next(undefined);
+      _next(void 0);
     });
   };
 }
@@ -12831,19 +12818,13 @@ module.exports = _asyncToGenerator, module.exports.__esModule = true, module.exp
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12856,8 +12837,8 @@ module.exports = _defineProperty, module.exports.__esModule = true, module.expor
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _iterableToArray(iter) {
-  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+function _iterableToArray(r) {
+  if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r);
 }
 module.exports = _iterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12994,7 +12975,7 @@ function _regeneratorRuntime() {
   function makeInvokeMethod(e, r, n) {
     var o = h;
     return function (i, a) {
-      if (o === f) throw new Error("Generator is already running");
+      if (o === f) throw Error("Generator is already running");
       if (o === s) {
         if ("throw" === i) throw a;
         return {
@@ -13136,7 +13117,7 @@ function _regeneratorRuntime() {
           } else if (c) {
             if (this.prev < i.catchLoc) return handle(i.catchLoc, !0);
           } else {
-            if (!u) throw new Error("try statement without catch or finally");
+            if (!u) throw Error("try statement without catch or finally");
             if (this.prev < i.finallyLoc) return handle(i.finallyLoc);
           }
         }
@@ -13176,7 +13157,7 @@ function _regeneratorRuntime() {
           return o;
         }
       }
-      throw new Error("illegal catch attempt");
+      throw Error("illegal catch attempt");
     },
     delegateYield: function delegateYield(e, r, n) {
       return this.delegate = {
@@ -13202,8 +13183,8 @@ var arrayWithoutHoles = __webpack_require__(/*! ./arrayWithoutHoles.js */ "./nod
 var iterableToArray = __webpack_require__(/*! ./iterableToArray.js */ "./node_modules/@babel/runtime/helpers/iterableToArray.js");
 var unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js");
 var nonIterableSpread = __webpack_require__(/*! ./nonIterableSpread.js */ "./node_modules/@babel/runtime/helpers/nonIterableSpread.js");
-function _toConsumableArray(arr) {
-  return arrayWithoutHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableSpread();
+function _toConsumableArray(r) {
+  return arrayWithoutHoles(r) || iterableToArray(r) || unsupportedIterableToArray(r) || nonIterableSpread();
 }
 module.exports = _toConsumableArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -13217,17 +13198,17 @@ module.exports = _toConsumableArray, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -13240,11 +13221,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -13258,11 +13239,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -13276,13 +13257,12 @@ module.exports = _typeof, module.exports.__esModule = true, module.exports["defa
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _unsupportedIterableToArray(o, minLen) {
-  if (!o) return;
-  if (typeof o === "string") return arrayLikeToArray(o, minLen);
-  var n = Object.prototype.toString.call(o).slice(8, -1);
-  if (n === "Object" && o.constructor) n = o.constructor.name;
-  if (n === "Map" || n === "Set") return Array.from(o);
-  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
 }
 module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -15566,7 +15546,7 @@ var axios = __webpack_require__(/*! axios */ "./node_modules/axios/index.js").de
     },
     handleSaveData: function handleSaveData(callback) {
       var _this2 = this;
-      return _babel_runtime_helpers_asyncToGenerator__WEBPACK_IMPORTED_MODULE_0___default()( /*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_3___default.a.mark(function _callee() {
+      return _babel_runtime_helpers_asyncToGenerator__WEBPACK_IMPORTED_MODULE_0___default()(/*#__PURE__*/_babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_3___default.a.mark(function _callee() {
         var addListingURL, urlWithListingType;
         return _babel_runtime_regenerator__WEBPACK_IMPORTED_MODULE_3___default.a.wrap(function _callee$(_context) {
           while (1) switch (_context.prev = _context.next) {
@@ -17166,7 +17146,6 @@ __webpack_require__.r(__webpack_exports__);
       type: Number,
       default: 0 // Unlimitted
     },
-
     maxWidgetInfoText: {
       type: String,
       default: 'Up to __DATA__ item{s} can be added'
@@ -18529,11 +18508,9 @@ __webpack_require__.r(__webpack_exports__);
     canDrag: {
       default: true // move | clone
     },
-
     dragType: {
       default: 'move' // move | clone
     },
-
     itemClassName: {
       default: ''
     },
@@ -18541,7 +18518,6 @@ __webpack_require__.r(__webpack_exports__);
       default: 'div' // div | li
     }
   },
-
   computed: {
     listItemStyle: function listItemStyle() {
       var style = {
@@ -18706,9 +18682,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _mixins_helpers__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../mixins/helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   name: "form-builder-widget-list-section-component",
@@ -19948,9 +19924,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -20540,9 +20516,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -20662,7 +20638,6 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
                   _main_widget.original_widget_key = matched_field.widget_key;
                   // console.log( { widget, widget_key: matched_field.widget_key,  matched_field } );
                 }
-
                 if (typeof matched_field.label === 'string' && matched_field.label.length) {
                   _main_widget.label = matched_field.label;
                 }
@@ -21122,9 +21097,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -21692,9 +21667,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -22228,9 +22203,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -22749,9 +22724,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -23268,9 +23243,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -23915,9 +23890,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -24211,7 +24186,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       if (!placeholder.insertByButton) {
         return false;
       }
-      var findPlaceholder = function findPlaceholder(placeholderKey, placeholders) {
+      var _findPlaceholder = function findPlaceholder(placeholderKey, placeholders) {
         var _iterator4 = _createForOfIteratorHelper(placeholders),
           _step4;
         try {
@@ -24224,7 +24199,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
               continue;
             }
             if ("placeholder_group" === _placeholder.type) {
-              var _targetPlaceholder = findPlaceholder(placeholderKey, _placeholder.placeholders);
+              var _targetPlaceholder = _findPlaceholder(placeholderKey, _placeholder.placeholders);
               if (_targetPlaceholder) {
                 return _targetPlaceholder;
               }
@@ -24238,7 +24213,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
         }
         return null;
       };
-      var targetPlaceholder = findPlaceholder(placeholderKey, this.placeholders);
+      var targetPlaceholder = _findPlaceholder(placeholderKey, this.placeholders);
       return targetPlaceholder ? false : true;
     },
     addPlaceholder: function addPlaceholder(placeholderKey) {
@@ -24933,9 +24908,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _mixins_helpers__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../../mixins/helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -25357,16 +25332,16 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
     genarateWidgetKeyForActiveWidgets: function genarateWidgetKeyForActiveWidgets(widget_key) {
       if (typeof this.active_widget_fields[widget_key] !== "undefined") {
         var matched_keys = Object.keys(this.active_widget_fields);
-        var getUniqueKey = function getUniqueKey(current_key, new_key) {
+        var _getUniqueKey = function getUniqueKey(current_key, new_key) {
           if (matched_keys.includes(new_key)) {
             var field_id = new_key.match(/[_](\d+)$/);
             field_id = field_id ? parseInt(field_id[1]) : 1;
             var new_field_key = current_key + "_" + (field_id + 1);
-            return getUniqueKey(current_key, new_field_key);
+            return _getUniqueKey(current_key, new_field_key);
           }
           return new_key;
         };
-        return getUniqueKey(widget_key, widget_key);
+        return _getUniqueKey(widget_key, widget_key);
       }
       return widget_key;
     },
@@ -25382,16 +25357,16 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
         }
         field_keys.push(this.active_widget_fields[key].field_key);
       }
-      var getUniqueKey = function getUniqueKey(field_key) {
+      var _getUniqueKey2 = function getUniqueKey(field_key) {
         if (field_keys.includes(field_key)) {
           var field_id = field_key.match(/[-](\d+)$/);
           field_id = field_id ? parseInt(field_id[1]) : 1;
           var new_field_key = current_field_key + "-" + (field_id + 1);
-          return getUniqueKey(new_field_key);
+          return _getUniqueKey2(new_field_key);
         }
         return field_key;
       };
-      var unique_field_key = getUniqueKey(current_field_key);
+      var unique_field_key = _getUniqueKey2(current_field_key);
       return unique_field_key;
     },
     handleGroupDragStart: function handleGroupDragStart(widget_group_key) {
@@ -25932,9 +25907,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _mixins_helpers__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../../mixins/helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -26600,7 +26575,7 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
       return options_values.includes(value);
     }
     /* syncValidationWithLocalState( validation_log ) {
-         return validation_log;
+          return validation_log;
     } */
   }
 });
@@ -27592,78 +27567,78 @@ var render = function render() {
   var _vm$status_messages;
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "directorist-directory-type atbdp-cpt-manager"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-directory-type-top"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-directory-type-top-left"
-  }, [this.enabled_multi_directory ? _c("a", {
+  }, [this.enabled_multi_directory ? _c('a', {
     staticClass: "directorist-back-directory",
     attrs: {
-      href: "edit.php?post_type=at_biz_dir&page=atbdp-directory-types"
+      "href": "edit.php?post_type=at_biz_dir&page=atbdp-directory-types"
     }
-  }, [_c("svg", {
+  }, [_c('svg', {
     attrs: {
-      xmlns: "http://www.w3.org/2000/svg",
-      width: "14",
-      height: "14",
-      viewBox: "0 0 14 14",
-      fill: "none"
+      "xmlns": "http://www.w3.org/2000/svg",
+      "width": "14",
+      "height": "14",
+      "viewBox": "0 0 14 14",
+      "fill": "none"
     }
-  }, [_c("path", {
+  }, [_c('path', {
     attrs: {
       "fill-rule": "evenodd",
       "clip-rule": "evenodd",
-      d: "M7.51556 1.38019C7.80032 1.66495 7.80032 2.12663 7.51556 2.41139L3.65616 6.27079H12.1041C12.5068 6.27079 12.8333 6.59725 12.8333 6.99996C12.8333 7.40267 12.5068 7.72913 12.1041 7.72913H3.65616L7.51556 11.5885C7.80032 11.8733 7.80032 12.335 7.51556 12.6197C7.2308 12.9045 6.76912 12.9045 6.48436 12.6197L1.38019 7.51556C1.09544 7.2308 1.09544 6.76912 1.38019 6.48436L6.48436 1.38019C6.76912 1.09544 7.2308 1.09544 7.51556 1.38019Z",
-      fill: "currentColor"
+      "d": "M7.51556 1.38019C7.80032 1.66495 7.80032 2.12663 7.51556 2.41139L3.65616 6.27079H12.1041C12.5068 6.27079 12.8333 6.59725 12.8333 6.99996C12.8333 7.40267 12.5068 7.72913 12.1041 7.72913H3.65616L7.51556 11.5885C7.80032 11.8733 7.80032 12.335 7.51556 12.6197C7.2308 12.9045 6.76912 12.9045 6.48436 12.6197L1.38019 7.51556C1.09544 7.2308 1.09544 6.76912 1.38019 6.48436L6.48436 1.38019C6.76912 1.09544 7.2308 1.09544 7.51556 1.38019Z",
+      "fill": "currentColor"
     }
-  })]), _vm._v("\n        All Directories\n      ")]) : _vm._e(), _vm._v(" "), _c("div", {
+  })]), _vm._v("\n        All Directories\n      ")]) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "directorist-row-tooltip",
     attrs: {
       "data-tooltip": "Click here to rename the directory.",
       "data-flow": "bottom"
     }
-  }, [_vm.options.name && _vm.options.name.type ? _c(_vm.options.name.type + "-field", _vm._b({
+  }, [_vm.options.name && _vm.options.name.type ? _c(_vm.options.name.type + '-field', _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateOptionsField({
-          field: "name",
+          field: 'name',
           value: $event
         });
       }
     }
-  }, "component", _vm.options.name, false)) : _vm._e()], 1)]), _vm._v(" "), _c("div", {
+  }, 'component', _vm.options.name, false)) : _vm._e()], 1)]), _vm._v(" "), _c('div', {
     staticClass: "directorist-directory-type-top-right"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-primary",
     attrs: {
-      type: "button",
-      disabled: _vm.footer_actions.save.isDisabled
+      "type": "button",
+      "disabled": _vm.footer_actions.save.isDisabled
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.saveData();
       }
     }
-  }, [_vm.footer_actions.save.showLoading ? _c("span", {
+  }, [_vm.footer_actions.save.showLoading ? _c('span', {
     staticClass: "fa fa-spinner fa-spin"
-  }) : _vm._e(), _vm._v("\n        " + _vm._s(_vm.footer_actions.save.label) + "\n      ")])])]), _vm._v(" "), (_vm$status_messages = _vm.status_messages) !== null && _vm$status_messages !== void 0 && _vm$status_messages.length ? _c("div", {
+  }) : _vm._e(), _vm._v("\n        " + _vm._s(_vm.footer_actions.save.label) + "\n      ")])])]), _vm._v(" "), (_vm$status_messages = _vm.status_messages) !== null && _vm$status_messages !== void 0 && _vm$status_messages.length ? _c('div', {
     staticClass: "atbdp-cptm-status-feedback"
   }, _vm._l(this.status_messages, function (status, index) {
-    return _c("div", {
+    return _c('div', {
       key: index,
       staticClass: "cptm-alert",
-      class: "cptm-alert-" + status.type
+      class: 'cptm-alert-' + status.type
     }, [_vm._v("\n      " + _vm._s(status.message) + "\n    ")]);
-  }), 0) : _vm._e(), _vm._v(" "), _c("div", {
+  }), 0) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "directorist-directory-type-bottom"
-  }, [_c("headerNavigation"), _vm._v(" "), _c("div", {
+  }, [_c('headerNavigation'), _vm._v(" "), _c('div', {
     staticClass: "atbdp-cptm-body"
-  }, [_c("tabContents", {
+  }, [_c('tabContents', {
     on: {
-      save: function save($event) {
+      "save": function save($event) {
         return _vm.handleSaveData($event);
       }
     }
@@ -27689,34 +27664,34 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("ul", {
+  return _c('ul', {
     staticClass: "cptm-header-navigation"
   }, _vm._l(_vm.headerNavigation, function (nav, index) {
-    return _c("li", {
+    return _c('li', {
       key: index,
       staticClass: "cptm-header-nav__list-item",
       class: nav.key
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "cptm-header-nav__list-item-link",
       class: _vm.getActiveClass(index, _vm.active_nav_index),
       attrs: {
-        href: "#"
+        "href": "#"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.swichNav(index);
         }
       }
-    }, [nav.icon ? _c("span", {
+    }, [nav.icon ? _c('span', {
       staticClass: "cptm-header-nav__icon",
       domProps: {
-        innerHTML: _vm._s(nav.icon)
+        "innerHTML": _vm._s(nav.icon)
       }
-    }) : _vm._e(), _vm._v(" "), _c("span", {
+    }) : _vm._e(), _vm._v(" "), _c('span', {
       staticClass: "cptm-header-nav__label",
       domProps: {
-        innerHTML: _vm._s(nav.label)
+        "innerHTML": _vm._s(nav.label)
       }
     })])]);
   }), 0);
@@ -27741,21 +27716,21 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "atbdp-cptm-tab-contents"
   }, [_vm._l(_vm.tabContents, function (tab, tab_index) {
-    return [tab_index === _vm.active_nav_index ? _c("div", {
+    return [tab_index === _vm.active_nav_index ? _c('div', {
       key: tab_index,
       staticClass: "atbdp-cptm-tab-item",
       class: _vm.getActiveClass(tab_index, _vm.active_nav_index)
     }, [_c(tab.type, _vm._b({
       tag: "component",
       on: {
-        save: function save($event) {
-          return _vm.$emit("save", $event);
+        "save": function save($event) {
+          return _vm.$emit('save', $event);
         }
       }
-    }, "component", tab, false))], 1) : _vm._e()];
+    }, 'component', tab, false))], 1) : _vm._e()];
   })], 2);
 };
 var staticRenderFns = [];
@@ -27781,99 +27756,99 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-placeholder-blcok",
     class: _vm.getContainerClass,
     on: {
-      drop: function drop($event) {
+      "drop": function drop($event) {
         $event.preventDefault();
         return _vm.placeholderOnDrop();
       },
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
-        return _vm.$emit("placeholder-dragover-on");
+        return _vm.$emit('placeholder-dragover-on');
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.placeholderOnDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.placeholderOnDragLeave();
       }
     }
-  }, [_c("p", {
+  }, [_c('p', {
     staticClass: "cptm-placeholder-label",
     class: {
       hide: _vm.selectedWidgets && _vm.selectedWidgets.length
     }
-  }, [_vm._v("\n    " + _vm._s(_vm.label) + "\n  ")]), _vm._v(" "), _c("div", {
+  }, [_vm._v("\n    " + _vm._s(_vm.label) + "\n  ")]), _vm._v(" "), _c('div', {
     staticClass: "cptm-widget-insert-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-insert-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-insert-modal-container"
-  }, [_c("widgets-window", {
+  }, [_c('widgets-window', {
     attrs: {
-      id: _vm.id,
-      availableWidgets: _vm.availableWidgets,
-      acceptedWidgets: _vm.acceptedWidgets,
-      rejectedWidgets: _vm.rejectedWidgets,
-      activeWidgets: _vm.activeWidgets,
-      selectedWidgets: _vm.selectedWidgets,
-      active: _vm.showWidgetsPickerWindow,
-      maxWidget: _vm.maxWidget,
-      maxWidgetInfoText: _vm.maxWidgetInfoText,
-      bottomAchhor: true
+      "id": _vm.id,
+      "availableWidgets": _vm.availableWidgets,
+      "acceptedWidgets": _vm.acceptedWidgets,
+      "rejectedWidgets": _vm.rejectedWidgets,
+      "activeWidgets": _vm.activeWidgets,
+      "selectedWidgets": _vm.selectedWidgets,
+      "active": _vm.showWidgetsPickerWindow,
+      "maxWidget": _vm.maxWidget,
+      "maxWidgetInfoText": _vm.maxWidgetInfoText,
+      "bottomAchhor": true
     },
     on: {
       "widget-selection": function widgetSelection($event) {
-        return _vm.$emit("insert-widget", $event);
+        return _vm.$emit('insert-widget', $event);
       },
-      close: function close($event) {
-        return _vm.$emit("close-widgets-picker-window");
+      "close": function close($event) {
+        return _vm.$emit('close-widgets-picker-window');
       }
     }
-  })], 1), _vm._v(" "), _vm.canAddMore ? _c("a", {
+  })], 1), _vm._v(" "), _vm.canAddMore ? _c('a', {
     staticClass: "cptm-widget-insert-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("open-widgets-picker-window");
+        return _vm.$emit('open-widgets-picker-window');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-plus"
-  })]) : _vm._e()])]), _vm._v(" "), _vm.selectedWidgets && _vm.selectedWidgets.length ? _c("div", {
+  })]) : _vm._e()])]), _vm._v(" "), _vm.selectedWidgets && _vm.selectedWidgets.length ? _c('div', {
     staticClass: "cptm-widget-preview-area"
   }, [_vm._l(_vm.selectedWidgets, function (widget, widget_index) {
-    return [_vm.hasValidWidget(widget) ? [_c(_vm.activeWidgets[widget].type + "-card-widget", {
+    return [_vm.hasValidWidget(widget) ? [_c(_vm.activeWidgets[widget].type + '-card-widget', {
       key: widget_index,
       tag: "component",
       attrs: {
-        label: typeof _vm.availableWidgets[widget] !== "undefined" ? _vm.availableWidgets[widget].label : "Not Available",
-        icon: typeof _vm.activeWidgets[widget].icon === "string" ? _vm.activeWidgets[widget].icon : "",
-        options: _vm.activeWidgets[widget].options,
-        widgetDropable: _vm.widgetDropable,
-        canMove: _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.activeWidgets[widget].can_move) !== undefined ? _vm.activeWidgets[widget].can_move : true,
-        canEdit: _vm.widgetHasOptions(_vm.activeWidgets[widget])
+        "label": typeof _vm.availableWidgets[widget] !== 'undefined' ? _vm.availableWidgets[widget].label : 'Not Available',
+        "icon": typeof _vm.activeWidgets[widget].icon === 'string' ? _vm.activeWidgets[widget].icon : '',
+        "options": _vm.activeWidgets[widget].options,
+        "widgetDropable": _vm.widgetDropable,
+        "canMove": _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.activeWidgets[widget].can_move) !== undefined ? _vm.activeWidgets[widget].can_move : true,
+        "canEdit": _vm.widgetHasOptions(_vm.activeWidgets[widget])
       },
       on: {
-        drag: function drag($event) {
-          return _vm.$emit("drag-widget", widget);
+        "drag": function drag($event) {
+          return _vm.$emit('drag-widget', widget);
         },
-        drop: function drop($event) {
-          return _vm.$emit("drop-widget", widget);
+        "drop": function drop($event) {
+          return _vm.$emit('drop-widget', widget);
         },
-        dragend: function dragend($event) {
-          return _vm.$emit("dragend-widget", widget);
+        "dragend": function dragend($event) {
+          return _vm.$emit('dragend-widget', widget);
         },
-        edit: function edit($event) {
-          return _vm.$emit("edit-widget", widget);
+        "edit": function edit($event) {
+          return _vm.$emit('edit-widget', widget);
         },
-        trash: function trash($event) {
-          return _vm.$emit("trash-widget", widget);
+        "trash": function trash($event) {
+          return _vm.$emit('trash-widget', widget);
         }
       }
     })] : _vm._e()];
@@ -27899,78 +27874,78 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.show ? _c("div", {
+  return _vm.show ? _c('div', {
     staticClass: "cptm-modal-container cptm-toggle-modal active"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-modal-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-modal"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-modal-content"
-  }, [_vm.showModelHeader ? _c("div", {
+  }, [_vm.showModelHeader ? _c('div', {
     staticClass: "cptm-modal-header"
-  }, [_c("h3", {
+  }, [_c('h3', {
     staticClass: "cptm-modal-header-title",
     domProps: {
-      innerHTML: _vm._s(_vm.modelHeaderText)
+      "innerHTML": _vm._s(_vm.modelHeaderText)
     }
-  }), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {
     staticClass: "cptm-modal-actions"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-modal-action-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.cancel();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-times"
-  })])])]) : _vm._e(), _vm._v(" "), _c("div", {
+  })])])]) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-modal-body cptm-center-content cptm-content-wide"
-  }, [_c("form", {
+  }, [_c('form', {
     staticClass: "cptm-import-directory-form",
     attrs: {
-      action: "#",
-      method: "post"
+      "action": "#",
+      "method": "post"
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-group-feedback cptm-text-center cptm-mb-10"
-  }), _vm._v(" "), _c("h2", {
+  }), _vm._v(" "), _c('h2', {
     staticClass: "cptm-modal-confirmation-title",
     domProps: {
-      innerHTML: _vm._s(_vm.confirmationText)
+      "innerHTML": _vm._s(_vm.confirmationText)
     }
-  }), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {
     staticClass: "cptm-file-input-wrap"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-rounded",
     class: _vm.cancelButtonClass,
     attrs: {
-      type: "button"
+      "type": "button"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.cancelButtonLabel)
+      "innerHTML": _vm._s(_vm.cancelButtonLabel)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.cancel();
       }
     }
-  }), _vm._v(" "), _c("button", {
+  }), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-btn-rounded",
     class: _vm.confirmButtonClass,
     attrs: {
-      type: "button"
+      "type": "button"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.confirmButtonLabel)
+      "innerHTML": _vm._s(_vm.confirmButtonLabel)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.confirm();
       }
     }
@@ -27996,95 +27971,95 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     ref: "dropable_element",
     staticClass: "cptm-dropable-element",
     class: _vm.parentClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-dropable-placeholder cptm-dropable-placeholder-before",
     class: _vm.dropablePlaceholderBeforeClass
-  }), _vm._v(" "), _c("div", {}, [_vm._t("default")], 2), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {}, [_vm._t("default")], 2), _vm._v(" "), _c('div', {
     staticClass: "cptm-dropable-placeholder cptm-dropable-placeholder-after",
     class: _vm.dropablePlaceholderAfterClass
-  }), _vm._v(" "), _vm.dropable ? _c("div", {
+  }), _vm._v(" "), _vm.dropable ? _c('div', {
     staticClass: "cptm-dropable-area"
-  }, [_vm.dropInside ? _c("span", {
+  }, [_vm.dropInside ? _c('span', {
     staticClass: "cptm-dropable-area-inside",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_inside = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_inside = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedInside();
       }
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === "horizontal" ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === 'horizontal' ? _c('span', {
     staticClass: "cptm-dropable-area-left",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_left = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_left = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedBefore();
       }
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === "horizontal" ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === 'horizontal' ? _c('span', {
     staticClass: "cptm-dropable-area-right",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_right = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_right = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedAfter();
       }
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === "vertical" ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === 'vertical' ? _c('span', {
     staticClass: "cptm-dropable-area-top",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_top = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_top = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedBefore();
       }
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === "vertical" ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === 'vertical' ? _c('span', {
     staticClass: "cptm-dropable-area-bottom",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_bottom = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_bottom = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedAfter();
       }
     }
@@ -28113,30 +28088,30 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.field_list && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.field_list) === "object" ? _c("div", {
+  return _vm.field_list && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.field_list) === 'object' ? _c('div', {
     staticClass: "directorist-form-fields-area"
   }, [_vm._l(_vm.visibleFields, function (field, field_key) {
-    return field.type ? _c(field.type + "-field", _vm._b({
+    return field.type ? _c(field.type + '-field', _vm._b({
       key: field_key,
       tag: "component",
       attrs: {
         "section-id": _vm.sectionId,
         "field-id": "".concat(_vm.sectionId, "_").concat(field_key),
-        root: _vm.field_list
+        "root": _vm.field_list
       },
       on: {
-        update: function update($event) {
+        "update": function update($event) {
           return _vm.update({
             key: field_key,
             value: $event
           });
         }
       }
-    }, "component", _vm.excludeShowIfCondition(field), false)) : _vm._e();
-  }), _vm._v(" "), _vm.hasAdvancedFields ? _c("button", {
+    }, 'component', _vm.excludeShowIfCondition(field), false)) : _vm._e();
+  }), _vm._v(" "), _vm.hasAdvancedFields ? _c('button', {
     staticClass: "cptm-form-builder-group-options__advanced-toggle",
     on: {
-      click: _vm.toggleAdvanced
+      "click": _vm.toggleAdvanced
     }
   }, [_vm._v("\n    " + _vm._s(_vm.showAdvanced ? "Basic" : "Advanced") + "\n  ")]) : _vm._e()], 2) : _vm._e();
 };
@@ -28160,15 +28135,15 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.validationMessages ? _c("div", {
+  return _vm.validationMessages ? _c('div', {
     staticClass: "cptm-form-group-feedback"
   }, _vm._l(Object.values(_vm.validationMessages), function (alert, alert_key) {
-    return _c("div", {
+    return _c('div', {
       key: alert_key,
       staticClass: "cptm-form-alert",
-      class: "cptm-" + (alert.type ? alert.type : ""),
+      class: 'cptm-' + (alert.type ? alert.type : ''),
       domProps: {
-        innerHTML: _vm._s(alert.message ? alert.message : "")
+        "innerHTML": _vm._s(alert.message ? alert.message : '')
       }
     });
   }), 0) : _vm._e();
@@ -28193,43 +28168,43 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-option-card",
     class: _vm.mainWrapperClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-option-card-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-option-card-header-title-section"
-  }, [_c("h3", {
+  }, [_c('h3', {
     staticClass: "cptm-option-card-header-title"
-  }, [_vm._v(_vm._s(_vm.title))]), _vm._v(" "), _c("div", {
+  }, [_vm._v(_vm._s(_vm.title))]), _vm._v(" "), _c('div', {
     staticClass: "cptm-header-action-area"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-header-action-link cptm-header-action-close",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("close");
+        return _vm.$emit('close');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-times"
-  })])])])]), _vm._v(" "), _c("div", {
+  })])])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-option-card-body"
   }, [_vm.local_fields ? _vm._l(_vm.local_fields, function (field, field_key) {
-    return _c(field.type + "-field", _vm._b({
+    return _c(field.type + '-field', _vm._b({
       key: field_key,
       tag: "component",
       on: {
-        update: function update($event) {
+        "update": function update($event) {
           return _vm.updateFieldData($event, field_key);
         }
       }
-    }, "component", field, false));
-  }) : _vm._e()], 2), _vm._v(" "), _vm.bottomAchhor ? _c("span", {
+    }, 'component', field, false));
+  }) : _vm._e()], 2), _vm._v(" "), _vm.bottomAchhor ? _c('span', {
     staticClass: "cptm-anchor-down"
   }) : _vm._e()]);
 };
@@ -28256,144 +28231,144 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-tab-content",
     class: _vm.containerClass
   }, [_vm._l(_vm.sections, function (section, section_key) {
-    return _c("div", {
+    return _c('div', {
       key: section_key,
       staticClass: "cptm-section",
       class: _vm.sectionClass(section)
-    }, [["submission_form_fields", "search_form_fields", "single_listing_header", "single_listings_contents", "listings_card_grid_view", "listings_card_list_view"].includes(section.fields[0]) ? _c("div", {
+    }, [['submission_form_fields', 'search_form_fields', 'single_listing_header', 'single_listings_contents', 'listings_card_grid_view', 'listings_card_list_view'].includes(section.fields[0]) ? _c('div', {
       staticClass: "directorist-form-doc"
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "directorist-form-doc-left"
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "directorist-form-doc-title",
       domProps: {
-        innerHTML: _vm._s(section.title)
+        "innerHTML": _vm._s(section.title)
       }
-    }), _vm._v(" "), _vm.video && ["submission_form_fields", "search_form_fields"].includes(section.fields[0]) ? _c("a", {
+    }), _vm._v(" "), _vm.video && ['submission_form_fields', 'search_form_fields'].includes(section.fields[0]) ? _c('a', {
       staticClass: "directorist-form-doc__watch-tutorial",
       attrs: {
-        href: "#"
+        "href": "#"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.openVideoPopup.apply(null, arguments);
         }
       }
-    }, [_c("svg", {
+    }, [_c('svg', {
       attrs: {
-        xmlns: "http://www.w3.org/2000/svg",
-        width: "14",
-        height: "14",
-        viewBox: "0 0 14 14",
-        fill: "none"
+        "xmlns": "http://www.w3.org/2000/svg",
+        "width": "14",
+        "height": "14",
+        "viewBox": "0 0 14 14",
+        "fill": "none"
       }
-    }, [_c("path", {
+    }, [_c('path', {
       attrs: {
         "fill-rule": "evenodd",
         "clip-rule": "evenodd",
-        d: "M3.94256 2.33333H7.14074C7.6103 2.33332 7.99785 2.33331 8.31355 2.35911C8.64143 2.3859 8.94285 2.44339 9.22596 2.58765C9.665 2.81135 10.022 3.16831 10.2457 3.60735C10.3899 3.89046 10.4474 4.19187 10.4742 4.51976C10.4981 4.81257 10.4999 5.16718 10.5 5.59171L11.6396 4.45212C11.7511 4.34058 11.8607 4.23096 11.9567 4.15052C12.0424 4.07876 12.223 3.93485 12.473 3.91517C12.7522 3.8932 13.0251 4.00622 13.207 4.21921C13.3699 4.40993 13.3958 4.63932 13.4056 4.75068C13.4167 4.87549 13.4167 5.03051 13.4166 5.18822V8.81177C13.4167 8.96948 13.4167 9.1245 13.4056 9.24931C13.3958 9.36067 13.3699 9.59006 13.207 9.78078C13.0251 9.99377 12.7522 10.1068 12.473 10.0848C12.223 10.0651 12.0424 9.92123 11.9567 9.84947C11.8607 9.76904 11.7511 9.65941 11.6396 9.54787L10.5 8.40828C10.4999 8.83281 10.4981 9.18742 10.4742 9.48023C10.4474 9.80812 10.3899 10.1095 10.2457 10.3926C10.022 10.8317 9.665 11.1886 9.22596 11.4123C8.94285 11.5566 8.64144 11.6141 8.31355 11.6409C7.99784 11.6667 7.6103 11.6667 7.14072 11.6667H3.94257C3.473 11.6667 3.08545 11.6667 2.76975 11.6409C2.44186 11.6141 2.14045 11.5566 1.85734 11.4123C1.41829 11.1886 1.06134 10.8317 0.837632 10.3926C0.693379 10.1095 0.635883 9.80812 0.609093 9.48023C0.5833 9.16453 0.583306 8.77699 0.583313 8.30742V5.69257C0.583306 5.22301 0.5833 4.83546 0.609093 4.51976C0.635883 4.19187 0.693379 3.89046 0.837632 3.60735C1.06134 3.16831 1.41829 2.81135 1.85734 2.58765C2.14045 2.44339 2.44186 2.3859 2.76975 2.35911C3.08545 2.33331 3.47299 2.33332 3.94256 2.33333ZM9.33331 5.71666C9.33331 5.21699 9.33286 4.87732 9.31141 4.61477C9.29051 4.35903 9.25264 4.22824 9.20615 4.13701C9.0943 3.91748 8.91582 3.73901 8.6963 3.62715C8.60507 3.58067 8.47428 3.5428 8.21854 3.5219C7.95599 3.50045 7.61632 3.5 7.11665 3.5H3.96665C3.46698 3.5 3.1273 3.50045 2.86475 3.5219C2.60901 3.5428 2.47822 3.58067 2.38699 3.62715C2.16747 3.73901 1.98899 3.91748 1.87714 4.13701C1.83065 4.22824 1.79278 4.35903 1.77189 4.61477C1.75043 4.87732 1.74998 5.21699 1.74998 5.71666V8.28333C1.74998 8.783 1.75043 9.12267 1.77189 9.38522C1.79278 9.64097 1.83065 9.77175 1.87714 9.86298C1.98899 10.0825 2.16747 10.261 2.38699 10.3728C2.47822 10.4193 2.60901 10.4572 2.86475 10.4781C3.1273 10.4995 3.46698 10.5 3.96665 10.5H7.11665C7.61632 10.5 7.95599 10.4995 8.21854 10.4781C8.47428 10.4572 8.60507 10.4193 8.6963 10.3728C8.91582 10.261 9.0943 10.0825 9.20615 9.86298C9.25264 9.77175 9.29051 9.64097 9.31141 9.38522C9.33286 9.12267 9.33331 8.783 9.33331 8.28333V5.71666ZM10.7416 7L12.25 8.50837V5.49162L10.7416 7Z",
-        fill: "currentColor"
+        "d": "M3.94256 2.33333H7.14074C7.6103 2.33332 7.99785 2.33331 8.31355 2.35911C8.64143 2.3859 8.94285 2.44339 9.22596 2.58765C9.665 2.81135 10.022 3.16831 10.2457 3.60735C10.3899 3.89046 10.4474 4.19187 10.4742 4.51976C10.4981 4.81257 10.4999 5.16718 10.5 5.59171L11.6396 4.45212C11.7511 4.34058 11.8607 4.23096 11.9567 4.15052C12.0424 4.07876 12.223 3.93485 12.473 3.91517C12.7522 3.8932 13.0251 4.00622 13.207 4.21921C13.3699 4.40993 13.3958 4.63932 13.4056 4.75068C13.4167 4.87549 13.4167 5.03051 13.4166 5.18822V8.81177C13.4167 8.96948 13.4167 9.1245 13.4056 9.24931C13.3958 9.36067 13.3699 9.59006 13.207 9.78078C13.0251 9.99377 12.7522 10.1068 12.473 10.0848C12.223 10.0651 12.0424 9.92123 11.9567 9.84947C11.8607 9.76904 11.7511 9.65941 11.6396 9.54787L10.5 8.40828C10.4999 8.83281 10.4981 9.18742 10.4742 9.48023C10.4474 9.80812 10.3899 10.1095 10.2457 10.3926C10.022 10.8317 9.665 11.1886 9.22596 11.4123C8.94285 11.5566 8.64144 11.6141 8.31355 11.6409C7.99784 11.6667 7.6103 11.6667 7.14072 11.6667H3.94257C3.473 11.6667 3.08545 11.6667 2.76975 11.6409C2.44186 11.6141 2.14045 11.5566 1.85734 11.4123C1.41829 11.1886 1.06134 10.8317 0.837632 10.3926C0.693379 10.1095 0.635883 9.80812 0.609093 9.48023C0.5833 9.16453 0.583306 8.77699 0.583313 8.30742V5.69257C0.583306 5.22301 0.5833 4.83546 0.609093 4.51976C0.635883 4.19187 0.693379 3.89046 0.837632 3.60735C1.06134 3.16831 1.41829 2.81135 1.85734 2.58765C2.14045 2.44339 2.44186 2.3859 2.76975 2.35911C3.08545 2.33331 3.47299 2.33332 3.94256 2.33333ZM9.33331 5.71666C9.33331 5.21699 9.33286 4.87732 9.31141 4.61477C9.29051 4.35903 9.25264 4.22824 9.20615 4.13701C9.0943 3.91748 8.91582 3.73901 8.6963 3.62715C8.60507 3.58067 8.47428 3.5428 8.21854 3.5219C7.95599 3.50045 7.61632 3.5 7.11665 3.5H3.96665C3.46698 3.5 3.1273 3.50045 2.86475 3.5219C2.60901 3.5428 2.47822 3.58067 2.38699 3.62715C2.16747 3.73901 1.98899 3.91748 1.87714 4.13701C1.83065 4.22824 1.79278 4.35903 1.77189 4.61477C1.75043 4.87732 1.74998 5.21699 1.74998 5.71666V8.28333C1.74998 8.783 1.75043 9.12267 1.77189 9.38522C1.79278 9.64097 1.83065 9.77175 1.87714 9.86298C1.98899 10.0825 2.16747 10.261 2.38699 10.3728C2.47822 10.4193 2.60901 10.4572 2.86475 10.4781C3.1273 10.4995 3.46698 10.5 3.96665 10.5H7.11665C7.61632 10.5 7.95599 10.4995 8.21854 10.4781C8.47428 10.4572 8.60507 10.4193 8.6963 10.3728C8.91582 10.261 9.0943 10.0825 9.20615 9.86298C9.25264 9.77175 9.29051 9.64097 9.31141 9.38522C9.33286 9.12267 9.33331 8.783 9.33331 8.28333V5.71666ZM10.7416 7L12.25 8.50837V5.49162L10.7416 7Z",
+        "fill": "currentColor"
       }
-    })]), _vm._v("\n          " + _vm._s(_vm.video.button_text) + "\n        ")]) : _vm._e(), _vm._v(" "), _vm.learn_more ? _c("a", {
+    })]), _vm._v("\n          " + _vm._s(_vm.video.button_text) + "\n        ")]) : _vm._e(), _vm._v(" "), _vm.learn_more ? _c('a', {
       staticClass: "directorist-form-doc__link",
       attrs: {
-        href: _vm.learn_more.url,
-        target: "_blank"
+        "href": _vm.learn_more.url,
+        "target": "_blank"
       },
       domProps: {
-        innerHTML: _vm._s(_vm.learn_more.title)
+        "innerHTML": _vm._s(_vm.learn_more.title)
       }
-    }) : _vm._e()]), _vm._v(" "), section.fields[0] === "submission_form_fields" ? _c("div", {
+    }) : _vm._e()]), _vm._v(" "), section.fields[0] === 'submission_form_fields' ? _c('div', {
       staticClass: "directorist-form-doc-right"
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "directorist-form-doc__preview",
       attrs: {
-        href: "#",
-        target: "_blank"
+        "href": "#",
+        "target": "_blank"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           return _vm.saveData();
         }
       }
-    }, [_c("svg", {
+    }, [_c('svg', {
       attrs: {
-        xmlns: "http://www.w3.org/2000/svg",
-        width: "16",
-        height: "16",
-        viewBox: "0 0 16 16",
-        fill: "none"
+        "xmlns": "http://www.w3.org/2000/svg",
+        "width": "16",
+        "height": "16",
+        "viewBox": "0 0 16 16",
+        "fill": "none"
       }
-    }, [_c("path", {
+    }, [_c('path', {
       attrs: {
         "fill-rule": "evenodd",
         "clip-rule": "evenodd",
-        d: "M5.33749 1.86822C5.34546 1.87353 5.35345 1.87886 5.36147 1.88421L12.394 6.57255C12.5975 6.70817 12.7861 6.83392 12.931 6.95077C13.0822 7.07273 13.2605 7.24185 13.3631 7.48925C13.4987 7.81625 13.4987 8.18376 13.3631 8.51077C13.2605 8.75817 13.0822 8.92729 12.931 9.04924C12.7861 9.1661 12.5975 9.29184 12.394 9.42746L5.33751 14.1318C5.08879 14.2976 4.86513 14.4468 4.67535 14.5496C4.48544 14.6525 4.22477 14.7701 3.92052 14.752C3.53135 14.7287 3.17185 14.5363 2.93665 14.2254C2.75276 13.9823 2.70602 13.7002 2.68631 13.4851C2.66662 13.2701 2.66664 13.0014 2.66666 12.7024L2.66666 3.32643C2.66666 3.31679 2.66666 3.30718 2.66666 3.2976C2.66664 2.99867 2.66662 2.72987 2.68631 2.51492C2.70602 2.29982 2.75276 2.01769 2.93665 1.77461C3.17185 1.46369 3.53135 1.27129 3.92052 1.24806C4.22477 1.22989 4.48545 1.3475 4.67536 1.45042C4.86513 1.55326 5.08878 1.70238 5.33749 1.86822ZM4.01674 2.61031C4.01584 2.61839 4.01495 2.62713 4.01409 2.63658C4.00066 2.78307 3.99999 2.98946 3.99999 3.32643V12.6736C3.99999 13.0106 4.00066 13.2169 4.01409 13.3634C4.01495 13.3729 4.01584 13.3816 4.01674 13.3897C4.02396 13.386 4.03173 13.3819 4.04007 13.3773C4.1694 13.3073 4.3415 13.1933 4.62187 13.0064L11.6322 8.33283C11.8655 8.17735 12.0022 8.08542 12.094 8.01137C12.099 8.00736 12.1036 8.00357 12.1079 8.00001C12.1036 7.99644 12.099 7.99265 12.094 7.98864C12.0022 7.9146 11.8655 7.82267 11.6322 7.66719L4.62187 2.99361C4.3415 2.80669 4.1694 2.69277 4.04007 2.62267C4.03173 2.61815 4.02396 2.61405 4.01674 2.61031Z",
-        fill: "currentColor"
+        "d": "M5.33749 1.86822C5.34546 1.87353 5.35345 1.87886 5.36147 1.88421L12.394 6.57255C12.5975 6.70817 12.7861 6.83392 12.931 6.95077C13.0822 7.07273 13.2605 7.24185 13.3631 7.48925C13.4987 7.81625 13.4987 8.18376 13.3631 8.51077C13.2605 8.75817 13.0822 8.92729 12.931 9.04924C12.7861 9.1661 12.5975 9.29184 12.394 9.42746L5.33751 14.1318C5.08879 14.2976 4.86513 14.4468 4.67535 14.5496C4.48544 14.6525 4.22477 14.7701 3.92052 14.752C3.53135 14.7287 3.17185 14.5363 2.93665 14.2254C2.75276 13.9823 2.70602 13.7002 2.68631 13.4851C2.66662 13.2701 2.66664 13.0014 2.66666 12.7024L2.66666 3.32643C2.66666 3.31679 2.66666 3.30718 2.66666 3.2976C2.66664 2.99867 2.66662 2.72987 2.68631 2.51492C2.70602 2.29982 2.75276 2.01769 2.93665 1.77461C3.17185 1.46369 3.53135 1.27129 3.92052 1.24806C4.22477 1.22989 4.48545 1.3475 4.67536 1.45042C4.86513 1.55326 5.08878 1.70238 5.33749 1.86822ZM4.01674 2.61031C4.01584 2.61839 4.01495 2.62713 4.01409 2.63658C4.00066 2.78307 3.99999 2.98946 3.99999 3.32643V12.6736C3.99999 13.0106 4.00066 13.2169 4.01409 13.3634C4.01495 13.3729 4.01584 13.3816 4.01674 13.3897C4.02396 13.386 4.03173 13.3819 4.04007 13.3773C4.1694 13.3073 4.3415 13.1933 4.62187 13.0064L11.6322 8.33283C11.8655 8.17735 12.0022 8.08542 12.094 8.01137C12.099 8.00736 12.1036 8.00357 12.1079 8.00001C12.1036 7.99644 12.099 7.99265 12.094 7.98864C12.0022 7.9146 11.8655 7.82267 11.6322 7.66719L4.62187 2.99361C4.3415 2.80669 4.1694 2.69277 4.04007 2.62267C4.03173 2.61815 4.02396 2.61405 4.01674 2.61031Z",
+        "fill": "currentColor"
       }
-    })]), _vm._v("\n          preview\n        ")])]) : _vm._e()]) : _vm._e(), _vm._v(" "), section.fields[0] !== "submission_form_fields" && section.fields[0] !== "search_form_fields" && section.fields[0] !== "single_listing_header" && section.fields[0] !== "single_listing_header" && section.fields[0] !== "single_listings_contents" && section.fields[0] !== "listings_card_grid_view" && section.fields[0] !== "listings_card_list_view" ? _c("div", {
+    })]), _vm._v("\n          preview\n        ")])]) : _vm._e()]) : _vm._e(), _vm._v(" "), section.fields[0] !== 'submission_form_fields' && section.fields[0] !== 'search_form_fields' && section.fields[0] !== 'single_listing_header' && section.fields[0] !== 'single_listing_header' && section.fields[0] !== 'single_listings_contents' && section.fields[0] !== 'listings_card_grid_view' && section.fields[0] !== 'listings_card_list_view' ? _c('div', {
       staticClass: "cptm-title-area",
       class: _vm.sectionTitleAreaClass(section)
-    }, [section.title ? _c("h3", {
+    }, [section.title ? _c('h3', {
       staticClass: "cptm-title",
       domProps: {
-        innerHTML: _vm._s(section.title)
+        "innerHTML": _vm._s(section.title)
       }
-    }) : _vm._e(), _vm._v(" "), section.description ? _c("div", {
+    }) : _vm._e(), _vm._v(" "), section.description ? _c('div', {
       staticClass: "cptm-des",
       domProps: {
-        innerHTML: _vm._s(section.description)
+        "innerHTML": _vm._s(section.description)
       }
-    }) : _vm._e()]) : _vm._e(), _vm._v(" "), _vm.sectionFields(section) ? _c("div", {
+    }) : _vm._e()]) : _vm._e(), _vm._v(" "), _vm.sectionFields(section) ? _c('div', {
       staticClass: "cptm-form-fields"
     }, _vm._l(_vm.sectionFields(section), function (field, field_key) {
-      return _vm.fields[field].group !== "container" ? _c("div", {
+      return _vm.fields[field].group !== 'container' ? _c('div', {
         key: field_key
       }, [_vm.fields[field] ? _c(_vm.getFormFieldName(_vm.fields[field].type), _vm._b({
         ref: field,
         refInFor: true,
         tag: "component",
-        class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "highlight-field", _vm.getHighlightState(field)),
+        class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, 'highlight-field', _vm.getHighlightState(field)),
         attrs: {
           "field-id": field_key,
-          fieldKey: field,
-          id: _vm.menuKey + "__" + section_key + "__" + field,
+          "fieldKey": field,
+          "id": _vm.menuKey + '__' + section_key + '__' + field,
           "cached-data": _vm.cached_fields[field],
-          listing_type_id: _vm.listing_type_id
+          "listing_type_id": _vm.listing_type_id
         },
         on: {
-          update: function update($event) {
+          "update": function update($event) {
             return _vm.updateFieldValue(field, $event);
           },
-          save: function save($event) {
-            return _vm.$emit("save", $event);
+          "save": function save($event) {
+            return _vm.$emit('save', $event);
           },
-          validate: function validate($event) {
+          "validate": function validate($event) {
             return _vm.updateFieldValidationState(field, $event);
           },
           "is-visible": function isVisible($event) {
-            return _vm.updateFieldData(field, "isVisible", $event);
+            return _vm.updateFieldData(field, 'isVisible', $event);
           },
           "do-action": function doAction($event) {
-            return _vm.doAction($event, "sections-module");
+            return _vm.doAction($event, 'sections-module');
           }
         }
-      }, "component", _vm.fields[field], false)) : _vm._e(), _vm._v(" "), field === "way_to_show_preview" && _vm.groupedContainerFields.length > 0 ? _c("div", {
+      }, 'component', _vm.fields[field], false)) : _vm._e(), _vm._v(" "), field === 'way_to_show_preview' && _vm.groupedContainerFields.length > 0 ? _c('div', {
         staticClass: "cptm-field-group-container"
-      }, [_c("div", {
+      }, [_c('div', {
         staticClass: "atbdp-row"
-      }, [_c("div", {
+      }, [_c('div', {
         staticClass: "atbdp-col atbdp-col-4"
-      }, [_c("label", {
+      }, [_c('label', {
         staticClass: "cptm-field-group-container__label"
-      }, [_c("span", [_vm._v(_vm._s(_vm.containerGroupLabel))])])]), _vm._v(" "), _c("div", {
+      }, [_c('span', [_vm._v(_vm._s(_vm.containerGroupLabel))])])]), _vm._v(" "), _c('div', {
         staticClass: "atbdp-col atbdp-col-8"
-      }, [_c("div", {
+      }, [_c('div', {
         staticClass: "cptm-container-group-fields"
       }, _vm._l(_vm.groupedContainerFields, function (groupedField, groupedFieldKey) {
         return _c(_vm.getFormFieldName(_vm.fields[groupedField].type), _vm._b({
@@ -28401,36 +28376,36 @@ var render = function render() {
           ref: groupedField,
           refInFor: true,
           tag: "component",
-          class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "highlight-field", _vm.getHighlightState(groupedField)),
+          class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, 'highlight-field', _vm.getHighlightState(groupedField)),
           attrs: {
             "field-id": groupedFieldKey,
-            id: _vm.menuKey + "__" + section_key + "__" + groupedField,
+            "id": _vm.menuKey + '__' + section_key + '__' + groupedField,
             "cached-data": _vm.cached_fields[groupedField]
           },
           on: {
-            update: function update($event) {
+            "update": function update($event) {
               return _vm.updateFieldValue(groupedField, $event);
             },
-            save: function save($event) {
-              return _vm.$emit("save", $event);
+            "save": function save($event) {
+              return _vm.$emit('save', $event);
             },
-            validate: function validate($event) {
+            "validate": function validate($event) {
               return _vm.updateFieldValidationState(groupedField, $event);
             },
             "is-visible": function isVisible($event) {
-              return _vm.updateFieldData(groupedField, "isVisible", $event);
+              return _vm.updateFieldData(groupedField, 'isVisible', $event);
             },
             "do-action": function doAction($event) {
-              return _vm.doAction($event, "sections-module");
+              return _vm.doAction($event, 'sections-module');
             }
           }
-        }, "component", _vm.fields[groupedField], false));
+        }, 'component', _vm.fields[groupedField], false));
       }), 1)])])]) : _vm._e()], 1) : _vm._e();
     }), 0) : _vm._e()]);
-  }), _vm._v(" "), _vm.video ? _c("form-builder-widget-video-component", {
+  }), _vm._v(" "), _vm.video ? _c('form-builder-widget-video-component', {
     attrs: {
-      videoOpened: _vm.showVideo,
-      video: _vm.video
+      "videoOpened": _vm.showVideo,
+      "video": _vm.video
     },
     on: {
       "close-video": _vm.closeVideoPopup
@@ -28460,50 +28435,50 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "setting-left-sibebar"
-  }, [_c("ul", {
+  }, [_c('ul', {
     staticClass: "settings-nav"
   }, _vm._l(_vm.menu, function (meue_item, menu_key) {
-    return _c("li", {
+    return _c('li', {
       key: menu_key,
       staticClass: "settings-nav__item",
       class: {
         active: meue_item.active
       }
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "settings-nav__item__link",
-      class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "nav-has-dropdwon", meue_item.submenu),
+      class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, 'nav-has-dropdwon', meue_item.submenu),
       attrs: {
-        href: "#"
+        "href": "#"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.swichToNav({
             menu_key: menu_key
           }, $event);
         }
       }
-    }, [meue_item.icon ? _c("span", {
+    }, [meue_item.icon ? _c('span', {
       staticClass: "settings-nav__item__icon",
       domProps: {
-        innerHTML: _vm._s(meue_item.icon)
+        "innerHTML": _vm._s(meue_item.icon)
       }
-    }) : _vm._e(), _vm._v(" \n        " + _vm._s(meue_item.label) + " "), meue_item.submenu ? _c("span", {
+    }) : _vm._e(), _vm._v(" \n        " + _vm._s(meue_item.label) + " "), meue_item.submenu ? _c('span', {
       staticClass: "drop-toggle-caret"
-    }) : _vm._e()]), _vm._v(" "), meue_item.submenu ? _c("ul", _vm._l(meue_item.submenu, function (submeue_item, submenu_key) {
-      return _c("li", {
+    }) : _vm._e()]), _vm._v(" "), meue_item.submenu ? _c('ul', _vm._l(meue_item.submenu, function (submeue_item, submenu_key) {
+      return _c('li', {
         key: submenu_key
-      }, [_c("a", {
+      }, [_c('a', {
         class: {
           active: submeue_item.active
         },
         attrs: {
-          href: "#"
+          "href": "#"
         },
         on: {
-          click: function click($event) {
+          "click": function click($event) {
             $event.preventDefault();
             return _vm.swichToNav({
               menu_key: menu_key,
@@ -28511,10 +28486,10 @@ var render = function render() {
             }, $event);
           }
         }
-      }, [submeue_item.icon ? _c("span", {
+      }, [submeue_item.icon ? _c('span', {
         staticClass: "settings-nav__item__icon",
         domProps: {
-          innerHTML: _vm._s(submeue_item.icon)
+          "innerHTML": _vm._s(submeue_item.icon)
         }
       }) : _vm._e(), _vm._v(" \n              " + _vm._s(submeue_item.label) + "\n            ")])]);
     }), 0) : _vm._e()]);
@@ -28540,36 +28515,36 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.option_fields ? _c("div", {
+  return _vm.option_fields ? _c('div', {
     staticClass: "cptm-fields"
   }, _vm._l(Object.keys(_vm.option_fields), function (field_key, field_index) {
-    return _c("div", {
+    return _c('div', {
       key: field_index,
       class: _vm.fieldWrapperClass(field_key, _vm.option_fields[field_key])
-    }, [_c(_vm.option_fields[field_key].type + "-field", _vm._b({
+    }, [_c(_vm.option_fields[field_key].type + '-field', _vm._b({
       key: field_index,
       ref: field_key,
       refInFor: true,
       tag: "component",
       attrs: {
-        root: _vm.option_fields,
+        "root": _vm.option_fields,
         "field-id": field_key
       },
       on: {
-        update: function update($event) {
+        "update": function update($event) {
           return _vm.updateOptionFieldValue(field_key, $event);
         },
-        validate: function validate($event) {
+        "validate": function validate($event) {
           return _vm.updateOptionFieldValidationState(field_key, $event);
         },
         "is-visible": function isVisible($event) {
-          return _vm.updateOptionFieldData(field_key, "isVisible", $event);
+          return _vm.updateOptionFieldData(field_key, 'isVisible', $event);
         },
         "do-action": function doAction($event) {
-          return _vm.doAction($event, "sub-fields");
+          return _vm.doAction($event, 'sub-fields');
         }
       }
-    }, "component", _vm.option_fields[field_key], false))], 1);
+    }, 'component', _vm.option_fields[field_key], false))], 1);
   }), 0) : _vm._e();
 };
 var staticRenderFns = [];
@@ -28592,20 +28567,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("ul", {
+  return _c('ul', {
     staticClass: "cptm-sub-navigation"
   }, _vm._l(_vm.navLists, function (nav, index) {
-    return _c("li", {
+    return _c('li', {
       key: index,
       staticClass: "cptm-sub-nav__item"
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "cptm-sub-nav__item-link",
       class: _vm.getActiveClass(index, _vm.active_nav),
       attrs: {
-        href: "#"
+        "href": "#"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.swichNav(index);
         }
@@ -28633,11 +28608,11 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", [_c("div", {
+  return _c('div', [_c('div', {
     staticClass: "cptm-tab-content-header"
-  }, [_c("sub-navigation", {
+  }, [_c('sub-navigation', {
     attrs: {
-      navLists: _vm.navList
+      "navLists": _vm.navList
     },
     model: {
       value: _vm.active_sub_nav,
@@ -28646,46 +28621,46 @@ var render = function render() {
       },
       expression: "active_sub_nav"
     }
-  }), _vm._v(" "), _vm.currentVideo ? _c("a", {
+  }), _vm._v(" "), _vm.currentVideo ? _c('a', {
     staticClass: "directorist-form-doc__watch-tutorial",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.openVideoPopup.apply(null, arguments);
       }
     }
-  }, [_c("svg", {
+  }, [_c('svg', {
     attrs: {
-      xmlns: "http://www.w3.org/2000/svg",
-      width: "14",
-      height: "14",
-      viewBox: "0 0 14 14",
-      fill: "none"
+      "xmlns": "http://www.w3.org/2000/svg",
+      "width": "14",
+      "height": "14",
+      "viewBox": "0 0 14 14",
+      "fill": "none"
     }
-  }, [_c("path", {
+  }, [_c('path', {
     attrs: {
       "fill-rule": "evenodd",
       "clip-rule": "evenodd",
-      d: "M3.94256 2.33333H7.14074C7.6103 2.33332 7.99785 2.33331 8.31355 2.35911C8.64143 2.3859 8.94285 2.44339 9.22596 2.58765C9.665 2.81135 10.022 3.16831 10.2457 3.60735C10.3899 3.89046 10.4474 4.19187 10.4742 4.51976C10.4981 4.81257 10.4999 5.16718 10.5 5.59171L11.6396 4.45212C11.7511 4.34058 11.8607 4.23096 11.9567 4.15052C12.0424 4.07876 12.223 3.93485 12.473 3.91517C12.7522 3.8932 13.0251 4.00622 13.207 4.21921C13.3699 4.40993 13.3958 4.63932 13.4056 4.75068C13.4167 4.87549 13.4167 5.03051 13.4166 5.18822V8.81177C13.4167 8.96948 13.4167 9.1245 13.4056 9.24931C13.3958 9.36067 13.3699 9.59006 13.207 9.78078C13.0251 9.99377 12.7522 10.1068 12.473 10.0848C12.223 10.0651 12.0424 9.92123 11.9567 9.84947C11.8607 9.76904 11.7511 9.65941 11.6396 9.54787L10.5 8.40828C10.4999 8.83281 10.4981 9.18742 10.4742 9.48023C10.4474 9.80812 10.3899 10.1095 10.2457 10.3926C10.022 10.8317 9.665 11.1886 9.22596 11.4123C8.94285 11.5566 8.64144 11.6141 8.31355 11.6409C7.99784 11.6667 7.6103 11.6667 7.14072 11.6667H3.94257C3.473 11.6667 3.08545 11.6667 2.76975 11.6409C2.44186 11.6141 2.14045 11.5566 1.85734 11.4123C1.41829 11.1886 1.06134 10.8317 0.837632 10.3926C0.693379 10.1095 0.635883 9.80812 0.609093 9.48023C0.5833 9.16453 0.583306 8.77699 0.583313 8.30742V5.69257C0.583306 5.22301 0.5833 4.83546 0.609093 4.51976C0.635883 4.19187 0.693379 3.89046 0.837632 3.60735C1.06134 3.16831 1.41829 2.81135 1.85734 2.58765C2.14045 2.44339 2.44186 2.3859 2.76975 2.35911C3.08545 2.33331 3.47299 2.33332 3.94256 2.33333ZM9.33331 5.71666C9.33331 5.21699 9.33286 4.87732 9.31141 4.61477C9.29051 4.35903 9.25264 4.22824 9.20615 4.13701C9.0943 3.91748 8.91582 3.73901 8.6963 3.62715C8.60507 3.58067 8.47428 3.5428 8.21854 3.5219C7.95599 3.50045 7.61632 3.5 7.11665 3.5H3.96665C3.46698 3.5 3.1273 3.50045 2.86475 3.5219C2.60901 3.5428 2.47822 3.58067 2.38699 3.62715C2.16747 3.73901 1.98899 3.91748 1.87714 4.13701C1.83065 4.22824 1.79278 4.35903 1.77189 4.61477C1.75043 4.87732 1.74998 5.21699 1.74998 5.71666V8.28333C1.74998 8.783 1.75043 9.12267 1.77189 9.38522C1.79278 9.64097 1.83065 9.77175 1.87714 9.86298C1.98899 10.0825 2.16747 10.261 2.38699 10.3728C2.47822 10.4193 2.60901 10.4572 2.86475 10.4781C3.1273 10.4995 3.46698 10.5 3.96665 10.5H7.11665C7.61632 10.5 7.95599 10.4995 8.21854 10.4781C8.47428 10.4572 8.60507 10.4193 8.6963 10.3728C8.91582 10.261 9.0943 10.0825 9.20615 9.86298C9.25264 9.77175 9.29051 9.64097 9.31141 9.38522C9.33286 9.12267 9.33331 8.783 9.33331 8.28333V5.71666ZM10.7416 7L12.25 8.50837V5.49162L10.7416 7Z",
-      fill: "currentColor"
+      "d": "M3.94256 2.33333H7.14074C7.6103 2.33332 7.99785 2.33331 8.31355 2.35911C8.64143 2.3859 8.94285 2.44339 9.22596 2.58765C9.665 2.81135 10.022 3.16831 10.2457 3.60735C10.3899 3.89046 10.4474 4.19187 10.4742 4.51976C10.4981 4.81257 10.4999 5.16718 10.5 5.59171L11.6396 4.45212C11.7511 4.34058 11.8607 4.23096 11.9567 4.15052C12.0424 4.07876 12.223 3.93485 12.473 3.91517C12.7522 3.8932 13.0251 4.00622 13.207 4.21921C13.3699 4.40993 13.3958 4.63932 13.4056 4.75068C13.4167 4.87549 13.4167 5.03051 13.4166 5.18822V8.81177C13.4167 8.96948 13.4167 9.1245 13.4056 9.24931C13.3958 9.36067 13.3699 9.59006 13.207 9.78078C13.0251 9.99377 12.7522 10.1068 12.473 10.0848C12.223 10.0651 12.0424 9.92123 11.9567 9.84947C11.8607 9.76904 11.7511 9.65941 11.6396 9.54787L10.5 8.40828C10.4999 8.83281 10.4981 9.18742 10.4742 9.48023C10.4474 9.80812 10.3899 10.1095 10.2457 10.3926C10.022 10.8317 9.665 11.1886 9.22596 11.4123C8.94285 11.5566 8.64144 11.6141 8.31355 11.6409C7.99784 11.6667 7.6103 11.6667 7.14072 11.6667H3.94257C3.473 11.6667 3.08545 11.6667 2.76975 11.6409C2.44186 11.6141 2.14045 11.5566 1.85734 11.4123C1.41829 11.1886 1.06134 10.8317 0.837632 10.3926C0.693379 10.1095 0.635883 9.80812 0.609093 9.48023C0.5833 9.16453 0.583306 8.77699 0.583313 8.30742V5.69257C0.583306 5.22301 0.5833 4.83546 0.609093 4.51976C0.635883 4.19187 0.693379 3.89046 0.837632 3.60735C1.06134 3.16831 1.41829 2.81135 1.85734 2.58765C2.14045 2.44339 2.44186 2.3859 2.76975 2.35911C3.08545 2.33331 3.47299 2.33332 3.94256 2.33333ZM9.33331 5.71666C9.33331 5.21699 9.33286 4.87732 9.31141 4.61477C9.29051 4.35903 9.25264 4.22824 9.20615 4.13701C9.0943 3.91748 8.91582 3.73901 8.6963 3.62715C8.60507 3.58067 8.47428 3.5428 8.21854 3.5219C7.95599 3.50045 7.61632 3.5 7.11665 3.5H3.96665C3.46698 3.5 3.1273 3.50045 2.86475 3.5219C2.60901 3.5428 2.47822 3.58067 2.38699 3.62715C2.16747 3.73901 1.98899 3.91748 1.87714 4.13701C1.83065 4.22824 1.79278 4.35903 1.77189 4.61477C1.75043 4.87732 1.74998 5.21699 1.74998 5.71666V8.28333C1.74998 8.783 1.75043 9.12267 1.77189 9.38522C1.79278 9.64097 1.83065 9.77175 1.87714 9.86298C1.98899 10.0825 2.16747 10.261 2.38699 10.3728C2.47822 10.4193 2.60901 10.4572 2.86475 10.4781C3.1273 10.4995 3.46698 10.5 3.96665 10.5H7.11665C7.61632 10.5 7.95599 10.4995 8.21854 10.4781C8.47428 10.4572 8.60507 10.4193 8.6963 10.3728C8.91582 10.261 9.0943 10.0825 9.20615 9.86298C9.25264 9.77175 9.29051 9.64097 9.31141 9.38522C9.33286 9.12267 9.33331 8.783 9.33331 8.28333V5.71666ZM10.7416 7L12.25 8.50837V5.49162L10.7416 7Z",
+      "fill": "currentColor"
     }
-  })]), _vm._v("\n            " + _vm._s(_vm.currentVideo.button_text) + "\n        ")]) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  })]), _vm._v("\n            " + _vm._s(_vm.currentVideo.button_text) + "\n        ")]) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-tab-content-body"
   }, [_vm._l(_vm.subNavigation, function (sub_tab, sub_tab_index) {
-    return [(_vm.active_sub_nav === sub_tab_index ? true : false) ? _c("div", {
+    return [(_vm.active_sub_nav === sub_tab_index ? true : false) ? _c('div', {
       key: sub_tab_index,
       staticClass: "cptm-tab-sub-content-item",
       class: {
         active: _vm.active_sub_nav === sub_tab_index ? true : false
       }
-    }, [_c("sections-module", _vm._b({}, "sections-module", sub_tab, false))], 1) : _vm._e()];
-  })], 2), _vm._v(" "), _vm.currentVideo ? _c("form-builder-widget-video-component", {
+    }, [_c('sections-module', _vm._b({}, 'sections-module', sub_tab, false))], 1) : _vm._e()];
+  })], 2), _vm._v(" "), _vm.currentVideo ? _c('form-builder-widget-video-component', {
     attrs: {
-      video: _vm.currentVideo,
-      videoOpened: _vm.showVideo
+      "video": _vm.currentVideo,
+      "videoOpened": _vm.showVideo
     },
     on: {
       "close-video": _vm.closeVideoPopup
@@ -28712,49 +28687,49 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-actions-tools"
-  }, [_vm.canMove ? _c("a", {
+  }, [_vm.canMove ? _c('a', {
     attrs: {
-      href: "#",
-      draggable: "true"
+      "href": "#",
+      "draggable": "true"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
       },
-      drag: function drag($event) {
-        return _vm.$emit("drag");
+      "drag": function drag($event) {
+        return _vm.$emit('drag');
       },
-      dragend: function dragend($event) {
-        return _vm.$emit("dragend");
+      "dragend": function dragend($event) {
+        return _vm.$emit('dragend');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-expand-arrows"
-  })]) : _vm._e(), _vm._v(" "), _vm.canEdit ? _c("a", {
+  })]) : _vm._e(), _vm._v(" "), _vm.canEdit ? _c('a', {
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("edit");
+        return _vm.$emit('edit');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-cog"
-  })]) : _vm._e(), _vm._v(" "), _vm.canTrash ? _c("a", {
+  })]) : _vm._e(), _vm._v(" "), _vm.canTrash ? _c('a', {
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("trash");
+        return _vm.$emit('trash');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-trash-alt"
   })]) : _vm._e()]);
 };
@@ -28778,39 +28753,39 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-control-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-control"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-widget-control-action cptm-widget-control-action-move",
     attrs: {
-      draggable: "true"
+      "draggable": "true"
     },
     on: {
-      drag: function drag($event) {
-        return _vm.$emit("drag");
+      "drag": function drag($event) {
+        return _vm.$emit('drag');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-expand-arrows"
-  })]), _vm._v(" "), _c("span", {
+  })]), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-control-action cptm-widget-control-action-edit",
     on: {
-      click: function click($event) {
-        return _vm.$emit("edit");
+      "click": function click($event) {
+        return _vm.$emit('edit');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-cog"
-  })]), _vm._v(" "), _c("span", {
+  })]), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-control-action cptm-widget-control-action-trash",
     on: {
-      click: function click($event) {
-        return _vm.$emit("trash");
+      "click": function click($event) {
+        return _vm.$emit('trash');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-trash-alt"
   })])])]);
 };
@@ -28834,62 +28809,62 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-option-card",
     class: _vm.mainWrapperClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-option-card-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-option-card-header-title-section"
-  }, [_c("h3", {
+  }, [_c('h3', {
     staticClass: "cptm-option-card-header-title"
-  }, [_vm._v("Insert Element")]), _vm._v(" "), _c("div", {
+  }, [_vm._v("Insert Element")]), _vm._v(" "), _c('div', {
     staticClass: "cptm-header-action-area"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-header-action-link cptm-header-action-close",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("close");
+        return _vm.$emit('close');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-times"
-  })])])])]), _vm._v(" "), _c("div", {
+  })])])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-option-card-body"
-  }, [_vm.infoTexts.length ? _c("div", {
+  }, [_vm.infoTexts.length ? _c('div', {
     staticClass: "cptm-info-text-area"
   }, _vm._l(_vm.infoTexts, function (info, text_key) {
-    return _c("p", {
+    return _c('p', {
       key: text_key,
       staticClass: "cptm-info-text",
-      class: "cptm-" + info.type
+      class: 'cptm-' + info.type
     }, [_vm._v("\n                " + _vm._s(info.text) + "\n            ")]);
-  }), 0) : _vm._e(), _vm._v(" "), Object.keys(_vm.unSelectedWidgetsList).length ? _c("ul", {
+  }), 0) : _vm._e(), _vm._v(" "), Object.keys(_vm.unSelectedWidgetsList).length ? _c('ul', {
     staticClass: "cptm-form-builder-field-list"
   }, _vm._l(_vm.unSelectedWidgetsList, function (widget, widget_key) {
-    return _c("li", {
+    return _c('li', {
       key: widget_key,
       staticClass: "cptm-form-builder-field-list-item",
       class: _vm.widgetListClass(widget_key),
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           return _vm.selectWidget(widget_key);
         }
       }
-    }, [_c("pre", [_vm._v(_vm._s(widget.in_used))]), _vm._v(" "), _c("span", {
+    }, [_c('pre', [_vm._v(_vm._s(widget.in_used))]), _vm._v(" "), _c('span', {
       staticClass: "cptm-form-builder-field-list-icon"
-    }, [_c("span", {
+    }, [_c('span', {
       class: widget.icon
-    })]), _vm._v(" "), _c("span", {
+    })]), _vm._v(" "), _c('span', {
       staticClass: "cptm-form-builder-field-list-label"
     }, [_vm._v("\n                        " + _vm._s(widget.label) + "\n                    ")])]);
-  }), 0) : _c("p", {
+  }), 0) : _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v("Nothing available")])]), _vm._v(" "), _vm.bottomAchhor ? _c("span", {
+  }, [_vm._v("Nothing available")])]), _vm._v(" "), _vm.bottomAchhor ? _c('span', {
     staticClass: "cptm-anchor-down"
   }) : _vm._e()]);
 };
@@ -28913,44 +28888,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._m(0), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._m(0), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28959,12 +28934,12 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("p", {
+  return _c('p', {
     staticClass: "cptm-placeholder-author-thumb"
-  }, [_c("img", {
+  }, [_c('img', {
     attrs: {
-      src: "https://via.placeholder.com/150",
-      alt: ""
+      "src": "https://via.placeholder.com/150",
+      "alt": ""
     }
   })]);
 }];
@@ -28987,44 +28962,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29050,44 +29025,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29113,44 +29088,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29176,44 +29151,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29239,44 +29214,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29302,52 +29277,52 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-block-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-list-item-card cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-list-item"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-list-item-icon"
-  }, [_c("span", {
+  }, [_c('span', {
     class: _vm.listIcon
-  })]), _vm._v(" "), _c("span", {
+  })]), _vm._v(" "), _c('span', {
     staticClass: "cptm-list-item-label"
-  }, [_vm._v(_vm._s(_vm.label))])]), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._v(_vm._s(_vm.label))])]), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29373,44 +29348,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29436,44 +29411,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29499,44 +29474,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29562,44 +29537,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29625,46 +29600,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-block-wrap cptm-widget-title-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-title-card cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-title-block"
-  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29690,46 +29665,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-thumb cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._m(0), _vm._v(" "), _c("div", {
+  }, [_vm._m(0), _vm._v(" "), _c('div', {
     staticClass: "cptm-widget-label"
-  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29738,9 +29713,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-thumb-icon"
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-image-v"
   })]);
 }];
@@ -29763,46 +29738,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-block-wrap cptm-widget-title-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-title-card cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-title-block"
-  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29828,44 +29803,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._m(0), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._m(0), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29874,11 +29849,11 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("span", {
+  return _c('span', {
     staticStyle: {
       "font-size": "16px"
     }
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-eye"
   }), _vm._v("\n            0\n        ")]);
 }];
@@ -29901,32 +29876,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.listType === "div" ? _c("div", {
+  return _vm.listType === 'div' ? _c('div', {
     staticClass: "directorist-draggable-list-item",
     class: _vm.itemClassName,
     style: _vm.listItemStyle,
     attrs: {
-      draggable: _vm.canDrag
+      "draggable": _vm.canDrag
     },
     on: {
-      dragstart: _vm.dragStart,
-      dragend: _vm.dragEnd
+      "dragstart": _vm.dragStart,
+      "dragend": _vm.dragEnd
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-draggable-list-item-slot",
     style: _vm.slotStyle
-  }, [_vm._t("default")], 2)]) : _c("li", {
+  }, [_vm._t("default")], 2)]) : _c('li', {
     staticClass: "directorist-draggable-list-item",
     class: _vm.itemClassName,
     style: _vm.listItemStyle,
     attrs: {
-      draggable: "canDrag"
+      "draggable": "canDrag"
     },
     on: {
-      dragstart: _vm.dragStart,
-      dragend: _vm.dragEnd
+      "dragstart": _vm.dragStart,
+      "dragend": _vm.dragEnd
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-draggable-list-item-slot",
     style: _vm.slotStyle
   }, [_vm._t("default")], 2)]);
@@ -29951,53 +29926,53 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "directorist-draggable-list-item-wrapper",
     style: _vm.wrapperStyle,
     attrs: {
       "data-list-id": _vm.listId
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-droppable-area-wrap",
     class: _vm.className,
     style: {
-      display: _vm.droppable ? "flex" : "none"
+      display: _vm.droppable ? 'flex' : 'none'
     }
-  }, [_vm.droppableBefore ? _c("span", {
+  }, [_vm.droppableBefore ? _c('span', {
     staticClass: "directorist-droppable-area directorist-droppable-area-top",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.dragenterBeforeItem = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.dragenterBeforeItem = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedBefore();
       }
     }
-  }) : _vm._e(), _vm._v(" "), _vm.droppableAfter ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), _vm.droppableAfter ? _c('span', {
     staticClass: "directorist-droppable-area directorist-droppable-area-bottom",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.dragenterAfterItem = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.dragenterAfterItem = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedAfter();
       }
     }
-  }) : _vm._e()]), _vm._v(" "), _vm.dragenterBeforeItem ? _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _vm.dragenterBeforeItem ? _c('div', {
     staticClass: "directorist-droppable-item-preview directorist-droppable-item-preview-before"
-  }) : _vm._e(), _vm._v(" "), _vm._t("default"), _vm._v(" "), _vm.dragenterAfterItem ? _c("div", {
+  }) : _vm._e(), _vm._v(" "), _vm._t("default"), _vm._v(" "), _vm.dragenterAfterItem ? _c('div', {
     staticClass: "directorist-droppable-item-preview directorist-droppable-item-preview-after"
   }) : _vm._e()], 2);
 };
@@ -30021,18 +29996,18 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-group-field-drop-area",
     class: _vm.className,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: _vm.handleDragenter,
-      dragleave: _vm.handleDragleave,
-      drop: _vm.handleDrop
+      "dragenter": _vm.handleDragenter,
+      "dragleave": _vm.handleDragleave,
+      "drop": _vm.handleDrop
     }
-  }, [_c("p", {
+  }, [_c('p', {
     staticClass: "cptm-form-builder-group-field-drop-area-label"
   }, [_vm._v("\n    Add field by dragging it into this area\n  ")])]);
 };
@@ -30056,65 +30031,65 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-preset-fields"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-preset-fields-header"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-form-builder-preset-fields-header-action-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.togglePresetExpanded.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-form-builder-preset-fields-header-action-text"
-  }, [_vm._v("\n        " + _vm._s(_vm.title))]), _vm._v(" "), _c("span", {
+  }, [_vm._v("\n        " + _vm._s(_vm.title))]), _vm._v(" "), _c('span', {
     staticClass: "cptm-form-builder-preset-fields-header-action-icon",
-    class: _vm.isPresetExpanded ? "action-collapse-up" : "action-collapse-down"
-  }, [_c("span", {
+    class: _vm.isPresetExpanded ? 'action-collapse-up' : 'action-collapse-down'
+  }, [_c('span', {
     staticClass: "uil uil-angle-down",
     attrs: {
       "aria-hidden": "true"
     }
-  })])])]), _vm._v(" "), _c("slide-up-down", {
+  })])])]), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.isPresetExpanded,
-      duration: 500
+      "active": _vm.isPresetExpanded,
+      "duration": 500
     }
-  }, [_vm.filtered_widget_list ? _c("ul", {
+  }, [_vm.filtered_widget_list ? _c('ul', {
     staticClass: "cptm-form-builder-field-list"
   }, _vm._l(_vm.filtered_widget_list, function (widget, widget_key) {
-    return _c("draggable-list-item", {
+    return _c('draggable-list-item', {
       key: widget_key,
       attrs: {
         "list-type": "li",
         "item-class-name": "cptm-form-builder-field-list-item",
-        "drag-type": _vm.allowMultiple || widget.allowMultiple ? "clone" : "move"
+        "drag-type": _vm.allowMultiple || widget.allowMultiple ? 'clone' : 'move'
       },
       on: {
         "drag-start": function dragStart($event) {
-          return _vm.$emit("drag-start", {
+          return _vm.$emit('drag-start', {
             widget_key: widget_key,
             widget: widget
           });
         },
         "drag-end": function dragEnd($event) {
-          return _vm.$emit("drag-end", {
+          return _vm.$emit('drag-end', {
             widget_key: widget_key,
             widget: widget
           });
         }
       }
-    }, [_c("span", {
+    }, [_c('span', {
       staticClass: "cptm-form-builder-field-list-icon"
-    }, [widget.icon && widget.icon.length ? _c("span", {
+    }, [widget.icon && widget.icon.length ? _c('span', {
       class: widget.icon
-    }) : _vm._e()]), _vm._v(" "), _c("span", {
+    }) : _vm._e()]), _vm._v(" "), _c('span', {
       staticClass: "cptm-form-builder-field-list-label"
     }, [_vm._v(_vm._s(widget.label))])]);
   }), 1) : _vm._e()])], 1);
@@ -30142,108 +30117,108 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.widget_fields && Object.keys(_vm.widget_fields).length > 0 ? _c("div", {
+  return _vm.widget_fields && Object.keys(_vm.widget_fields).length > 0 ? _c('div', {
     staticClass: "cptm-form-builder-group-field-item",
-    class: _vm.expandState ? "expanded" : ""
-  }, [_vm.canMoveWidget ? _c("draggable-list-item", {
+    class: _vm.expandState ? 'expanded' : ''
+  }, [_vm.canMoveWidget ? _c('draggable-list-item', {
     on: {
       "drag-start": function dragStart($event) {
-        return _vm.$emit("drag-start");
+        return _vm.$emit('drag-start');
       },
       "drag-end": function dragEnd($event) {
-        return _vm.$emit("drag-end");
+        return _vm.$emit('drag-end');
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-field-item-drag"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-draggabledots",
     attrs: {
       "aria-hidden": "true"
     }
-  })])]) : _vm._e(), _vm._v(" "), _c("form-builder-widget-titlebar-component", {
+  })])]) : _vm._e(), _vm._v(" "), _c('form-builder-widget-titlebar-component', {
     attrs: {
-      label: _vm.widgetTitle,
-      sublabel: _vm.widgetSubtitle,
-      icon: _vm.widgetIcon,
-      expanded: _vm.expandState
+      "label": _vm.widgetTitle,
+      "sublabel": _vm.widgetSubtitle,
+      "icon": _vm.widgetIcon,
+      "expanded": _vm.expandState
     },
     on: {
       "toggle-expand": _vm.toggleExpand
     }
-  }), _vm._v(" "), _c("slide-up-down", {
+  }), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.expandState,
-      duration: 500
+      "active": _vm.expandState,
+      "duration": 500
     }
-  }, [_vm.widget_fields && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.widget_fields) === "object" ? _c("div", {
+  }, [_vm.widget_fields && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.widget_fields) === 'object' ? _c('div', {
     staticClass: "cptm-form-builder-group-field-item-body"
-  }, [_c("field-list-component", {
+  }, [_c('field-list-component', {
     attrs: {
-      root: _vm.activeWidgets,
+      "root": _vm.activeWidgets,
       "section-id": _vm.widgetKey,
       "field-list": _vm.widget_fields,
-      value: _vm.activeWidgets[_vm.widgetKey] ? _vm.activeWidgets[_vm.widgetKey] : ""
+      "value": _vm.activeWidgets[_vm.widgetKey] ? _vm.activeWidgets[_vm.widgetKey] : ''
     },
     on: {
-      update: function update($event) {
-        return _vm.$emit("update-widget-field", {
+      "update": function update($event) {
+        return _vm.$emit('update-widget-field', {
           widget_key: _vm.widgetKey,
           payload: $event
         });
       }
     }
-  })], 1) : _vm._e()]), _vm._v(" "), _c("div", {
+  })], 1) : _vm._e()]), _vm._v(" "), _c('div', {
     ref: "dropdownContent",
     staticClass: "cptm-form-builder-group-actions-dropdown cptm-form-builder-group-actions-dropdown--field"
-  }, [_vm.canTrashWidget ? _c("a", {
+  }, [_vm.canTrashWidget ? _c('a', {
     staticClass: "cptm-form-builder-group-actions-dropdown-btn",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.toggleExpandedDropdown.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-ellipsis-h",
     attrs: {
       "aria-hidden": "true"
     }
-  })]) : _vm._e(), _vm._v(" "), _c("slide-up-down", {
+  })]) : _vm._e(), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.expandedDropdown,
-      duration: 500
+      "active": _vm.expandedDropdown,
+      "duration": 500
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-actions-dropdown-content",
-    class: _vm.expandedDropdown ? "expanded" : ""
-  }, [_c("a", {
+    class: _vm.expandedDropdown ? 'expanded' : ''
+  }, [_c('a', {
     staticClass: "cptm-form-builder-field-item-action-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.handleTrashClick.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-trash-alt",
     attrs: {
       "aria-hidden": "true"
     }
-  }), _vm._v("\n          Remove Field\n        ")])])])], 1), _vm._v(" "), _c("confirmation-modal", {
+  }), _vm._v("\n          Remove Field\n        ")])])])], 1), _vm._v(" "), _c('confirmation-modal', {
     attrs: {
-      visible: _vm.showConfirmationModal,
-      widgetName: _vm.widgetName
+      "visible": _vm.showConfirmationModal,
+      "widgetName": _vm.widgetName
     },
     on: {
-      confirm: _vm.trashWidget,
-      cancel: _vm.closeConfirmationModal
+      "confirm": _vm.trashWidget,
+      "cancel": _vm.closeConfirmationModal
     }
   })], 1) : _vm._e();
 };
@@ -30267,37 +30242,37 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-group-field-item-header"
-  }, [_c("h4", {
+  }, [_c('h4', {
     staticClass: "cptm-title-3"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-title-icon",
     class: _vm.icon
-  }), _vm._v(" "), _c("span", {
+  }), _vm._v(" "), _c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.label)
+      "innerHTML": _vm._s(_vm.label)
     }
-  }), _vm._v(" "), _vm.sublabel.length ? _c("span", {
+  }), _vm._v(" "), _vm.sublabel.length ? _c('span', {
     staticClass: "cptm-text-gray cptm-px-5",
     domProps: {
-      innerHTML: _vm._s(_vm.sublabel)
+      "innerHTML": _vm._s(_vm.sublabel)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "cptm-form-builder-group-field-item-header-actions"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-form-builder-header-action-link",
-    class: _vm.expanded ? "action-collapse-down" : "action-collapse-up",
+    class: _vm.expanded ? 'action-collapse-down' : 'action-collapse-up',
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("toggle-expand");
+        return _vm.$emit('toggle-expand');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-angle-down",
     attrs: {
       "aria-hidden": "true"
@@ -30324,26 +30299,26 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.visible ? _c("div", {
+  return _vm.visible ? _c('div', {
     staticClass: "cptm-widget-trash-confirmation-modal-overlay",
     on: {
-      click: _vm.handleOverlayClick
+      "click": _vm.handleOverlayClick
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-trash-confirmation-modal",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.stopPropagation();
       }
     }
-  }, [_c("h2", [_vm._v("Are you sure you want to proceed?")]), _vm._v(" "), _c("p", [_vm._v('\n      Removing "'), _c("strong", [_vm._v(_vm._s(_vm.widgetName))]), _vm._v('" field will also remove it from the single and search pages.\n    ')]), _vm._v(" "), _c("button", {
+  }, [_c('h2', [_vm._v("Are you sure you want to proceed?")]), _vm._v(" "), _c('p', [_vm._v("\n      Removing \""), _c('strong', [_vm._v(_vm._s(_vm.widgetName))]), _vm._v("\" field will also remove it from the single and search pages.\n    ")]), _vm._v(" "), _c('button', {
     on: {
-      click: _vm.confirmDelete
+      "click": _vm.confirmDelete
     }
-  }, [_vm._v("Yes, delete")]), _vm._v(" "), _c("button", {
+  }, [_vm._v("Yes, delete")]), _vm._v(" "), _c('button', {
     staticClass: "cptm-widget-trash-confirmation-modal-action-btn__cancel",
     on: {
-      click: _vm.cancelDelete
+      "click": _vm.cancelDelete
     }
   }, [_vm._v("\n      Cancel\n    ")])])]) : _vm._e();
 };
@@ -30367,42 +30342,42 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.videoOpened ? _c("div", {
+  return _vm.videoOpened ? _c('div', {
     staticClass: "video-popup-overlay",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("close-video");
+        return _vm.$emit('close-video');
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "video-popup-content",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.stopPropagation();
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "video-container"
-  }, [_c("iframe", {
+  }, [_c('iframe', {
     attrs: {
-      width: "560",
-      height: "315",
-      src: _vm.video.url,
-      frameborder: "0",
-      allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
-      allowfullscreen: "",
-      title: _vm.video.title
+      "width": "560",
+      "height": "315",
+      "src": _vm.video.url,
+      "frameborder": "0",
+      "allow": "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
+      "allowfullscreen": "",
+      "title": _vm.video.title
     }
-  })])]), _vm._v(" "), _c("button", {
+  })])]), _vm._v(" "), _c('button', {
     staticClass: "close-btn",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("close-video");
+        return _vm.$emit('close-video');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "la la-close"
   })])]) : _vm._e();
 };
@@ -30426,9 +30401,9 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-active-fields-group"
-  }, [_c("form-builder-widget-group-header-component", _vm._b({
+  }, [_c('form-builder-widget-group-header-component', _vm._b({
     attrs: {
       "widgets-expanded": _vm.widgetsExpandState,
       "can-trash": _vm.canTrashGroup,
@@ -30436,46 +30411,46 @@ var render = function render() {
     },
     on: {
       "update-group-field": function updateGroupField($event) {
-        return _vm.$emit("update-group-field", $event);
+        return _vm.$emit('update-group-field', $event);
       },
       "toggle-expand-widgets": _vm.toggleExpandWidgets,
       "trash-group": function trashGroup($event) {
-        return _vm.$emit("trash-group");
+        return _vm.$emit('trash-group');
       },
       "drag-start": function dragStart($event) {
-        return _vm.$emit("group-drag-start");
+        return _vm.$emit('group-drag-start');
       },
       "drag-end": function dragEnd($event) {
-        return _vm.$emit("group-drag-end");
+        return _vm.$emit('group-drag-end');
       }
     }
-  }, "form-builder-widget-group-header-component", _vm.$props, false)), _vm._v(" "), _c("slide-up-down", {
+  }, 'form-builder-widget-group-header-component', _vm.$props, false)), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.widgetsExpandState,
-      duration: 800
+      "active": _vm.widgetsExpandState,
+      "duration": 800
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-fields"
   }, _vm._l(_vm.groupData.fields, function (widget_key, widget_index) {
-    return _c("draggable-list-item-wrapper", {
+    return _c('draggable-list-item-wrapper', {
       key: widget_index,
       attrs: {
         "list-id": "widget-item",
-        "is-dragging-self": _vm.currentDraggingWidget && "active_widgets" === _vm.currentDraggingWidget.from && widget_key === _vm.currentDraggingWidget.widget_key,
+        "is-dragging-self": _vm.currentDraggingWidget && 'active_widgets' === _vm.currentDraggingWidget.from && widget_key === _vm.currentDraggingWidget.widget_key,
         "class-name": "directorist-draggable-form-list-wrap",
-        droppables: true,
-        droppable: _vm.isDroppable(widget_index)
+        "droppables": true,
+        "droppable": _vm.isDroppable(widget_index)
       },
       on: {
-        drop: function drop($event) {
-          return _vm.$emit("drop-widget", {
+        "drop": function drop($event) {
+          return _vm.$emit('drop-widget', {
             widget_key: widget_key,
             widget_index: widget_index,
             drop_direction: $event.drop_direction
           });
         }
       }
-    }, [_c("form-builder-widget-component", {
+    }, [_c('form-builder-widget-component', {
       attrs: {
         "widget-key": widget_key,
         "active-widgets": _vm.activeWidgets,
@@ -30489,31 +30464,31 @@ var render = function render() {
           return _vm.updateDetectedUntrashableWidgets(widget_key);
         },
         "update-widget-field": function updateWidgetField($event) {
-          return _vm.$emit("update-widget-field", $event);
+          return _vm.$emit('update-widget-field', $event);
         },
         "trash-widget": function trashWidget($event) {
-          return _vm.$emit("trash-widget", {
+          return _vm.$emit('trash-widget', {
             widget_key: widget_key
           });
         },
         "drag-start": function dragStart($event) {
-          return _vm.$emit("widget-drag-start", {
+          return _vm.$emit('widget-drag-start', {
             widget_index: widget_index,
             widget_key: widget_key
           });
         },
         "drag-end": function dragEnd($event) {
-          return _vm.$emit("widget-drag-end", {
+          return _vm.$emit('widget-drag-end', {
             widget_index: widget_index,
             widget_key: widget_key
           });
         }
       }
     })], 1);
-  }), 1), _vm._v(" "), _vm.canShowWidgetDropPlaceholder ? _c("form-builder-droppable-placeholder", {
+  }), 1), _vm._v(" "), _vm.canShowWidgetDropPlaceholder ? _c('form-builder-droppable-placeholder', {
     on: {
-      drop: function drop($event) {
-        return _vm.$emit("append-widget");
+      "drop": function drop($event) {
+        return _vm.$emit('append-widget');
       }
     }
   }) : _vm._e()], 1)], 1);
@@ -30538,108 +30513,108 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-group-header-section",
-    class: _vm.groupFieldsExpandState ? "expanded" : ""
-  }, [_c("div", {
+    class: _vm.groupFieldsExpandState ? 'expanded' : ''
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-header"
-  }, [_c("draggable-list-item", {
+  }, [_c('draggable-list-item', {
     attrs: {
       "can-drag": _vm.isEnabledGroupDragging
     },
     on: {
       "drag-start": function dragStart($event) {
-        return _vm.$emit("drag-start");
+        return _vm.$emit('drag-start');
       },
       "drag-end": function dragEnd($event) {
-        return _vm.$emit("drag-end");
+        return _vm.$emit('drag-end');
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-field-item-drag"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-draggabledots",
     attrs: {
       "aria-hidden": "true"
     }
-  })])]), _vm._v(" "), _c("form-builder-widget-group-titlebar-component", _vm._b({
+  })])]), _vm._v(" "), _c('form-builder-widget-group-titlebar-component', _vm._b({
     attrs: {
       "widgets-expanded": _vm.widgetsExpanded
     },
     on: {
       "toggle-expand-group": _vm.toggleGroupFieldsExpand,
       "toggle-expand-widgets": function toggleExpandWidgets($event) {
-        return _vm.$emit("toggle-expand-widgets");
+        return _vm.$emit('toggle-expand-widgets');
       }
     }
-  }, "form-builder-widget-group-titlebar-component", _vm.$props, false)), _vm._v(" "), _c("div", {
+  }, 'form-builder-widget-group-titlebar-component', _vm.$props, false)), _vm._v(" "), _c('div', {
     ref: "dropdownContent",
     staticClass: "cptm-form-builder-group-actions-dropdown cptm-form-builder-group-actions-dropdown--group"
-  }, [_vm.canTrash ? _c("a", {
+  }, [_vm.canTrash ? _c('a', {
     staticClass: "cptm-form-builder-group-actions-dropdown-btn",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.toggleGroupExpandedDropdown.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-ellipsis-h",
     attrs: {
       "aria-hidden": "true"
     }
-  })]) : _vm._e(), _vm._v(" "), _c("slide-up-down", {
+  })]) : _vm._e(), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.groupExpandedDropdown,
-      duration: 500
+      "active": _vm.groupExpandedDropdown,
+      "duration": 500
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-actions-dropdown-content",
-    class: _vm.groupExpandedDropdown ? "expanded" : ""
-  }, [_c("a", {
+    class: _vm.groupExpandedDropdown ? 'expanded' : ''
+  }, [_c('a', {
     staticClass: "cptm-form-builder-field-item-action-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.handleGroupDelete.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-trash-alt",
     attrs: {
       "aria-hidden": "true"
     }
-  }), _vm._v("\n            Remove Section\n          ")])])])], 1)], 1), _vm._v(" "), _c("slide-up-down", {
+  }), _vm._v("\n            Remove Section\n          ")])])])], 1)], 1), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.groupFieldsExpandState,
-      duration: 500
+      "active": _vm.groupFieldsExpandState,
+      "duration": 500
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-options"
-  }, [_c("field-list-component", {
+  }, [_c('field-list-component', {
     attrs: {
       "field-list": _vm.finalGroupFields,
-      value: _vm.groupData
+      "value": _vm.groupData
     },
     on: {
-      update: function update($event) {
-        return _vm.$emit("update-group-field", $event);
+      "update": function update($event) {
+        return _vm.$emit('update-group-field', $event);
       }
     }
-  })], 1)]), _vm._v(" "), _c("confirmation-modal", {
+  })], 1)]), _vm._v(" "), _c('confirmation-modal', {
     attrs: {
-      visible: _vm.showConfirmationModal,
-      groupName: _vm.groupName
+      "visible": _vm.showConfirmationModal,
+      "groupName": _vm.groupName
     },
     on: {
-      confirm: _vm.trashGroup,
-      cancel: _vm.closeConfirmationModal
+      "confirm": _vm.trashGroup,
+      "cancel": _vm.closeConfirmationModal
     }
   })], 1);
 };
@@ -30666,46 +30641,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-group-title-area",
-    class: _vm.widgetsExpanded ? "expanded" : ""
-  }, [_c("h3", {
+    class: _vm.widgetsExpanded ? 'expanded' : ''
+  }, [_c('h3', {
     staticClass: "cptm-form-builder-group-title"
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.label)
+      "innerHTML": _vm._s(_vm.label)
     }
-  }), _vm._v(" "), _vm.groupFields && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.groupFields) === "object" ? _c("a", {
+  }), _vm._v(" "), _vm.groupFields && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.groupFields) === 'object' ? _c('a', {
     staticClass: "cptm-form-builder-header-action-link cptm-ml-5 cptm-link-light",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("toggle-expand-group");
+        return _vm.$emit('toggle-expand-group');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-cog",
     attrs: {
       "aria-hidden": "true"
     }
-  }), _vm._v(" Options\n    ")]) : _vm._e()]), _vm._v(" "), _vm.groupData && _vm.groupData.fields && _vm.groupData.fields.length ? _c("div", {
+  }), _vm._v(" Options\n    ")]) : _vm._e()]), _vm._v(" "), _vm.groupData && _vm.groupData.fields && _vm.groupData.fields.length ? _c('div', {
     staticClass: "cptm-form-builder-group-title-actions"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-form-builder-header-action-link",
-    class: _vm.widgetsExpanded ? "action-collapse-down" : "action-collapse-up",
+    class: _vm.widgetsExpanded ? 'action-collapse-down' : 'action-collapse-up',
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("toggle-expand-widgets");
+        return _vm.$emit('toggle-expand-widgets');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-angle-down",
     attrs: {
       "aria-hidden": "true"
@@ -30732,26 +30707,26 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.visible ? _c("div", {
+  return _vm.visible ? _c('div', {
     staticClass: "cptm-widget-trash-confirmation-modal-overlay",
     on: {
-      click: _vm.handleOverlayClick
+      "click": _vm.handleOverlayClick
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-trash-confirmation-modal",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.stopPropagation();
       }
     }
-  }, [_c("h2", [_vm._v("Are you sure you want to proceed?")]), _vm._v(" "), _c("p", [_vm._v('\n      Removing "'), _c("strong", [_vm._v(_vm._s(_vm.groupName))]), _vm._v("\" group will also remove it's all fields.\n    ")]), _vm._v(" "), _c("button", {
+  }, [_c('h2', [_vm._v("Are you sure you want to proceed?")]), _vm._v(" "), _c('p', [_vm._v("\n      Removing \""), _c('strong', [_vm._v(_vm._s(_vm.groupName))]), _vm._v("\" group will also remove it's all fields.\n    ")]), _vm._v(" "), _c('button', {
     on: {
-      click: _vm.confirmDelete
+      "click": _vm.confirmDelete
     }
-  }, [_vm._v("Yes, delete")]), _vm._v(" "), _c("button", {
+  }, [_vm._v("Yes, delete")]), _vm._v(" "), _c('button', {
     staticClass: "cptm-widget-trash-confirmation-modal-action-btn__cancel",
     on: {
-      click: _vm.cancelDelete
+      "click": _vm.cancelDelete
     }
   }, [_vm._v("\n      Cancel\n    ")])])]) : _vm._e();
 };
@@ -30775,20 +30750,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("ajax-action-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('ajax-action-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -30810,17 +30785,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("button-example-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('button-example-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -30842,14 +30817,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("button-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('button-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -30871,12 +30846,12 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {}, [_vm.card_templates ? [_c("div", {
+  return _c('div', {}, [_vm.card_templates ? [_c('div', {
     staticClass: "cptm-card-top-area cptm-text-center cptm-mb-20"
-  }, [_c("select-field", {
+  }, [_c('select-field', {
     attrs: {
-      theme: "default",
-      options: _vm.theCardBiulderTemplateOptionList
+      "theme": "default",
+      "options": _vm.theCardBiulderTemplateOptionList
     },
     model: {
       value: _vm.template_id,
@@ -30889,25 +30864,25 @@ var render = function render() {
     tag: "component",
     attrs: {
       "field-id": _vm.fieldId,
-      value: _vm.theCardBiulderValue
+      "value": _vm.theCardBiulderValue
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateValue($event);
       }
     }
-  }, "component", _vm.theCurrentTemplateModel, false))] : [_c(_vm.cardBiulderTemplate, {
+  }, 'component', _vm.theCurrentTemplateModel, false))] : [_c(_vm.cardBiulderTemplate, {
     tag: "component",
     attrs: {
       "field-id": _vm.fieldId,
-      value: _vm.value,
-      widgets: _vm.widgets,
-      layout: _vm.layout,
+      "value": _vm.value,
+      "widgets": _vm.widgets,
+      "layout": _vm.layout,
       "card-options": _vm.cardOptions
     },
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
   })]], 2);
@@ -30932,46 +30907,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-top-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_top_left",
-      containerClass: "cptm-card-preview-top-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_left.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_left)
+      "id": "thumbnail_top_left",
+      "containerClass": "cptm-card-preview-top-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_left.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31005,26 +30980,26 @@ var render = function render() {
         return _vm.handleDragleaveOnPlaceholder(_vm.local_layout.thumbnail.top_left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_left");
+        return _vm.activeInsertWindow('thumbnail_top_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-top-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_top_right",
-      containerClass: "cptm-card-preview-top-right-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
+      "id": "thumbnail_top_right",
+      "containerClass": "cptm-card-preview-top-right-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31055,26 +31030,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.top_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_right");
+        return _vm.activeInsertWindow('thumbnail_top_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-bottom-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_bottom_left",
-      containerClass: "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.bottom_left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.bottom_left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.bottom_left.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.bottom_left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_bottom_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_left)
+      "id": "thumbnail_bottom_left",
+      "containerClass": "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.bottom_left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.bottom_left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.bottom_left.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.bottom_left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_bottom_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31105,26 +31080,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.bottom_left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_bottom_left");
+        return _vm.activeInsertWindow('thumbnail_bottom_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-bottom-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_bottom_right",
-      containerClass: "cptm-card-preview-bottom-right-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.bottom_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.bottom_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.bottom_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.bottom_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_bottom_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_right)
+      "id": "thumbnail_bottom_right",
+      "containerClass": "cptm-card-preview-bottom-right-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.bottom_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.bottom_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.bottom_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.bottom_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_bottom_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31155,28 +31130,28 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.bottom_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_bottom_right");
+        return _vm.activeInsertWindow('thumbnail_bottom_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-author-avatar"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_avatar",
-      containerClass: _vm.getAvatarPlaceholderClass,
-      label: _vm.local_layout.thumbnail.avatar.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.avatar.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.avatar.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.avatar.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_avatar"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.avatar)
+      "id": "thumbnail_avatar",
+      "containerClass": _vm.getAvatarPlaceholderClass,
+      "label": _vm.local_layout.thumbnail.avatar.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.avatar.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.avatar.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.avatar.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_avatar'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.avatar)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31201,24 +31176,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.thumbnail.avatar);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_avatar");
+        return _vm.activeInsertWindow('thumbnail_avatar');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_top",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-align-left",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "id": "thumbnail_body_top",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-align-left",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31243,24 +31218,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_top");
+        return _vm.activeInsertWindow('thumbnail_body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_bottom",
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "id": "thumbnail_body_bottom",
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31285,24 +31260,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_bottom");
+        return _vm.activeInsertWindow('thumbnail_body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      id: "body_excerpt",
-      containerClass: "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpr"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "id": "body_excerpt",
+      "containerClass": "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpr'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31327,26 +31302,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpr");
+        return _vm.activeInsertWindow('body_excerpr');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_left",
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "id": "thumbnail_footer_left",
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31371,24 +31346,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_right",
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "id": "thumbnail_footer_right",
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31413,7 +31388,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -31424,9 +31399,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -31449,46 +31424,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget grid-view-with-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-top-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_top_left",
-      containerClass: "cptm-card-preview-top-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_left.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_left)
+      "id": "thumbnail_top_left",
+      "containerClass": "cptm-card-preview-top-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_left.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31522,26 +31497,26 @@ var render = function render() {
         return _vm.handleDragleaveOnPlaceholder(_vm.local_layout.thumbnail.top_left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_left");
+        return _vm.activeInsertWindow('thumbnail_top_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-top-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_top_right",
-      containerClass: "cptm-card-preview-top-right-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
+      "id": "thumbnail_top_right",
+      "containerClass": "cptm-card-preview-top-right-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31572,26 +31547,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.top_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_right");
+        return _vm.activeInsertWindow('thumbnail_top_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-bottom-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_bottom_left",
-      containerClass: "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.bottom_left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.bottom_left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.bottom_left.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.bottom_left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_bottom_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_left)
+      "id": "thumbnail_bottom_left",
+      "containerClass": "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.bottom_left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.bottom_left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.bottom_left.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.bottom_left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_bottom_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31622,26 +31597,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.bottom_left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_bottom_left");
+        return _vm.activeInsertWindow('thumbnail_bottom_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-bottom-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_bottom_right",
-      containerClass: "cptm-card-preview-bottom-right-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.bottom_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.bottom_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.bottom_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.bottom_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_bottom_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_right)
+      "id": "thumbnail_bottom_right",
+      "containerClass": "cptm-card-preview-bottom-right-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.bottom_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.bottom_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.bottom_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.bottom_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_bottom_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31672,28 +31647,28 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.bottom_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_bottom_right");
+        return _vm.activeInsertWindow('thumbnail_bottom_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-author-avatar"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_avatar",
-      containerClass: _vm.getAvatarPlaceholderClass,
-      label: _vm.local_layout.thumbnail.avatar.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.avatar.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.avatar.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.avatar.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_avatar"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.avatar)
+      "id": "thumbnail_avatar",
+      "containerClass": _vm.getAvatarPlaceholderClass,
+      "label": _vm.local_layout.thumbnail.avatar.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.avatar.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.avatar.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.avatar.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_avatar'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.avatar)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31718,24 +31693,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.thumbnail.avatar);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_avatar");
+        return _vm.activeInsertWindow('thumbnail_avatar');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_top",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-align-left",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "id": "thumbnail_body_top",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-align-left",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31760,24 +31735,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_top");
+        return _vm.activeInsertWindow('thumbnail_body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_bottom",
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "id": "thumbnail_body_bottom",
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31802,24 +31777,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_bottom");
+        return _vm.activeInsertWindow('thumbnail_body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      id: "body_excerpt",
-      containerClass: "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpr"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "id": "body_excerpt",
+      "containerClass": "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpr'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31844,26 +31819,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpr");
+        return _vm.activeInsertWindow('body_excerpr');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_left",
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "id": "thumbnail_footer_left",
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31888,24 +31863,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_right",
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "id": "thumbnail_footer_right",
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31930,7 +31905,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -31941,9 +31916,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -31966,44 +31941,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget grid-view-without-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-placeholder-row cptm-no-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-placeholder-col cptm-placeholder-top-right-col cptm-card-light"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "body_avatar",
-      containerClass: "cptm-listing-card-author-avatar-placeholder cptm-card-light cptm-mb-20 cptm-text-center",
-      label: _vm.local_layout.body.avatar.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.avatar.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.avatar.selectedWidgets,
-      maxWidget: _vm.local_layout.body.avatar.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_avatar"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.avatar)
+      "id": "body_avatar",
+      "containerClass": "cptm-listing-card-author-avatar-placeholder cptm-card-light cptm-mb-20 cptm-text-center",
+      "label": _vm.local_layout.body.avatar.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.avatar.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.avatar.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.avatar.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_avatar'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.avatar)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32028,26 +32003,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.avatar);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_avatar");
+        return _vm.activeInsertWindow('body_avatar');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-placeholder-col cptm-placeholder-title-col"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "body_title",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20",
-      label: _vm.local_layout.body.title.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.title.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.title.selectedWidgets,
-      maxWidget: _vm.local_layout.body.title.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_title"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.title)
+      "id": "body_title",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20",
+      "label": _vm.local_layout.body.title.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.title.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.title.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.title.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_title'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.title)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32072,26 +32047,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.title);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_title");
+        return _vm.activeInsertWindow('body_title');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-placeholder-col cptm-placeholder-action-col"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "body_quick_actions",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-text-right",
-      label: _vm.local_layout.body.quick_actions.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.quick_actions.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.quick_actions.selectedWidgets,
-      maxWidget: _vm.local_layout.body.quick_actions.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_quick_actions"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.quick_actions)
+      "id": "body_quick_actions",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-text-right",
+      "label": _vm.local_layout.body.quick_actions.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.quick_actions.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.quick_actions.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.quick_actions.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_quick_actions'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.quick_actions)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32116,24 +32091,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.quick_actions);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_quick_actions");
+        return _vm.activeInsertWindow('body_quick_actions');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)]), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1)]), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_quick_info",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20",
-      label: _vm.local_layout.body.quick_info.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.quick_info.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.quick_info.selectedWidgets,
-      maxWidget: _vm.local_layout.body.quick_info.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_quick_info"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.quick_info)
+      "id": "thumbnail_quick_info",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20",
+      "label": _vm.local_layout.body.quick_info.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.quick_info.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.quick_info.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.quick_info.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_quick_info'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.quick_info)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32158,24 +32133,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.quick_info);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_quick_info");
+        return _vm.activeInsertWindow('thumbnail_quick_info');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_bottom",
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "id": "thumbnail_body_bottom",
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32200,24 +32175,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_bottom");
+        return _vm.activeInsertWindow('thumbnail_body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      id: "body_excerpt",
-      containerClass: "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpr"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "id": "body_excerpt",
+      "containerClass": "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpr'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32242,26 +32217,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpr");
+        return _vm.activeInsertWindow('body_excerpr');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_left",
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "id": "thumbnail_footer_left",
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32286,24 +32261,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_right",
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "id": "thumbnail_footer_right",
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32328,7 +32303,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -32356,45 +32331,45 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget cptm-card-list-view"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-top-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
+      "containerClass": "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32425,31 +32400,31 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.top_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_right");
+        return _vm.activeInsertWindow('thumbnail_top_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-content"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "containerClass": "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32474,25 +32449,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_top");
+        return _vm.activeInsertWindow('body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-body-header-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
-      label: _vm.local_layout.body.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.right.selectedWidgets,
-      maxWidget: _vm.local_layout.body.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.right)
+      "containerClass": "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32517,23 +32492,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_right");
+        return _vm.activeInsertWindow('body_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)]), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1)]), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32558,23 +32533,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_bottom");
+        return _vm.activeInsertWindow('body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpt"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "containerClass": "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpt'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32599,25 +32574,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpt");
+        return _vm.activeInsertWindow('body_excerpt');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32642,23 +32617,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32683,7 +32658,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -32694,9 +32669,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -32719,45 +32694,45 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget cptm-card-list-view list-view-with-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-top-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
+      "containerClass": "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32788,31 +32763,31 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.top_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_right");
+        return _vm.activeInsertWindow('thumbnail_top_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-content"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "containerClass": "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32837,25 +32812,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_top");
+        return _vm.activeInsertWindow('body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-body-header-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
-      label: _vm.local_layout.body.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.right.selectedWidgets,
-      maxWidget: _vm.local_layout.body.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.right)
+      "containerClass": "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32880,23 +32855,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_right");
+        return _vm.activeInsertWindow('body_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)]), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1)]), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32921,23 +32896,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_bottom");
+        return _vm.activeInsertWindow('body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpt"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "containerClass": "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpt'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32962,25 +32937,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpt");
+        return _vm.activeInsertWindow('body_excerpt');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33005,23 +32980,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33046,7 +33021,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -33057,9 +33032,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -33082,45 +33057,45 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget cptm-card-list-view list-view-without-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-content"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "containerClass": "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33145,25 +33120,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_top");
+        return _vm.activeInsertWindow('body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-body-header-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
-      label: _vm.local_layout.body.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.right.selectedWidgets,
-      maxWidget: _vm.local_layout.body.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.right)
+      "containerClass": "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33188,23 +33163,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_right");
+        return _vm.activeInsertWindow('body_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)]), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1)]), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33229,23 +33204,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_bottom");
+        return _vm.activeInsertWindow('body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpt"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "containerClass": "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpt'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33270,25 +33245,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpt");
+        return _vm.activeInsertWindow('body_excerpt');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33313,23 +33288,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33354,7 +33329,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -33382,74 +33357,74 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetCardOptionsWindowActiveStatus || _vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetCardOptionsWindowActiveStatus || _vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetCardOptionsWindowActiveStatus
+      "active": _vm.widgetCardOptionsWindowActiveStatus
     },
     on: {
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeCardWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetCardOptionsWindow, false)), _vm._v(" "), _c("options-window", _vm._b({
+  }, 'options-window', _vm.widgetCardOptionsWindow, false)), _vm._v(" "), _c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-area-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-title-bar"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-title-bar-headings cptm-card-light"
-  }, [Object.keys(_vm.card_options.general).length ? _c("div", {
+  }, [Object.keys(_vm.card_options.general).length ? _c('div', {
     staticClass: "cptm-card-options-widgets-area"
   }, [_vm._l(_vm.card_options.general, function (widget, widget_key) {
-    return [_c(widget.type + "-card-widget", {
+    return [_c(widget.type + '-card-widget', {
       key: widget_key,
       tag: "component",
       attrs: {
-        label: _vm.getWidgetLabel(widget),
-        canMove: false,
-        canTrash: false
+        "label": _vm.getWidgetLabel(widget),
+        "canMove": false,
+        "canTrash": false
       },
       on: {
-        edit: function edit($event) {
+        "edit": function edit($event) {
           return _vm.editOption(_vm.card_options.general, widget_key);
         }
       }
     })];
-  })], 2) : _vm._e()]), _vm._v(" "), _c("div", {
+  })], 2) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "cptm-title-bar-actions"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-quick-action"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "listings_header_quick_actions",
-      containerClass: "cptm-card-preview-quick-action-placeholder cptm-card-light",
-      label: _vm.local_layout.listings_header.quick_actions.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.listings_header.quick_actions.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.listings_header.quick_actions.selectedWidgets,
-      maxWidget: _vm.local_layout.listings_header.quick_actions.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_quick_actions"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.listings_header.quick_actions)
+      "id": "listings_header_quick_actions",
+      "containerClass": "cptm-card-preview-quick-action-placeholder cptm-card-light",
+      "label": _vm.local_layout.listings_header.quick_actions.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.listings_header.quick_actions.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.listings_header.quick_actions.selectedWidgets,
+      "maxWidget": _vm.local_layout.listings_header.quick_actions.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('listings_header_quick_actions'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.listings_header.quick_actions)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33483,32 +33458,32 @@ var render = function render() {
         return _vm.handleDragleaveOnPlaceholder(_vm.local_layout.listings_header.quick_actions);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("listings_header_quick_actions");
+        return _vm.activeInsertWindow('listings_header_quick_actions');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)])]), _vm._v(" "), _c("div", {
+  })], 1)])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-placeholer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "listings_header_thumbnail",
-      containerClass: "cptm-card-preview-thumbnail-placeholder cptm-card-dark",
-      label: _vm.local_layout.listings_header.thumbnail.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.listings_header.thumbnail.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.listings_header.thumbnail.selectedWidgets,
-      maxWidget: _vm.local_layout.listings_header.thumbnail.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_thumbnail"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.listings_header.thumbnail)
+      "id": "listings_header_thumbnail",
+      "containerClass": "cptm-card-preview-thumbnail-placeholder cptm-card-dark",
+      "label": _vm.local_layout.listings_header.thumbnail.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.listings_header.thumbnail.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.listings_header.thumbnail.selectedWidgets,
+      "maxWidget": _vm.local_layout.listings_header.thumbnail.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('listings_header_thumbnail'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.listings_header.thumbnail)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33539,26 +33514,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.listings_header.thumbnail);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("listings_header_thumbnail");
+        return _vm.activeInsertWindow('listings_header_thumbnail');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "listings_header_quick_info",
-      containerClass: "cptm-listing-card-preview-quick-info-placeholder cptm-card-light",
-      label: _vm.local_layout.listings_header.quick_info.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.listings_header.quick_info.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.listings_header.quick_info.selectedWidgets,
-      maxWidget: _vm.local_layout.listings_header.quick_info.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_quick_info"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.listings_header.quick_info)
+      "id": "listings_header_quick_info",
+      "containerClass": "cptm-listing-card-preview-quick-info-placeholder cptm-card-light",
+      "label": _vm.local_layout.listings_header.quick_info.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.listings_header.quick_info.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.listings_header.quick_info.selectedWidgets,
+      "maxWidget": _vm.local_layout.listings_header.quick_info.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('listings_header_quick_info'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.listings_header.quick_info)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33583,25 +33558,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.listings_header.quick_info);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("listings_header_quick_info");
+        return _vm.activeInsertWindow('listings_header_quick_info');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), Object.keys(_vm.card_options.content_settings).length ? _c("div", {
+  })], 1), _vm._v(" "), Object.keys(_vm.card_options.content_settings).length ? _c('div', {
     staticClass: "cptm-card-options-widgets-area"
   }, [_vm._l(_vm.card_options.content_settings, function (widget, widget_key) {
-    return [_c(widget.type + "-card-widget", {
+    return [_c(widget.type + '-card-widget', {
       key: widget_key,
       tag: "component",
       attrs: {
-        label: _vm.getWidgetLabel(widget),
-        canMove: false,
-        canTrash: false
+        "label": _vm.getWidgetLabel(widget),
+        "canMove": false,
+        "canTrash": false
       },
       on: {
-        edit: function edit($event) {
+        "edit": function edit($event) {
           return _vm.editOption(_vm.card_options.content_settings, widget_key);
         }
       }
@@ -33611,9 +33586,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -33636,65 +33611,65 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetCardOptionsWindowActiveStatus || _vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetCardOptionsWindowActiveStatus || _vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetCardOptionsWindowActiveStatus
+      "active": _vm.widgetCardOptionsWindowActiveStatus
     },
     on: {
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeCardWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetCardOptionsWindow, false)), _vm._v(" "), _c("options-window", _vm._b({
+  }, 'options-window', _vm.widgetCardOptionsWindow, false)), _vm._v(" "), _c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-placeholder"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-preview-placeholder__card"
-  }, [_c("Container", {
+  }, [_c('Container', {
     attrs: {
       "drag-handle-selector": ".cptm-drag-element"
     },
     on: {
-      drop: _vm.onDrop
+      "drop": _vm.onDrop
     }
   }, _vm._l(_vm.placeholders, function (placeholderItem, index) {
-    return _c("Draggable", {
+    return _c('Draggable', {
       key: index
-    }, [placeholderItem.type == "placeholder_group" ? _c("div", {
+    }, [placeholderItem.type == 'placeholder_group' ? _c('div', {
       staticClass: "draggable-item"
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "cptm-preview-placeholder__card__item cptm-preview-placeholder__card__item--top"
     }, _vm._l(placeholderItem.placeholders, function (placeholderSubItem, subIndex) {
-      return _c("card-widget-placeholder", {
+      return _c('card-widget-placeholder', {
         key: "".concat(index, "_").concat(subIndex),
         attrs: {
-          placeholderKey: placeholderSubItem.placeholderKey,
-          id: "listings_header_".concat(index, "_").concat(subIndex),
-          containerClass: "cptm-preview-placeholder__card__box cptm-card-light",
-          label: placeholderSubItem.label,
-          availableWidgets: _vm.theAvailableWidgets,
-          activeWidgets: _vm.active_widgets,
-          acceptedWidgets: placeholderSubItem.acceptedWidgets,
-          rejectedWidgets: placeholderSubItem.rejectedWidgets,
-          selectedWidgets: placeholderSubItem.selectedWidgets,
-          maxWidget: placeholderSubItem.maxWidget,
-          showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_".concat(index, "_").concat(subIndex)),
-          widgetDropable: _vm.widgetIsDropable(placeholderSubItem)
+          "placeholderKey": placeholderSubItem.placeholderKey,
+          "id": "listings_header_".concat(index, "_").concat(subIndex),
+          "containerClass": "cptm-preview-placeholder__card__box cptm-card-light",
+          "label": placeholderSubItem.label,
+          "availableWidgets": _vm.theAvailableWidgets,
+          "activeWidgets": _vm.active_widgets,
+          "acceptedWidgets": placeholderSubItem.acceptedWidgets,
+          "rejectedWidgets": placeholderSubItem.rejectedWidgets,
+          "selectedWidgets": placeholderSubItem.selectedWidgets,
+          "maxWidget": placeholderSubItem.maxWidget,
+          "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus("listings_header_".concat(index, "_").concat(subIndex)),
+          "widgetDropable": _vm.widgetIsDropable(placeholderSubItem)
         },
         on: {
           "insert-widget": function insertWidget($event) {
@@ -33726,26 +33701,26 @@ var render = function render() {
           }
         }
       });
-    }), 1), _vm._v(" "), _c("div", {
+    }), 1), _vm._v(" "), _c('div', {
       staticClass: "cptm-drag-element las la-arrows-alt"
-    })]) : _vm._e(), _vm._v(" "), placeholderItem.type == "placeholder_item" ? _c("div", {
+    })]) : _vm._e(), _vm._v(" "), placeholderItem.type == 'placeholder_item' ? _c('div', {
       staticClass: "draggable-item"
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "cptm-preview-placeholder__card__item cptm-preview-placeholder__card__item--bottom"
-    }, [_c("card-widget-placeholder", {
+    }, [_c('card-widget-placeholder', {
       attrs: {
-        placeholderKey: placeholderItem.placeholderKey,
-        id: "listings_header_" + index,
-        containerClass: "cptm-preview-placeholder__card__box cptm-card-light",
-        label: placeholderItem.label,
-        availableWidgets: _vm.theAvailableWidgets,
-        activeWidgets: _vm.active_widgets,
-        acceptedWidgets: placeholderItem.acceptedWidgets,
-        rejectedWidgets: placeholderItem.rejectedWidgets,
-        selectedWidgets: placeholderItem.selectedWidgets,
-        maxWidget: placeholderItem.maxWidget,
-        showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_" + index),
-        widgetDropable: _vm.widgetIsDropable(placeholderItem)
+        "placeholderKey": placeholderItem.placeholderKey,
+        "id": 'listings_header_' + index,
+        "containerClass": "cptm-preview-placeholder__card__box cptm-card-light",
+        "label": placeholderItem.label,
+        "availableWidgets": _vm.theAvailableWidgets,
+        "activeWidgets": _vm.active_widgets,
+        "acceptedWidgets": placeholderItem.acceptedWidgets,
+        "rejectedWidgets": placeholderItem.rejectedWidgets,
+        "selectedWidgets": placeholderItem.selectedWidgets,
+        "maxWidget": placeholderItem.maxWidget,
+        "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('listings_header_' + index),
+        "widgetDropable": _vm.widgetIsDropable(placeholderItem)
       },
       on: {
         "insert-widget": function insertWidget($event) {
@@ -33770,32 +33745,32 @@ var render = function render() {
           return _vm.handleDropOnPlaceholder(placeholderItem);
         },
         "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-          return _vm.activeInsertWindow("listings_header_" + index);
+          return _vm.activeInsertWindow('listings_header_' + index);
         },
         "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
           return _vm.closeInsertWindow();
         }
       }
-    })], 1), _vm._v(" "), _c("div", {
+    })], 1), _vm._v(" "), _c('div', {
       staticClass: "cptm-drag-element las la-arrows-alt"
     })]) : _vm._e()]);
-  }), 1), _vm._v(" "), _c("div", {
+  }), 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-placeholder-buttons"
   }, [_vm._l(Object.keys(_vm.placeholdersMap), function (placeholderKey) {
-    return [_vm.canShowAddPlaceholderButton(placeholderKey) ? _c("div", {
+    return [_vm.canShowAddPlaceholderButton(placeholderKey) ? _c('div', {
       key: placeholderKey,
       staticClass: "cptm-preview-placeholder__card__action"
-    }, [_c("button", {
+    }, [_c('button', {
       staticClass: "cptm-preview-placeholder__card__btn",
       attrs: {
-        type: "button"
+        "type": "button"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           return _vm.addPlaceholder(placeholderKey);
         }
       }
-    }, [_c("span", {
+    }, [_c('span', {
       staticClass: "icon fa fa-plus"
     }), _vm._v("\n              " + _vm._s(_vm.getAddPlaceholderButtonLabel(placeholderKey)) + "\n            ")])]) : _vm._e()];
   })], 2)], 1)])]);
@@ -33820,17 +33795,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("checkbox-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('checkbox-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33852,20 +33827,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("color-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('color-field'), _vm._b({
     tag: "component",
     attrs: {
-      canChange: _vm.canChange
+      "canChange": _vm.canChange
     },
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33887,45 +33862,45 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "directorist-input-wrap directorist-footer-wrap"
-  }, [!_vm.isButtonEditable ? _c("div", {
+  }, [!_vm.isButtonEditable ? _c('div', {
     staticClass: "directorist-input"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn",
     attrs: {
-      type: "button",
+      "type": "button",
       "data-info": "Click to edit button text"
     },
     on: {
-      click: _vm.showEditableButton
+      "click": _vm.showEditableButton
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-save-text",
     domProps: {
-      innerHTML: _vm._s(_vm.value)
+      "innerHTML": _vm._s(_vm.value)
     }
-  }), _vm._v(" "), _c("span", {
+  }), _vm._v(" "), _c('span', {
     staticClass: "cptm-save-icon la la-pen"
-  })])]) : _vm._e(), _vm._v(" "), _vm.isButtonEditable ? _c("div", {
+  })])]) : _vm._e(), _vm._v(" "), _vm.isButtonEditable ? _c('div', {
     staticClass: "directorist-input"
   }, [_c("text-field", {
     ref: "formGroup",
     tag: "component",
     attrs: {
-      value: _vm.value
+      "value": _vm.value
     },
     on: {
-      enter: _vm.hideEditableButton,
-      blur: _vm.hideEditableButton,
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "enter": _vm.hideEditableButton,
+      "blur": _vm.hideEditableButton,
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
   })], 1) : _vm._e()]);
@@ -33950,14 +33925,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("export-data-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('export-data-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33979,14 +33954,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("export-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('export-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34008,20 +33983,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-multi-option-group"
-  }, [_vm.label.length ? _c("h3", {
+  }, [_vm.label.length ? _c('h3', {
     staticClass: "cptm-multi-option-label"
   }, [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _vm._l(_vm.local_fields, function (field, field_key) {
-    return [_c(field.type + "-field", _vm._b({
+    return [_c(field.type + '-field', _vm._b({
       key: field_key,
       tag: "component",
       on: {
-        update: function update($event) {
+        "update": function update($event) {
           return _vm.updateValue(field_key, $event);
         }
       }
-    }, "component", field, false))];
+    }, 'component', field, false))];
   })], 2);
 };
 var staticRenderFns = [];
@@ -34044,12 +34019,12 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder cptm-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-col-5 cptm-col-sticky"
   }, [_vm._l(_vm.widgets, function (widget_group, widget_group_key) {
-    return [_c("form-builder-widget-list-section-component", _vm._b({
+    return [_c('form-builder-widget-list-section-component', _vm._b({
       attrs: {
         "field-id": _vm.fieldId,
         "widget-group": widget_group_key,
@@ -34065,27 +34040,27 @@ var render = function render() {
           return _vm.handleWidgetListItemDragEnd(widget_group_key, $event);
         }
       }
-    }, "form-builder-widget-list-section-component", widget_group, false))];
-  })], 2), _vm._v(" "), _c("div", {
+    }, 'form-builder-widget-list-section-component', widget_group, false))];
+  })], 2), _vm._v(" "), _c('div', {
     staticClass: "cptm-col-7"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-active-fields"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-active-fields-container cptm-col-sticky"
   }, [_vm._l(_vm.active_widget_groups, function (widget_group, widget_group_key) {
-    return _c("draggable-list-item-wrapper", {
+    return _c('draggable-list-item-wrapper', {
       key: widget_group_key,
       attrs: {
         "list-id": "widget-group",
         "is-dragging-self": _vm.currentDraggingGroup && widget_group_key === _vm.currentDraggingGroup.widget_group_key,
-        droppable: _vm.currentDraggingGroup
+        "droppable": _vm.currentDraggingGroup
       },
       on: {
-        drop: function drop($event) {
+        "drop": function drop($event) {
           return _vm.handleGroupDrop(widget_group_key, $event);
         }
       }
-    }, [_c("form-builder-widget-group-component", {
+    }, [_c('form-builder-widget-group-component', {
       attrs: {
         "group-key": widget_group_key,
         "field-id": _vm.fieldId,
@@ -34130,18 +34105,18 @@ var render = function render() {
         }
       }
     })], 1);
-  }), _vm._v(" "), _vm.showAddNewGroupButton ? _c("div", {
+  }), _vm._v(" "), _vm.showAddNewGroupButton ? _c('div', {
     staticClass: "cptm-form-builder-active-fields-footer"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.addNewGroupButtonLabel)
+      "innerHTML": _vm._s(_vm.addNewGroupButtonLabel)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.addNewGroup();
       }
     }
@@ -34167,16 +34142,16 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("text-field", _vm._b({
+  return _c('text-field', _vm._b({
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "text-field", _vm.$props, false));
+  }, 'text-field', _vm.$props, false));
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34198,9 +34173,9 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group directorist-type-icon-select"
-  }, [_c("div", {
+  }, [_c('div', {
     ref: "iconPickerElm",
     staticClass: "icon-picker-wrap"
   })]);
@@ -34225,15 +34200,15 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("label", [_vm._v(_vm._s(_vm.label))]), _vm._v(" "), _c("input", {
+  }, [_c('label', [_vm._v(_vm._s(_vm.label))]), _vm._v(" "), _c('input', {
     attrs: {
-      type: "file"
+      "type": "file"
     },
     on: {
-      change: function change($event) {
-        return _vm.$emit("update", $event.target.files);
+      "change": function change($event) {
+        return _vm.$emit('update', $event.target.files);
       }
     }
   })]);
@@ -34258,14 +34233,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("import-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('import-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34287,35 +34262,35 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [!_vm.hidden && _vm.label.length ? _c("label", {
+  }, [!_vm.hidden && _vm.label.length ? _c('label', {
     attrs: {
-      for: _vm.name
+      "for": _vm.name
     }
-  }, [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _c("input", {
+  }, [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _c('input', {
     staticClass: "cptm-form-control",
     attrs: {
-      type: !_vm.hidden ? "text" : "hidden",
-      placeholder: _vm.placeholder
+      "type": !_vm.hidden ? 'text' : 'hidden',
+      "placeholder": _vm.placeholder
     },
     domProps: {
-      value: _vm.theValue
+      "value": _vm.theValue
     },
     on: {
-      input: function input($event) {
+      "input": function input($event) {
         return _vm.updateValue($event.target.value);
       }
     }
-  }), _vm._v(" "), !_vm.hidden && _vm.hasError ? _c("div", {
+  }), _vm._v(" "), !_vm.hidden && _vm.hasError ? _c('div', {
     staticClass: "cptm-form-group-feedback"
   }, _vm._l(_vm.validationMessages, function (alert, alert_key) {
-    return _c("div", {
+    return _c('div', {
       key: alert_key,
       staticClass: "cptm-form-alert",
-      class: "cptm-" + alert.type
-    }, [_vm._v("\n            " + _vm._s(alert.message) + "\n        ")]);
+      class: 'cptm-' + alert.type
+    }, [_vm._v("\r\n            " + _vm._s(alert.message) + "\r\n        ")]);
   }), 0) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -34338,51 +34313,51 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-multi-option-group"
-  }, [_c("h3", {
+  }, [_c('h3', {
     staticClass: "cptm-multi-option-label"
   }, [_vm._v(_vm._s(_vm.label))]), _vm._v(" "), _vm._l(_vm.theActiveGroups, function (option_group, option_group_key) {
-    return [_c("div", {
+    return [_c('div', {
       key: option_group_key,
       staticClass: "cptm-multi-option-group-section"
-    }, [_c("h3", [_vm._v("# " + _vm._s(option_group_key + 1))]), _vm._v(" "), _vm._l(option_group, function (option, option_key) {
-      return [_c(option.type + "-field", _vm._b({
+    }, [_c('h3', [_vm._v("# " + _vm._s(option_group_key + 1))]), _vm._v(" "), _vm._l(option_group, function (option, option_key) {
+      return [_c(option.type + '-field', _vm._b({
         key: "".concat(_vm.fieldId, "_").concat(option_key),
         tag: "component",
         attrs: {
-          root: option_group,
-          validation: _vm.getValidation(option_key, option_group_key, option),
-          value: option.value
+          "root": option_group,
+          "validation": _vm.getValidation(option_key, option_group_key, option),
+          "value": option.value
         },
         on: {
-          update: function update($event) {
+          "update": function update($event) {
             return _vm.updateValue(option_group_key, option_key, $event);
           }
         }
-      }, "component", _vm.getSanitizedOption(option), false))];
-    }), _vm._v(" "), _c("p", {
+      }, 'component', _vm.getSanitizedOption(option), false))];
+    }), _vm._v(" "), _c('p', {
       staticStyle: {
         "text-align": "right"
       }
-    }, [_c("button", {
+    }, [_c('button', {
       staticClass: "cptm-btn cptm-btn-secondery",
       attrs: {
-        type: "button"
+        "type": "button"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           return _vm.removeOptionGroup(option_group_key);
         }
       }
     }, [_vm._v("\n                    " + _vm._s(_vm.removeButtonLabel) + "\n                ")])])], 2)];
-  }), _vm._v(" "), _c("button", {
+  }), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-btn-primary",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.addNewOptionGroup();
       }
     }
@@ -34408,17 +34383,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("note-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('note-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34440,19 +34415,19 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("text-field", _vm._b({
+  return _c('text-field', _vm._b({
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "text-field", _vm.$props, false));
+  }, 'text-field', _vm.$props, false));
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34474,16 +34449,16 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("text-field", _vm._b({
+  return _c('text-field', _vm._b({
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "text-field", _vm.$props, false));
+  }, 'text-field', _vm.$props, false));
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34505,14 +34480,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("radio-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('radio-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34534,17 +34509,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("range-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('range-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34566,14 +34541,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("restore-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('restore-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34595,12 +34570,12 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _c("pre", [_vm._v(_vm._s(_vm.selected))]), _vm._v(" "), _c("multiselect", {
+  }, [_vm.label.length ? _c('label', [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _c('pre', [_vm._v(_vm._s(_vm.selected))]), _vm._v(" "), _c('multiselect', {
     attrs: {
-      options: _vm.options_1
+      "options": _vm.options_1
     },
     model: {
       value: _vm.selected,
@@ -34609,11 +34584,11 @@ var render = function render() {
       },
       expression: "selected"
     }
-  }), _vm._v(" "), _vm.validationMessages ? _c("div", {
+  }), _vm._v(" "), _vm.validationMessages ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validationMessages.type
+    class: 'cptm-' + _vm.validationMessages.type
   }, [_vm._v("\n            " + _vm._s(_vm.validationMessages.message) + "\n        ")])]) : _vm._e()], 1);
 };
 var staticRenderFns = [];
@@ -34636,17 +34611,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("select-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('select-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34668,20 +34643,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("shortcode-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('shortcode-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34703,20 +34678,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("shortcode-list-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('shortcode-list-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34738,14 +34713,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("tab-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('tab-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34767,29 +34742,29 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("text-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('text-field'), _vm._b({
     tag: "component",
     attrs: {
-      canChange: _vm.canChange
+      "canChange": _vm.canChange
     },
     on: {
-      enter: function enter($event) {
-        return _vm.$emit("enter", $event);
+      "enter": function enter($event) {
+        return _vm.$emit('enter', $event);
       },
-      blur: function blur($event) {
-        return _vm.$emit("blur", $event);
+      "blur": function blur($event) {
+        return _vm.$emit('blur', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34811,17 +34786,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("textarea-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('textarea-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34843,17 +34818,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("toggle-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('toggle-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34875,17 +34850,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("wp-media-picker-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('wp-media-picker-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34907,50 +34882,50 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("sub-fields-module", {
+  }, [_c('sub-fields-module', {
     attrs: {
       "option-fields": _vm.optionFields,
-      value: _vm.value
+      "value": _vm.value
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateOptionData($event);
       }
     }
-  }), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "settings-save-btn",
     attrs: {
-      type: "button",
-      disabled: _vm.button.is_disabled
+      "type": "button",
+      "disabled": _vm.button.is_disabled
     },
     domProps: {
-      innerHTML: _vm._s(_vm.button.label)
+      "innerHTML": _vm._s(_vm.button.label)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.submitAjaxRequest();
       }
     }
-  }), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback cptm-my-10"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n                    " + _vm._s(_vm.validation_message.message) + "\n                ")])]) : _vm._e()])])], 1);
 };
 var staticRenderFns = [];
@@ -34973,23 +34948,23 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-form-group-button-example",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "directorist-btn-example directorist-btn",
     class: _vm.buttonClass,
     style: _vm.buttonStyles
@@ -35015,29 +34990,29 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "settings-save-btn",
     attrs: {
-      href: _vm.formattedUrl,
-      target: _vm.openInNewTab ? "_blank" : "_self"
+      "href": _vm.formattedUrl,
+      "target": _vm.openInNewTab ? '_blank' : '_self'
     },
     domProps: {
-      innerHTML: _vm._s(_vm.buttonLabel)
+      "innerHTML": _vm._s(_vm.buttonLabel)
     }
   })])])]);
 };
@@ -35061,28 +35036,28 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-theme-butterfly"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-checkbox-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-checkbox-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -35091,20 +35066,20 @@ var render = function render() {
       }],
       staticClass: "cptm-checkbox",
       attrs: {
-        type: "checkbox",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "type": "checkbox",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId)
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, typeof option.value !== "undefined" ? option.value : "") > -1 : _vm.local_value
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '') > -1 : _vm.local_value
       },
       on: {
-        change: function change($event) {
+        "change": function change($event) {
           var $$a = _vm.local_value,
             $$el = $event.target,
             $$c = $$el.checked ? true : false;
           if (Array.isArray($$a)) {
-            var $$v = typeof option.value !== "undefined" ? option.value : "",
+            var $$v = typeof option.value !== 'undefined' ? option.value : '',
               $$i = _vm._i($$a, $$v);
             if ($$el.checked) {
               $$i < 0 && (_vm.local_value = $$a.concat([$$v]));
@@ -35116,32 +35091,32 @@ var render = function render() {
           }
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       staticClass: "cptm-checkbox-ui",
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       },
       domProps: {
-        innerHTML: _vm._s(option.label)
+        "innerHTML": _vm._s(option.label)
       }
     })]);
-  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c("p", {
+  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35173,30 +35148,30 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-color-picker-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-color-picker"
-  }, [_c("v-input-colorpicker", {
+  }, [_c('v-input-colorpicker', {
     attrs: {
-      value: _vm.local_value,
-      picker: "sketch"
+      "value": _vm.local_value,
+      "picker": "sketch"
     },
     model: {
       value: _vm.local_value,
@@ -35205,19 +35180,19 @@ var render = function render() {
       },
       expression: "local_value"
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-color-picker-label"
-  }, [_vm._v(_vm._s(_vm.local_value))])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.local_value))])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35249,32 +35224,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "settings-save-btn",
     attrs: {
-      href: "#",
-      target: "_blank"
+      "href": "#",
+      "target": "_blank"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.button_label)
+      "innerHTML": _vm._s(_vm.button_label)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.exportData.apply(null, arguments);
       }
@@ -35301,38 +35276,38 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.exportJSON();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-download"
-  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")])]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")])]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n                " + _vm._s(_vm.validation_message.message) + "\n            ")])]) : _vm._e()])]);
 };
 var staticRenderFns = [];
@@ -35355,43 +35330,43 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("input", {
+  }, [_c('input', {
     staticClass: "cptm-d-none",
     attrs: {
-      type: "file",
-      accept: ".json",
-      id: _vm.fieldId
+      "type": "file",
+      "accept": ".json",
+      "id": _vm.fieldId
     },
     on: {
-      input: _vm.importJSON
+      "input": _vm.importJSON
     }
-  }), _vm._v(" "), _c("label", {
+  }), _vm._v(" "), _c('label', {
     staticClass: "cptm-btn cptm-label-btn cptm-btn-secondery",
     attrs: {
-      for: _vm.fieldId
+      "for": _vm.fieldId
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-upload"
-  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n                    " + _vm._s(_vm.validation_message.message) + "\n                ")])]) : _vm._e()])])]);
 };
 var staticRenderFns = [];
@@ -35414,19 +35389,19 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-note"
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "fa fa-info-circle"
-  }), _vm._v(" "), _c("div", [_c("h2", {
+  }), _vm._v(" "), _c('div', [_c('h2', {
     staticClass: "cptm-form-note-title",
     domProps: {
-      innerHTML: _vm._s(_vm.title)
+      "innerHTML": _vm._s(_vm.title)
     }
-  }), _vm._v(" "), _vm.description.length ? _c("div", {
+  }), _vm._v(" "), _vm.description.length ? _c('div', {
     staticClass: "cptm-form-note-content",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
   }) : _vm._e()])]);
 };
@@ -35450,30 +35425,30 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-preview-wrapper"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-radio-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-radio-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -35482,37 +35457,37 @@ var render = function render() {
       }],
       staticClass: "cptm-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
     }, [_vm._v("\n                " + _vm._s(option.label) + "\n              ")])]);
-  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c("p", {
+  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v("\n            " + _vm._s(_vm.infoTextForNoOption) + "\n          ")]) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v("\n            " + _vm._s(_vm.infoTextForNoOption) + "\n          ")]) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35522,12 +35497,12 @@ var render = function render() {
       },
       expression: "validationLog"
     }
-  }), _vm._v(" "), _vm.preview ? _c("div", {
+  }), _vm._v(" "), _vm.preview ? _c('div', {
     staticClass: "cptm-preview-area-archive"
   }, _vm._l(Object.keys(_vm.preview), function (previewKey) {
-    return _vm.local_value === previewKey ? _c("img", {
+    return _vm.local_value === previewKey ? _c('img', {
       attrs: {
-        src: _vm.preview[previewKey]
+        "src": _vm.preview[previewKey]
       }
     }) : _vm._e();
   }), 0) : _vm._e()], 1)])])]);
@@ -35552,33 +35527,33 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-range-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-range-bar"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_slider-range"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_range-bar"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_range-fill",
     style: _vm.rangeFillStyle
-  })]), _vm._v(" "), _c("input", {
+  })]), _vm._v(" "), _c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -35587,36 +35562,36 @@ var render = function render() {
     }],
     staticClass: "directorist_slider-input",
     attrs: {
-      type: "range",
-      id: _vm.fieldId,
-      step: _vm.theStep,
-      min: _vm.theMin,
-      max: _vm.theMax,
-      name: _vm.name
+      "type": "range",
+      "id": _vm.fieldId,
+      "step": _vm.theStep,
+      "min": _vm.theMin,
+      "max": _vm.theMax,
+      "name": _vm.name
     },
     domProps: {
-      value: _vm.range_value
+      "value": _vm.range_value
     },
     on: {
-      __r: function __r($event) {
+      "__r": function __r($event) {
         _vm.range_value = $event.target.value;
       }
     }
-  })])]), _vm._v(" "), _c("div", {
+  })])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-form-range-output"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-form-range-output-text"
-  }, [_vm._v(_vm._s(_vm.range_value))])])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.range_value))])])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35648,38 +35623,38 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.restore();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-sync-alt"
-  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n                    " + _vm._s(_vm.validation_message.message) + "\n                ")])]) : _vm._e()])])]);
 };
 var staticRenderFns = [];
@@ -35705,118 +35680,118 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", {
+  }, [_vm.label.length ? _c('label', {
     class: {
-      "atbdp-label-icon-wrapper": _vm.icon.length
+      'atbdp-label-icon-wrapper': _vm.icon.length
     }
-  }, [_vm.icon.length ? _c("div", {
+  }, [_vm.icon.length ? _c('div', {
     staticClass: "atbdp-label-icon",
     domProps: {
-      innerHTML: _vm._s(_vm.icon)
+      "innerHTML": _vm._s(_vm.icon)
     }
   }) : _vm._e(), _vm._v(" "), _c(_vm.labelType, {
     tag: "component",
     domProps: {
-      innerHTML: _vm._s(_vm.label)
+      "innerHTML": _vm._s(_vm.label)
     }
-  })], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  })], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_dropdown",
-    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "--open", _vm.show_option_modal)
-  }, [_c("a", {
+    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, '--open', _vm.show_option_modal)
+  }, [_c('a', {
     staticClass: "directorist_dropdown-toggle",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.toggleTheOptionModal();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_dropdown-toggle__text"
-  }, [_vm._v(_vm._s(_vm.theCurrentOptionLabel))])]), _vm._v(" "), _vm.theOptions ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.theCurrentOptionLabel))])]), _vm._v(" "), _vm.theOptions ? _c('div', {
     staticClass: "directorist_dropdown-option",
-    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "--show", _vm.show_option_modal)
-  }, [_c("ul", [_vm.showDefaultOption && _vm.theDefaultOption ? _c("li", [_c("a", {
+    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, '--show', _vm.show_option_modal)
+  }, [_c('ul', [_vm.showDefaultOption && _vm.theDefaultOption ? _c('li', [_c('a', {
     attrs: {
-      href: "#"
+      "href": "#"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.theDefaultOption.label ? _vm.theDefaultOption.label : "")
+      "innerHTML": _vm._s(_vm.theDefaultOption.label ? _vm.theDefaultOption.label : '')
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.updateOption(_vm.theDefaultOption.value);
       }
     }
   })]) : _vm._e(), _vm._v(" "), _vm._l(_vm.theOptions, function (option, option_key) {
-    return _c("li", {
+    return _c('li', {
       key: option_key
-    }, [_c("a", {
+    }, [_c('a', {
       class: {
         active: option.value == _vm.value ? true : false
       },
       attrs: {
-        href: "#"
+        "href": "#"
       },
       domProps: {
-        innerHTML: _vm._s(option.label ? option.label : "")
+        "innerHTML": _vm._s(option.label ? option.label : '')
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.updateOption(option.value);
         }
       }
     })]);
-  })], 2)]) : _vm._e()]), _vm._v(" "), _c("select", {
+  })], 2)]) : _vm._e()]), _vm._v(" "), _c('select', {
     staticClass: "cptm-d-none",
     domProps: {
-      value: _vm.local_value
+      "value": _vm.local_value
     },
     on: {
-      change: function change($event) {
+      "change": function change($event) {
         return _vm.update_value($event.target.value);
       }
     }
-  }, [_vm.showDefaultOption && _vm.theDefaultOption ? _c("option", {
+  }, [_vm.showDefaultOption && _vm.theDefaultOption ? _c('option', {
     domProps: {
-      value: _vm.theDefaultOption.value
+      "value": _vm.theDefaultOption.value
     }
   }, [_vm._v(_vm._s(_vm.theDefaultOption.label))]) : _vm._e(), _vm._v(" "), _vm._l(_vm.theOptions, function (option, option_key) {
-    return _c("option", {
+    return _c('option', {
       key: option_key,
       domProps: {
-        value: option.value
+        "value": option.value
       }
     }, [_vm._v("\n                    " + _vm._s(option.label) + "\n                ")]);
-  })], 2), _vm._v(" "), _c("form-field-validatior", {
+  })], 2), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35848,38 +35823,38 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [!_vm.generateShortcode ? _c("input", {
+  }, [!_vm.generateShortcode ? _c('input', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button",
-      value: "Generate Shortcode"
+      "type": "button",
+      "value": "Generate Shortcode"
     },
     on: {
-      click: _vm.generate
+      "click": _vm.generate
     }
-  }) : _vm._e(), _vm._v(" "), _vm.generateShortcode ? _c("div", {
+  }) : _vm._e(), _vm._v(" "), _vm.generateShortcode ? _c('div', {
     ref: "shortcode",
     staticClass: "cptm-shortcode",
     on: {
-      click: _vm.copyToClip
+      "click": _vm.copyToClip
     }
-  }, [_vm._v(_vm._s(_vm.shortcode))]) : _vm._e(), _vm._v(" "), _vm.successMsg.length ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.shortcode))]) : _vm._e(), _vm._v(" "), _vm.successMsg.length ? _c('div', {
     staticClass: "cptm-info-text cptm-info-success"
   }, [_vm._v(_vm._s(_vm.successMsg))]) : _vm._e()])])]);
 };
@@ -35903,68 +35878,68 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-mb-n20"
-  }, [_vm.successMsg.length ? _c("span", {
+  }, [_vm.successMsg.length ? _c('span', {
     staticClass: "cptm-info-text cptm-info-success directorist-center-content-inline",
     domProps: {
-      innerHTML: _vm._s(_vm.successMsg)
+      "innerHTML": _vm._s(_vm.successMsg)
     }
-  }) : _vm._e(), _vm._v(" "), _vm.shortcodes_list.length ? _c("button", {
+  }) : _vm._e(), _vm._v(" "), _vm.shortcodes_list.length ? _c('button', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
-        return _vm.copyToClip("all-shortcodes");
+      "click": function click($event) {
+        return _vm.copyToClip('all-shortcodes');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.copyButtonLabel)
+      "innerHTML": _vm._s(_vm.copyButtonLabel)
     }
-  })]) : _vm._e(), _vm._v(" "), _c("button", {
+  })]) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: _vm.generateShortcode
+      "click": _vm.generateShortcode
     }
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.generateButtonLabel)
+      "innerHTML": _vm._s(_vm.generateButtonLabel)
     }
-  })])]), _vm._v(" "), _vm.dirty ? _c("div", [_vm.shortcodes_list.length ? _c("div", {
+  })])]), _vm._v(" "), _vm.dirty ? _c('div', [_vm.shortcodes_list.length ? _c('div', {
     staticClass: "cptm-shortcodes"
   }, _vm._l(_vm.shortcodes_list, function (shortcode, i) {
-    return _c("p", {
+    return _c('p', {
       key: i,
       ref: "shortcodes",
       refInFor: true,
       staticClass: "directorist-alert",
       domProps: {
-        innerHTML: _vm._s(shortcode)
+        "innerHTML": _vm._s(shortcode)
       }
     });
-  }), 0) : _c("div", [_c("p", {
+  }), 0) : _c('div', [_c('p', {
     staticClass: "directorist-alert"
   }, [_vm._v("Nothing to generate")])])]) : _vm._e()])])]);
 };
@@ -35988,25 +35963,25 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group tab-field"
-  }, [_vm.schema.length ? _c("div", {
+  }, [_vm.schema.length ? _c('div', {
     staticClass: "cptm-schema-tab-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-schema-tab-label"
-  }, [_vm._v("\n        " + _vm._s(_vm.schema) + "\n      ")]), _vm._v(" "), _c("div", {
+  }, [_vm._v("\n        " + _vm._s(_vm.schema) + "\n      ")]), _vm._v(" "), _c('div', {
     staticClass: "cptm-schema-tab-wrapper",
     class: {
-      "cptm-schema-multi-directory-disabled": !_vm.multi_directory_status
+      'cptm-schema-multi-directory-disabled': !_vm.multi_directory_status
     }
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-schema-tab-item",
       class: {
-        active: _vm.local_value === option.value
+        'active': _vm.local_value === option.value
       }
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -36015,47 +35990,47 @@ var render = function render() {
       }],
       staticClass: "cptm-schema-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       staticClass: "cptm-schema-label-wrapper",
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "cptm-schema-label"
-    }, [_vm._v("\n              " + _vm._s(option.label) + "\n              "), !_vm.multi_directory_status.length ? _c("span", {
+    }, [_vm._v("\n              " + _vm._s(option.label) + "\n              "), !_vm.multi_directory_status.length ? _c('span', {
       staticClass: "cptm-schema-label-badge"
-    }, [_vm._v("Multi Directory Disabled")]) : _vm._e()]), _vm._v(" "), _c("div", {
+    }, [_vm._v("Multi Directory Disabled")]) : _vm._e()]), _vm._v(" "), _c('div', {
       staticClass: "cptm-schema-label-description"
     }, [_vm._v("\n                " + _vm._s(option.description) + "\n              ")])])]);
-  }), 0)]) : _c("div", {
+  }), 0)]) : _c('div', {
     staticClass: "cptm-preview-wrapper"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-tab-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-tab-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -36064,35 +36039,35 @@ var render = function render() {
       }],
       staticClass: "cptm-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
     }, [_vm._v("\n          " + _vm._s(option.label) + "\n        ")])]);
-  }), 0), _vm._v(" "), _c("form-field-validatior", {
+  }), 0), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36127,60 +36102,60 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, ["hidden" !== _vm.input_type && _vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, ['hidden' !== _vm.input_type && _vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) !== "object" ? true : false) ? _c("input", {
+  }, [(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) !== 'object' ? true : false) ? _c('input', {
     staticClass: "cptm-form-control",
     class: _vm.formControlClass,
     attrs: {
-      id: _vm.fieldId,
-      type: _vm.input_type,
-      min: _vm.min,
-      max: _vm.max,
-      step: _vm.step,
-      placeholder: _vm.placeholder,
-      disabled: _vm.disable
+      "id": _vm.fieldId,
+      "type": _vm.input_type,
+      "min": _vm.min,
+      "max": _vm.max,
+      "step": _vm.step,
+      "placeholder": _vm.placeholder,
+      "disabled": _vm.disable
     },
     domProps: {
-      value: _vm.filteredValue === false ? "" : _vm.filteredValue
+      "value": _vm.filteredValue === false ? '' : _vm.filteredValue
     },
     on: {
-      input: function input($event) {
-        return _vm.$emit("update", $event.target.value);
+      "input": function input($event) {
+        return _vm.$emit('update', $event.target.value);
       }
     }
-  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) === "object" ? true : false) ? _c("input", {
+  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) === 'object' ? true : false) ? _c('input', {
     attrs: {
-      type: "hidden"
+      "type": "hidden"
     },
     domProps: {
-      value: JSON.stringify(_vm.filteredValue)
+      "value": JSON.stringify(_vm.filteredValue)
     }
-  }) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.filteredValue,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.filteredValue,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36212,23 +36187,23 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("textarea", {
+  }, [_c('textarea', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -36237,32 +36212,32 @@ var render = function render() {
     }],
     staticClass: "cptm-form-control",
     attrs: {
-      name: "",
-      id: "",
-      cols: _vm.cols,
-      rows: _vm.rows,
-      placeholder: _vm.placeholder
+      "name": "",
+      "id": "",
+      "cols": _vm.cols,
+      "rows": _vm.rows,
+      "placeholder": _vm.placeholder
     },
     domProps: {
-      value: _vm.local_value
+      "value": _vm.local_value
     },
     on: {
-      input: function input($event) {
+      "input": function input($event) {
         if ($event.target.composing) return;
         _vm.local_value = $event.target.value;
       }
     }
-  }), _vm._v(" "), _c("form-field-validatior", {
+  }), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.local_value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.local_value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36294,34 +36269,34 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_vertical-align-m"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_item"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-input-toggle",
     class: _vm.toggleClass,
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.toggleValue();
       }
     }
-  }), _vm._v(" "), _c("input", {
+  }), _vm._v(" "), _c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -36329,18 +36304,18 @@ var render = function render() {
       expression: "local_value"
     }],
     staticStyle: {
-      display: "none"
+      "display": "none"
     },
     attrs: {
-      type: "checkbox",
-      id: _vm.name,
-      name: _vm.name
+      "type": "checkbox",
+      "id": _vm.name,
+      "name": _vm.name
     },
     domProps: {
-      checked: Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, null) > -1 : _vm.local_value
+      "checked": Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, null) > -1 : _vm.local_value
     },
     on: {
-      change: function change($event) {
+      "change": function change($event) {
         var $$a = _vm.local_value,
           $$el = $event.target,
           $$c = $$el.checked ? true : false;
@@ -36357,26 +36332,26 @@ var render = function render() {
         }
       }
     }
-  })]), _vm._v(" "), _c("div", {
+  })]), _vm._v(" "), _c('div', {
     staticClass: "directorist_item"
-  }, [_vm.compLinkIsEnable ? _c("a", {
+  }, [_vm.compLinkIsEnable ? _c('a', {
     staticClass: "cptm-btn cptm-btn-outline directorist_btn-start",
     class: _vm.compLinkClass,
     attrs: {
-      href: _vm.link,
-      target: _vm.comp.link.target
+      "href": _vm.link,
+      "target": _vm.comp.link.target
     }
-  }, [_vm._v("\n                        " + _vm._s(_vm.comp.link.label) + "\n                    ")]) : _vm._e()])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v("\n                        " + _vm._s(_vm.comp.link.label) + "\n                    ")]) : _vm._e()])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36386,13 +36361,13 @@ var render = function render() {
       },
       expression: "validationLog"
     }
-  })], 1)]), _vm._v(" "), _c("confirmation-modal", _vm._b({
+  })], 1)]), _vm._v(" "), _c('confirmation-modal', _vm._b({
     on: {
-      cancel: function cancel($event) {
+      "cancel": function cancel($event) {
         return _vm.confirmationOnCancel();
       }
     }
-  }, "confirmation-modal", _vm.confirmation, false))], 1);
+  }, 'confirmation-modal', _vm.confirmation, false))], 1);
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -36414,66 +36389,66 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-thumbnail"
-  }, [_vm.thumbnailSrc.length ? _c("div", {
+  }, [_vm.thumbnailSrc.length ? _c('div', {
     staticClass: "cptm-thumbnail-img-wrap"
-  }, [_c("img", {
+  }, [_c('img', {
     staticClass: "cptm-thumbnail-img",
     attrs: {
-      src: _vm.thumbnailSrc,
-      width: "100%",
-      height: "auto"
+      "src": _vm.thumbnailSrc,
+      "width": "100%",
+      "height": "auto"
     }
-  }), _vm._v(" "), _vm.hasThumbnail ? _c("span", {
+  }), _vm._v(" "), _vm.hasThumbnail ? _c('span', {
     staticClass: "cptm-thumbnail-action action-trash",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.deleteThumbnail();
       }
     }
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-trash-alt"
-  })]) : _vm._e()]) : _vm._e(), _vm._v(" "), !_vm.thumbnailSrc.length ? _c("span", {
+  })]) : _vm._e()]) : _vm._e(), _vm._v(" "), !_vm.thumbnailSrc.length ? _c('span', {
     staticClass: "cptm-thumbnail-placeholder"
-  }, [_vm._m(0)]) : _vm._e()]), _vm._v(" "), _c("input", {
+  }, [_vm._m(0)]) : _vm._e()]), _vm._v(" "), _c('input', {
     staticClass: "cptm-btn cptm-btn-primary",
     attrs: {
-      type: "button",
-      value: _vm.theButtonLabel
+      "type": "button",
+      "value": _vm.theButtonLabel
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.openMediaPicker.apply(null, arguments);
       }
     }
-  }), _vm._v(" "), _c("form-field-validatior", {
+  }), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36488,9 +36463,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("span", {
+  return _c('span', {
     staticClass: "cptm-thumbnail-placeholder-icon"
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-image"
   })]);
 }];
@@ -36513,35 +36488,35 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("button", {
+  }) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "settings-save-btn",
     attrs: {
-      type: "button",
-      disabled: _vm.button.is_disabled
+      "type": "button",
+      "disabled": _vm.button.is_disabled
     },
     domProps: {
-      innerHTML: _vm._s(_vm.button.label)
+      "innerHTML": _vm._s(_vm.button.label)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.submitAjaxRequest();
       }
     }
-  }), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback cptm-my-10"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n            " + _vm._s(_vm.validation_message.message) + "\n        ")])]) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -36564,22 +36539,22 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-checkbox-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-checkbox-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -36588,20 +36563,20 @@ var render = function render() {
       }],
       staticClass: "cptm-checkbox",
       attrs: {
-        type: "checkbox",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "type": "checkbox",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId)
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, typeof option.value !== "undefined" ? option.value : "") > -1 : _vm.local_value
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '') > -1 : _vm.local_value
       },
       on: {
-        change: function change($event) {
+        "change": function change($event) {
           var $$a = _vm.local_value,
             $$el = $event.target,
             $$c = $$el.checked ? true : false;
           if (Array.isArray($$a)) {
-            var $$v = typeof option.value !== "undefined" ? option.value : "",
+            var $$v = typeof option.value !== 'undefined' ? option.value : '',
               $$i = _vm._i($$a, $$v);
             if ($$el.checked) {
               $$i < 0 && (_vm.local_value = $$a.concat([$$v]));
@@ -36613,32 +36588,32 @@ var render = function render() {
           }
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       staticClass: "cptm-checkbox-ui",
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       },
       domProps: {
-        innerHTML: _vm._s(option.label + " " + option_index)
+        "innerHTML": _vm._s(option.label + ' ' + option_index)
       }
     })]);
-  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c("p", {
+  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36670,30 +36645,30 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-color-picker-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-color-picker"
-  }, [_c("v-input-colorpicker", {
+  }, [_c('v-input-colorpicker', {
     attrs: {
-      value: _vm.local_value,
-      picker: "sketch"
+      "value": _vm.local_value,
+      "picker": "sketch"
     },
     model: {
       value: _vm.local_value,
@@ -36702,24 +36677,24 @@ var render = function render() {
       },
       expression: "local_value"
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-color-picker-label"
-  }, [_vm._v(_vm._s(_vm.local_value))])]), _vm._v(" "), _vm.validationMessages ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.local_value))])]), _vm._v(" "), _vm.validationMessages ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validationMessages.type
-  }, [_vm._v("\n                    " + _vm._s(_vm.validationMessages.message) + "\n                ")])]) : _vm._e()])]), _vm._v(" "), _c("form-field-validatior", {
+    class: 'cptm-' + _vm.validationMessages.type
+  }, [_vm._v("\n                    " + _vm._s(_vm.validationMessages.message) + "\n                ")])]) : _vm._e()])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36751,26 +36726,26 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("a", {
+  }) : _vm._e(), _vm._v(" "), _c('a', {
     staticClass: "settings-save-btn",
     attrs: {
-      href: "#",
-      target: "_blank"
+      "href": "#",
+      "target": "_blank"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.button_label)
+      "innerHTML": _vm._s(_vm.button_label)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.exportData.apply(null, arguments);
       }
@@ -36797,32 +36772,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("button", {
+  }) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.exportJSON();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-download"
-  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n            " + _vm._s(_vm.validation_message.message) + "\n        ")])]) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -36845,37 +36820,37 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("input", {
+  }) : _vm._e(), _vm._v(" "), _c('input', {
     staticClass: "cptm-d-none",
     attrs: {
-      type: "file",
-      accept: ".json",
-      id: _vm.fieldId
+      "type": "file",
+      "accept": ".json",
+      "id": _vm.fieldId
     },
     on: {
-      input: _vm.importJSON
+      "input": _vm.importJSON
     }
-  }), _vm._v(" "), _c("label", {
+  }), _vm._v(" "), _c('label', {
     staticClass: "cptm-btn cptm-label-btn cptm-btn-secondery",
     attrs: {
-      for: _vm.fieldId
+      "for": _vm.fieldId
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-upload"
-  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n            " + _vm._s(_vm.validation_message.message) + "\n        ")])]) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -36898,19 +36873,19 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-note"
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "fa fa-info-circle"
-  }), _vm._v(" "), _c("div", [_c("h2", {
+  }), _vm._v(" "), _c('div', [_c('h2', {
     staticClass: "cptm-form-note-title",
     domProps: {
-      innerHTML: _vm._s(_vm.title)
+      "innerHTML": _vm._s(_vm.title)
     }
-  }), _vm._v(" "), _vm.description.length ? _c("div", {
+  }), _vm._v(" "), _vm.description.length ? _c('div', {
     staticClass: "cptm-form-note-content",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
   }) : _vm._e()])]);
 };
@@ -36934,24 +36909,24 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-preview-wrapper"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-preview-radio-area"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-info-text",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-radio-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-radio-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -36960,37 +36935,37 @@ var render = function render() {
       }],
       staticClass: "cptm-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
     }, [_vm._v("\n                    " + _vm._s(option.label) + "\n                ")])]);
-  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c("p", {
+  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37000,12 +36975,12 @@ var render = function render() {
       },
       expression: "validationLog"
     }
-  })], 1), _vm._v(" "), _vm.preview ? _c("div", {
+  })], 1), _vm._v(" "), _vm.preview ? _c('div', {
     staticClass: "cptm-preview-area-archive"
   }, _vm._l(Object.keys(_vm.preview), function (previewKey) {
-    return _vm.local_value === previewKey ? _c("img", {
+    return _vm.local_value === previewKey ? _c('img', {
       attrs: {
-        src: _vm.preview[previewKey]
+        "src": _vm.preview[previewKey]
       }
     }) : _vm._e();
   }), 0) : _vm._e()]);
@@ -37030,27 +37005,27 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-form-range-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-range-bar"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_slider-range"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_range-bar"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_range-fill",
     style: _vm.rangeFillStyle
-  })]), _vm._v(" "), _c("input", {
+  })]), _vm._v(" "), _c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -37059,36 +37034,36 @@ var render = function render() {
     }],
     staticClass: "directorist_slider-input",
     attrs: {
-      type: "range",
-      id: _vm.fieldId,
-      step: _vm.theStep,
-      min: _vm.theMin,
-      max: _vm.theMax,
-      name: _vm.name
+      "type": "range",
+      "id": _vm.fieldId,
+      "step": _vm.theStep,
+      "min": _vm.theMin,
+      "max": _vm.theMax,
+      "name": _vm.name
     },
     domProps: {
-      value: _vm.range_value
+      "value": _vm.range_value
     },
     on: {
-      __r: function __r($event) {
+      "__r": function __r($event) {
         _vm.range_value = $event.target.value;
       }
     }
-  })])]), _vm._v(" "), _c("div", {
+  })])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-form-range-output"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-form-range-output-text"
-  }, [_vm._v(_vm._s(_vm.range_value))])])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.range_value))])])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37120,32 +37095,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("button", {
+  }) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.restore();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-sync-alt"
-  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n            " + _vm._s(_vm.validation_message.message) + "\n        ")])]) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -37171,87 +37146,87 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "directorist_dropdown",
-    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "--open", _vm.show_option_modal)
-  }, [_c("a", {
+    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, '--open', _vm.show_option_modal)
+  }, [_c('a', {
     staticClass: "directorist_dropdown-toggle",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.toggleTheOptionModal();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_dropdown-toggle__text"
-  }, [_vm._v(_vm._s(_vm.theCurrentOptionLabel))])]), _vm._v(" "), _vm.theOptions ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.theCurrentOptionLabel))])]), _vm._v(" "), _vm.theOptions ? _c('div', {
     staticClass: "directorist_dropdown-option",
-    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "--show", _vm.show_option_modal)
-  }, [_c("ul", _vm._l(_vm.theOptions, function (option, option_key) {
-    return _c("li", {
+    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, '--show', _vm.show_option_modal)
+  }, [_c('ul', _vm._l(_vm.theOptions, function (option, option_key) {
+    return _c('li', {
       key: option_key
-    }, [_c("a", {
+    }, [_c('a', {
       class: {
         active: option.value == _vm.value ? true : false
       },
       attrs: {
-        href: "#"
+        "href": "#"
       },
       domProps: {
-        innerHTML: _vm._s(option.label ? option.label : "")
+        "innerHTML": _vm._s(option.label ? option.label : '')
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.updateOption(option.value);
         }
       }
     })]);
-  }), 0)]) : _vm._e()]), _vm._v(" "), _c("select", {
+  }), 0)]) : _vm._e()]), _vm._v(" "), _c('select', {
     staticClass: "cptm-d-none",
     domProps: {
-      value: _vm.local_value
+      "value": _vm.local_value
     },
     on: {
-      change: function change($event) {
+      "change": function change($event) {
         return _vm.update_value($event.target.value);
       }
     }
-  }, [_vm.showDefaultOption && _vm.default_option ? _c("option", {
+  }, [_vm.showDefaultOption && _vm.default_option ? _c('option', {
     domProps: {
-      value: _vm.default_option.value
+      "value": _vm.default_option.value
     }
   }, [_vm._v(_vm._s(_vm.default_option.label))]) : _vm._e(), _vm._v(" "), _vm._l(_vm.theOptions, function (option, option_key) {
-    return [_c("option", {
+    return [_c('option', {
       key: option_key,
       domProps: {
-        value: option.value
+        "value": option.value
       }
     }, [_vm._v(_vm._s(option.label))])];
-  })], 2), _vm._v(" "), _c("form-field-validatior", {
+  })], 2), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37283,32 +37258,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.generateShortcode ? _c("input", {
+  }) : _vm._e(), _vm._v(" "), !_vm.generateShortcode ? _c('input', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button",
-      value: "Generate Shortcode"
+      "type": "button",
+      "value": "Generate Shortcode"
     },
     on: {
-      click: _vm.generate
+      "click": _vm.generate
     }
-  }) : _vm._e(), _vm._v(" "), _vm.generateShortcode ? _c("div", {
+  }) : _vm._e(), _vm._v(" "), _vm.generateShortcode ? _c('div', {
     ref: "shortcode",
     staticClass: "cptm-shortcode",
     on: {
-      click: _vm.copyToClip
+      "click": _vm.copyToClip
     }
-  }, [_vm._v(_vm._s(_vm.shortcode))]) : _vm._e(), _vm._v(" "), _vm.successMsg.length ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.shortcode))]) : _vm._e(), _vm._v(" "), _vm.successMsg.length ? _c('div', {
     staticClass: "cptm-info-text cptm-info-success"
   }, [_vm._v(_vm._s(_vm.successMsg))]) : _vm._e()]);
 };
@@ -37332,67 +37307,67 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-6"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-6 directorist-text-right directorist-mb-n20"
-  }, [_vm.successMsg.length ? _c("span", {
+  }, [_vm.successMsg.length ? _c('span', {
     staticClass: "cptm-info-text cptm-info-success directorist-center-content-inline",
     domProps: {
-      innerHTML: _vm._s(_vm.successMsg)
+      "innerHTML": _vm._s(_vm.successMsg)
     }
-  }) : _vm._e(), _vm._v(" "), _vm.shortcodes_list.length ? _c("button", {
+  }) : _vm._e(), _vm._v(" "), _vm.shortcodes_list.length ? _c('button', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
-        return _vm.copyToClip("all-shortcodes");
+      "click": function click($event) {
+        return _vm.copyToClip('all-shortcodes');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.copyButtonLabel)
+      "innerHTML": _vm._s(_vm.copyButtonLabel)
     }
-  })]) : _vm._e(), _vm._v(" "), _c("button", {
+  })]) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: _vm.generateShortcode
+      "click": _vm.generateShortcode
     }
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.generateButtonLabel)
+      "innerHTML": _vm._s(_vm.generateButtonLabel)
     }
-  })])])]), _vm._v(" "), _vm.dirty ? _c("div", [_vm.shortcodes_list.length ? _c("div", {
+  })])])]), _vm._v(" "), _vm.dirty ? _c('div', [_vm.shortcodes_list.length ? _c('div', {
     ref: "all-shortcodes",
     staticClass: "cptm-shortcodes"
   }, _vm._l(_vm.shortcodes_list, function (shortcode, i) {
-    return _c("p", {
+    return _c('p', {
       key: i,
       ref: "shortcodes",
       refInFor: true,
       staticClass: "directorist-alert",
       domProps: {
-        innerHTML: _vm._s(shortcode)
+        "innerHTML": _vm._s(shortcode)
       }
     });
-  }), 0) : _c("div", [_c("p", {
+  }), 0) : _c('div', [_c('p', {
     staticClass: "directorist-alert"
   }, [_vm._v("Nothing to generate")])])]) : _vm._e()]);
 };
@@ -37416,24 +37391,24 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-preview-wrapper tab-field"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-tab-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-tab-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-tab-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -37442,35 +37417,35 @@ var render = function render() {
       }],
       staticClass: "cptm-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
     }, [_vm._v("\n          " + _vm._s(option.label) + "\n        ")])]);
-  }), 0), _vm._v(" "), _c("form-field-validatior", {
+  }), 0), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37505,57 +37480,57 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, ["hidden" !== _vm.input_type && _vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, ['hidden' !== _vm.input_type && _vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) !== "object" ? true : false) ? _c("input", {
+  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) !== 'object' ? true : false) ? _c('input', {
     staticClass: "cptm-form-control",
     class: _vm.formControlClass,
     attrs: {
-      type: _vm.input_type,
-      placeholder: _vm.placeholder,
-      disabled: _vm.disable
+      "type": _vm.input_type,
+      "placeholder": _vm.placeholder,
+      "disabled": _vm.disable
     },
     domProps: {
-      value: _vm.filteredValue
+      "value": _vm.filteredValue
     },
     on: {
-      keyup: function keyup($event) {
-        if (!$event.type.indexOf("key") && _vm._k($event.keyCode, "enter", 13, $event.key, "Enter")) return null;
-        return _vm.$emit("enter", $event.target.value);
+      "keyup": function keyup($event) {
+        if (!$event.type.indexOf('key') && _vm._k($event.keyCode, "enter", 13, $event.key, "Enter")) return null;
+        return _vm.$emit('enter', $event.target.value);
       },
-      blur: function blur($event) {
-        return _vm.$emit("blur", $event.target.value);
+      "blur": function blur($event) {
+        return _vm.$emit('blur', $event.target.value);
       },
-      input: function input($event) {
-        return _vm.$emit("update", $event.target.value);
+      "input": function input($event) {
+        return _vm.$emit('update', $event.target.value);
       }
     }
-  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) === "object" ? true : false) ? _c("input", {
+  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) === 'object' ? true : false) ? _c('input', {
     attrs: {
-      type: "hidden"
+      "type": "hidden"
     },
     domProps: {
-      value: JSON.stringify(_vm.filteredValue)
+      "value": JSON.stringify(_vm.filteredValue)
     }
-  }) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.filteredValue,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.filteredValue,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37587,22 +37562,22 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _vm.editor ? _c("div", {
+  }) : _vm._e(), _vm._v(" "), _vm.editor ? _c('div', {
     staticClass: "cptm-form-control",
     attrs: {
-      id: _vm.editorID
+      "id": _vm.editorID
     }
-  }) : _c("textarea", {
+  }) : _c('textarea', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -37611,31 +37586,31 @@ var render = function render() {
     }],
     staticClass: "cptm-form-control",
     attrs: {
-      name: "",
-      cols: _vm.cols,
-      rows: _vm.rows,
-      placeholder: _vm.placeholder
+      "name": "",
+      "cols": _vm.cols,
+      "rows": _vm.rows,
+      "placeholder": _vm.placeholder
     },
     domProps: {
-      value: _vm.local_value
+      "value": _vm.local_value
     },
     on: {
-      input: function input($event) {
+      "input": function input($event) {
         if ($event.target.composing) return;
         _vm.local_value = $event.target.value;
       }
     }
-  }), _vm._v(" "), _c("form-field-validatior", {
+  }), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.local_value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.local_value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37667,25 +37642,25 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-input-toggle-wrap"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "directorist_vertical-align-m"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_item"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-input-toggle",
     class: _vm.toggleClass,
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.toggleValue();
       }
     }
-  }), _vm._v(" "), _c("input", {
+  }), _vm._v(" "), _c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -37693,18 +37668,18 @@ var render = function render() {
       expression: "local_value"
     }],
     staticStyle: {
-      display: "none"
+      "display": "none"
     },
     attrs: {
-      type: "checkbox",
-      id: _vm.name,
-      name: _vm.name
+      "type": "checkbox",
+      "id": _vm.name,
+      "name": _vm.name
     },
     domProps: {
-      checked: Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, null) > -1 : _vm.local_value
+      "checked": Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, null) > -1 : _vm.local_value
     },
     on: {
-      change: function change($event) {
+      "change": function change($event) {
         var $$a = _vm.local_value,
           $$el = $event.target,
           $$c = $$el.checked ? true : false;
@@ -37721,40 +37696,40 @@ var render = function render() {
         }
       }
     }
-  })]), _vm._v(" "), _c("div", {
+  })]), _vm._v(" "), _c('div', {
     staticClass: "directorist_item"
-  }, [_vm.compLinkIsEnable ? _c("a", {
+  }, [_vm.compLinkIsEnable ? _c('a', {
     staticClass: "cptm-btn cptm-btn-outline directorist_btn-start",
     class: _vm.compLinkClass,
     attrs: {
-      href: _vm.comp.link.url,
-      target: _vm.comp.link.target
+      "href": _vm.comp.link.url,
+      "target": _vm.comp.link.target
     },
     domProps: {
-      innerHTML: _vm._s(_vm.comp.link.label)
+      "innerHTML": _vm._s(_vm.comp.link.label)
     }
-  }) : _vm._e()])]), _vm._v(" "), _vm.description.length ? _c("p", {
+  }) : _vm._e()])]), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("confirmation-modal", _vm._b({
+  }) : _vm._e()]), _vm._v(" "), _c('confirmation-modal', _vm._b({
     on: {
-      cancel: function cancel($event) {
+      "cancel": function cancel($event) {
         return _vm.confirmationOnCancel();
       }
     }
-  }, "confirmation-modal", _vm.confirmation, false)), _vm._v(" "), _c("form-field-validatior", {
+  }, 'confirmation-modal', _vm.confirmation, false)), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37786,104 +37761,104 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-preview-image-upload",
-    class: _vm.thumbnailSrc.length ? "cptm-preview-image-upload--show" : ""
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+    class: _vm.thumbnailSrc.length ? 'cptm-preview-image-upload--show' : ''
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-thumbnail"
-  }, [_vm.hasThumbnail ? _c("span", {
+  }, [_vm.hasThumbnail ? _c('span', {
     staticClass: "cptm-thumbnail-action action-trash",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.deleteThumbnail();
       }
     }
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-trash-alt"
-  })]) : _vm._e(), _vm._v(" "), _vm.thumbnailSrc.length ? _c("div", {
+  })]) : _vm._e(), _vm._v(" "), _vm.thumbnailSrc.length ? _c('div', {
     staticClass: "cptm-thumbnail-img-wrap"
-  }, [_c("img", {
+  }, [_c('img', {
     staticClass: "cptm-thumbnail-img",
     attrs: {
-      src: _vm.thumbnailSrc,
-      width: "100%",
-      height: "auto"
+      "src": _vm.thumbnailSrc,
+      "width": "100%",
+      "height": "auto"
     }
-  })]) : _vm._e(), _vm._v(" "), !_vm.thumbnailSrc.length ? _c("span", {
+  })]) : _vm._e(), _vm._v(" "), !_vm.thumbnailSrc.length ? _c('span', {
     staticClass: "cptm-thumbnail-placeholder"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-thumbnail-placeholder-icon"
-  }, [_c("svg", {
+  }, [_c('svg', {
     attrs: {
-      xmlns: "http://www.w3.org/2000/svg",
-      width: "40",
-      height: "40",
-      viewBox: "0 0 40 40",
-      fill: "none"
+      "xmlns": "http://www.w3.org/2000/svg",
+      "width": "40",
+      "height": "40",
+      "viewBox": "0 0 40 40",
+      "fill": "none"
     }
-  }, [_c("g", {
+  }, [_c('g', {
     attrs: {
       "clip-path": "url(#clip0_5019_6906)"
     }
-  }, [_c("path", {
+  }, [_c('path', {
     attrs: {
-      d: "M33.6766 39.7132H6.31999C4.71995 39.7107 3.18616 39.0739 2.05497 37.9423C0.923782 36.8107 0.287519 35.2766 0.285706 33.6766V6.32231C0.28752 4.72248 0.923857 3.18869 2.05511 2.05743C3.18637 0.926176 4.72016 0.28984 6.31999 0.288025H33.6766C35.2764 0.28984 36.8102 0.926176 37.9414 2.05743C39.0727 3.18869 39.709 4.72248 39.7108 6.32231V33.6766C39.709 35.2766 39.0728 36.8107 37.9416 37.9423C36.8104 39.0739 35.2766 39.7107 33.6766 39.7132ZM6.31999 3.14517C5.47764 3.14608 4.67005 3.4811 4.07441 4.07673C3.47878 4.67237 3.14376 5.47996 3.14285 6.32231V33.6766C3.14345 34.5192 3.47831 35.3273 4.07394 35.9233C4.66957 36.5194 5.47734 36.8548 6.31999 36.856H33.6766C34.5192 36.8548 35.327 36.5194 35.9226 35.9233C36.5182 35.3273 36.8531 34.5192 36.8537 33.6766V6.32231C36.8528 5.47996 36.5178 4.67237 35.9221 4.07673C35.3265 3.4811 34.5189 3.14608 33.6766 3.14517H6.31999Z",
-      fill: "#D2D6DB"
+      "d": "M33.6766 39.7132H6.31999C4.71995 39.7107 3.18616 39.0739 2.05497 37.9423C0.923782 36.8107 0.287519 35.2766 0.285706 33.6766V6.32231C0.28752 4.72248 0.923857 3.18869 2.05511 2.05743C3.18637 0.926176 4.72016 0.28984 6.31999 0.288025H33.6766C35.2764 0.28984 36.8102 0.926176 37.9414 2.05743C39.0727 3.18869 39.709 4.72248 39.7108 6.32231V33.6766C39.709 35.2766 39.0728 36.8107 37.9416 37.9423C36.8104 39.0739 35.2766 39.7107 33.6766 39.7132ZM6.31999 3.14517C5.47764 3.14608 4.67005 3.4811 4.07441 4.07673C3.47878 4.67237 3.14376 5.47996 3.14285 6.32231V33.6766C3.14345 34.5192 3.47831 35.3273 4.07394 35.9233C4.66957 36.5194 5.47734 36.8548 6.31999 36.856H33.6766C34.5192 36.8548 35.327 36.5194 35.9226 35.9233C36.5182 35.3273 36.8531 34.5192 36.8537 33.6766V6.32231C36.8528 5.47996 36.5178 4.67237 35.9221 4.07673C35.3265 3.4811 34.5189 3.14608 33.6766 3.14517H6.31999Z",
+      "fill": "#D2D6DB"
     }
-  }), _vm._v(" "), _c("path", {
+  }), _vm._v(" "), _c('path', {
     attrs: {
-      d: "M13.5543 19.6869C12.5444 19.6869 11.5571 19.3874 10.7174 18.8263C9.87766 18.2652 9.22317 17.4677 8.83669 16.5347C8.45021 15.6016 8.34909 14.5749 8.54611 13.5844C8.74314 12.5939 9.22947 11.684 9.94359 10.9699C10.6577 10.2558 11.5676 9.76945 12.5581 9.57242C13.5486 9.3754 14.5753 9.47652 15.5084 9.863C16.4414 10.2495 17.2389 10.904 17.8 11.7437C18.3611 12.5834 18.6606 13.5707 18.6606 14.5806C18.6591 15.9344 18.1206 17.2323 17.1633 18.1896C16.206 19.1469 14.9081 19.6854 13.5543 19.6869ZM13.5543 12.3326C13.1094 12.3326 12.6745 12.4645 12.3046 12.7117C11.9347 12.9589 11.6464 13.3102 11.4762 13.7213C11.306 14.1323 11.2616 14.5846 11.3484 15.0209C11.4353 15.4573 11.6496 15.858 11.9643 16.1725C12.279 16.487 12.6798 16.7011 13.1162 16.7878C13.5526 16.8745 14.0048 16.8298 14.4158 16.6593C14.8267 16.4889 15.1779 16.2005 15.4249 15.8305C15.6719 15.4604 15.8037 15.0255 15.8034 14.5806C15.8025 13.9845 15.5652 13.413 15.1436 12.9916C14.722 12.5702 14.1504 12.3332 13.5543 12.3326ZM3.04457 36.48C2.76869 36.4798 2.4988 36.3996 2.26748 36.2493C2.03616 36.099 1.85332 35.8849 1.74104 35.6329C1.62876 35.3809 1.59185 35.1018 1.63476 34.8292C1.67767 34.5567 1.79857 34.3025 1.98286 34.0972L8.69828 26.6149C9.3463 25.8887 10.2508 25.4423 11.2213 25.3696C12.1919 25.2969 13.1528 25.6036 13.9017 26.2252L16.7874 28.6069C16.8811 28.6869 16.9906 28.7464 17.1087 28.7814C17.2268 28.8164 17.351 28.8263 17.4731 28.8103C17.5943 28.7977 17.7117 28.7609 17.8183 28.702C17.9249 28.6431 18.0186 28.5633 18.0937 28.4674L25.6869 18.6572C26.0369 18.202 26.487 17.8335 27.0022 17.58C27.5175 17.3266 28.0841 17.195 28.6583 17.1954H28.672C29.2409 17.1947 29.8025 17.3233 30.3143 17.5716C30.8261 17.8199 31.2748 18.1813 31.6263 18.6286L38.9086 27.8937C39.1427 28.1917 39.2489 28.5704 39.2038 28.9467C39.1587 29.323 38.966 29.6659 38.668 29.9C38.37 30.1342 37.9913 30.2404 37.615 30.1952C37.2388 30.1501 36.8959 29.9574 36.6617 29.6594L29.3794 20.3943C29.2943 20.286 29.1854 20.1987 29.0612 20.1392C28.9369 20.0798 28.8006 20.0497 28.6629 20.0514C28.5246 20.0565 28.389 20.0906 28.2648 20.1514C28.1405 20.2122 28.0305 20.2985 27.9417 20.4046L20.3429 30.2103C20.0336 30.6093 19.6475 30.9421 19.2072 31.1891C18.767 31.436 18.2817 31.5921 17.78 31.6481C17.2784 31.704 16.7706 31.6587 16.2868 31.5148C15.803 31.3709 15.353 31.1313 14.9634 30.8103L12.0777 28.4286C11.8967 28.2784 11.6645 28.2044 11.43 28.2221C11.1955 28.2398 10.977 28.3478 10.8206 28.5234L4.11428 36C3.98032 36.1514 3.81562 36.2726 3.63117 36.3553C3.44671 36.4381 3.24674 36.4806 3.04457 36.48Z",
-      fill: "#D2D6DB"
+      "d": "M13.5543 19.6869C12.5444 19.6869 11.5571 19.3874 10.7174 18.8263C9.87766 18.2652 9.22317 17.4677 8.83669 16.5347C8.45021 15.6016 8.34909 14.5749 8.54611 13.5844C8.74314 12.5939 9.22947 11.684 9.94359 10.9699C10.6577 10.2558 11.5676 9.76945 12.5581 9.57242C13.5486 9.3754 14.5753 9.47652 15.5084 9.863C16.4414 10.2495 17.2389 10.904 17.8 11.7437C18.3611 12.5834 18.6606 13.5707 18.6606 14.5806C18.6591 15.9344 18.1206 17.2323 17.1633 18.1896C16.206 19.1469 14.9081 19.6854 13.5543 19.6869ZM13.5543 12.3326C13.1094 12.3326 12.6745 12.4645 12.3046 12.7117C11.9347 12.9589 11.6464 13.3102 11.4762 13.7213C11.306 14.1323 11.2616 14.5846 11.3484 15.0209C11.4353 15.4573 11.6496 15.858 11.9643 16.1725C12.279 16.487 12.6798 16.7011 13.1162 16.7878C13.5526 16.8745 14.0048 16.8298 14.4158 16.6593C14.8267 16.4889 15.1779 16.2005 15.4249 15.8305C15.6719 15.4604 15.8037 15.0255 15.8034 14.5806C15.8025 13.9845 15.5652 13.413 15.1436 12.9916C14.722 12.5702 14.1504 12.3332 13.5543 12.3326ZM3.04457 36.48C2.76869 36.4798 2.4988 36.3996 2.26748 36.2493C2.03616 36.099 1.85332 35.8849 1.74104 35.6329C1.62876 35.3809 1.59185 35.1018 1.63476 34.8292C1.67767 34.5567 1.79857 34.3025 1.98286 34.0972L8.69828 26.6149C9.3463 25.8887 10.2508 25.4423 11.2213 25.3696C12.1919 25.2969 13.1528 25.6036 13.9017 26.2252L16.7874 28.6069C16.8811 28.6869 16.9906 28.7464 17.1087 28.7814C17.2268 28.8164 17.351 28.8263 17.4731 28.8103C17.5943 28.7977 17.7117 28.7609 17.8183 28.702C17.9249 28.6431 18.0186 28.5633 18.0937 28.4674L25.6869 18.6572C26.0369 18.202 26.487 17.8335 27.0022 17.58C27.5175 17.3266 28.0841 17.195 28.6583 17.1954H28.672C29.2409 17.1947 29.8025 17.3233 30.3143 17.5716C30.8261 17.8199 31.2748 18.1813 31.6263 18.6286L38.9086 27.8937C39.1427 28.1917 39.2489 28.5704 39.2038 28.9467C39.1587 29.323 38.966 29.6659 38.668 29.9C38.37 30.1342 37.9913 30.2404 37.615 30.1952C37.2388 30.1501 36.8959 29.9574 36.6617 29.6594L29.3794 20.3943C29.2943 20.286 29.1854 20.1987 29.0612 20.1392C28.9369 20.0798 28.8006 20.0497 28.6629 20.0514C28.5246 20.0565 28.389 20.0906 28.2648 20.1514C28.1405 20.2122 28.0305 20.2985 27.9417 20.4046L20.3429 30.2103C20.0336 30.6093 19.6475 30.9421 19.2072 31.1891C18.767 31.436 18.2817 31.5921 17.78 31.6481C17.2784 31.704 16.7706 31.6587 16.2868 31.5148C15.803 31.3709 15.353 31.1313 14.9634 30.8103L12.0777 28.4286C11.8967 28.2784 11.6645 28.2044 11.43 28.2221C11.1955 28.2398 10.977 28.3478 10.8206 28.5234L4.11428 36C3.98032 36.1514 3.81562 36.2726 3.63117 36.3553C3.44671 36.4381 3.24674 36.4806 3.04457 36.48Z",
+      "fill": "#D2D6DB"
     }
-  })]), _vm._v(" "), _c("defs", [_c("clipPath", {
+  })]), _vm._v(" "), _c('defs', [_c('clipPath', {
     attrs: {
-      id: "clip0_5019_6906"
+      "id": "clip0_5019_6906"
     }
-  }, [_c("rect", {
+  }, [_c('rect', {
     attrs: {
-      width: "40",
-      height: "40",
-      fill: "white"
+      "width": "40",
+      "height": "40",
+      "fill": "white"
     }
-  })])])])])]) : _vm._e(), _vm._v(" "), _c("label", {
+  })])])])])]) : _vm._e(), _vm._v(" "), _c('label', {
     staticClass: "cptm-upload-btn cptm-btn cptm-btn-dark directorist-row-tooltip",
     attrs: {
       "data-tooltip": "Change image",
       "data-flow": "bottom"
     }
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-top-arrow-to-top"
-  }), _vm._v(" "), _c("input", {
+  }), _vm._v(" "), _c('input', {
     attrs: {
-      type: "button",
-      value: _vm.theButtonLabel
+      "type": "button",
+      "value": _vm.theButtonLabel
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.openMediaPicker.apply(null, arguments);
       }
     }
-  })]), _vm._v(" "), _c("div", {
+  })]), _vm._v(" "), _c('div', {
     staticClass: "cptm-thumbnail-drag-text"
-  }, [_vm._v("upload image here")])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v("upload image here")])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -39576,8 +39551,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "vueDndrop", function() { return vueDndrop; });
 /**
  * Bundle of: vue-dndrop
- * Generated: 2023-02-10
- * Version: 1.3.0
+ * Generated: 2024-12-18
+ * Version: 1.3.2
  */
 
 var containerInstance = 'dndrop-container-instance';
@@ -40587,11 +40562,6 @@ function addGrabListeners () {
     window.document.addEventListener(e, onMouseDown, { passive: false });
   });
 }
-
-function removeGrabListeners () {
-  var touchstart = grabEvents[1];
-  window.document.removeEventListener(touchstart, onMouseDown, { passive: false });
-}
 function addMoveListeners () {
   moveEvents.forEach(function (e) {
     window.document.addEventListener(e, onMouseMove, { passive: false });
@@ -40825,6 +40795,9 @@ var handleDragStartConditions = (function handleDragStartConditions () {
     releaseEvents.forEach(function (e) { return window.document.addEventListener(e, onUp); }, {
       passive: false,
     });
+    grabEvents.forEach(function (e) { return window.document.addEventListener(e, onMove); }, {
+      passive: false,
+    });
     window.document.addEventListener('drag', onHTMLDrag, {
       passive: false,
     });
@@ -40835,6 +40808,9 @@ var handleDragStartConditions = (function handleDragStartConditions () {
       passive: false,
     });
     releaseEvents.forEach(function (e) { return window.document.removeEventListener(e, onUp); }, {
+      passive: false,
+    });
+    grabEvents.forEach(function (e) { return window.document.removeEventListener(e, onMove); }, {
       passive: false,
     });
     window.document.removeEventListener('drag', onHTMLDrag, {
@@ -40928,7 +40904,7 @@ function handleMouseMoveForContainer (ref, orientation) {
   }
 }
 function onMouseMove (event) {
-  event.preventDefault();
+  if (event.cancelable) { event.preventDefault(); }
   var e = getPointerEvent(event);
   if (!draggableInfo) {
     initiateDrag(e, getElementCursor(event.target));
@@ -40976,7 +40952,6 @@ function handleMissedDragFrame () {
 function onMouseUp () {
   removeMoveListeners();
   removeReleaseListeners();
-  removeGrabListeners();
   if (handleScroll && typeof handleScroll === 'function') { handleScroll({ reset: true }); }
   if (cursorStyleElement) {
     removeStyle(cursorStyleElement);
@@ -42635,7 +42610,7 @@ function normalizeComponent(
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-!function(t,e){ true?module.exports=e():undefined}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="/",e(e.s=89)}([function(t,e){t.exports=function(t){try{return!!t()}catch(t){return!0}}},function(t,e,n){var r=n(35),i=Function.prototype,o=i.call,s=r&&i.bind.bind(o,o);t.exports=r?s:function(t){return function(){return o.apply(t,arguments)}}},function(t,e,n){var r=n(59),i=r.all;t.exports=r.IS_HTMLDDA?function(t){return"function"==typeof t||t===i}:function(t){return"function"==typeof t}},function(t,e,n){var r=n(4),i=n(43).f,o=n(30),s=n(11),u=n(33),a=n(95),l=n(66);t.exports=function(t,e){var n,c,f,p,h,d=t.target,v=t.global,g=t.stat;if(n=v?r:g?r[d]||u(d,{}):(r[d]||{}).prototype)for(c in e){if(p=e[c],t.dontCallGetSet?(h=i(n,c),f=h&&h.value):f=n[c],!l(v?c:d+(g?".":"#")+c,t.forced)&&void 0!==f){if(typeof p==typeof f)continue;a(p,f)}(t.sham||f&&f.sham)&&o(p,"sham",!0),s(n,c,p,t)}}},function(t,e,n){(function(e){var n=function(t){return t&&t.Math==Math&&t};t.exports=n("object"==typeof globalThis&&globalThis)||n("object"==typeof window&&window)||n("object"==typeof self&&self)||n("object"==typeof e&&e)||function(){return this}()||Function("return this")()}).call(e,n(139))},function(t,e,n){var r=n(0);t.exports=!r(function(){return 7!=Object.defineProperty({},1,{get:function(){return 7}})[1]})},function(t,e,n){var r=n(8),i=String,o=TypeError;t.exports=function(t){if(r(t))return t;throw o(i(t)+" is not an object")}},function(t,e,n){var r=n(1),i=n(14),o=r({}.hasOwnProperty);t.exports=Object.hasOwn||function(t,e){return o(i(t),e)}},function(t,e,n){var r=n(2),i=n(59),o=i.all;t.exports=i.IS_HTMLDDA?function(t){return"object"==typeof t?null!==t:r(t)||t===o}:function(t){return"object"==typeof t?null!==t:r(t)}},function(t,e,n){var r=n(4),i=n(47),o=n(7),s=n(75),u=n(72),a=n(76),l=i("wks"),c=r.Symbol,f=c&&c.for,p=a?c:c&&c.withoutSetter||s;t.exports=function(t){if(!o(l,t)||!u&&"string"!=typeof l[t]){var e="Symbol."+t;u&&o(c,t)?l[t]=c[t]:l[t]=a&&f?f(e):p(e)}return l[t]}},function(t,e,n){var r=n(123);t.exports=function(t){return r(t.length)}},function(t,e,n){var r=n(2),i=n(13),o=n(104),s=n(33);t.exports=function(t,e,n,u){u||(u={});var a=u.enumerable,l=void 0!==u.name?u.name:e;if(r(n)&&o(n,l,u),u.global)a?t[e]=n:s(e,n);else{try{u.unsafe?t[e]&&(a=!0):delete t[e]}catch(t){}a?t[e]=n:i.f(t,e,{value:n,enumerable:!1,configurable:!u.nonConfigurable,writable:!u.nonWritable})}return t}},function(t,e,n){var r=n(35),i=Function.prototype.call;t.exports=r?i.bind(i):function(){return i.apply(i,arguments)}},function(t,e,n){var r=n(5),i=n(62),o=n(77),s=n(6),u=n(50),a=TypeError,l=Object.defineProperty,c=Object.getOwnPropertyDescriptor;e.f=r?o?function(t,e,n){if(s(t),e=u(e),s(n),"function"==typeof t&&"prototype"===e&&"value"in n&&"writable"in n&&!n.writable){var r=c(t,e);r&&r.writable&&(t[e]=n.value,n={configurable:"configurable"in n?n.configurable:r.configurable,enumerable:"enumerable"in n?n.enumerable:r.enumerable,writable:!1})}return l(t,e,n)}:l:function(t,e,n){if(s(t),e=u(e),s(n),i)try{return l(t,e,n)}catch(t){}if("get"in n||"set"in n)throw a("Accessors not supported");return"value"in n&&(t[e]=n.value),t}},function(t,e,n){var r=n(24),i=Object;t.exports=function(t){return i(r(t))}},function(t,e,n){var r=n(1),i=r({}.toString),o=r("".slice);t.exports=function(t){return o(i(t),8,-1)}},function(t,e,n){var r=n(0),i=n(9),o=n(23),s=i("species");t.exports=function(t){return o>=51||!r(function(){var e=[],n=e.constructor={};return n[s]=function(){return{foo:1}},1!==e[t](Boolean).foo})}},function(t,e,n){var r=n(4),i=n(2),o=function(t){return i(t)?t:void 0};t.exports=function(t,e){return arguments.length<2?o(r[t]):r[t]&&r[t][e]}},function(t,e,n){var r=n(15);t.exports=Array.isArray||function(t){return"Array"==r(t)}},function(t,e,n){var r=n(39),i=n(24);t.exports=function(t){return r(i(t))}},function(t,e,n){var r=n(29),i=String;t.exports=function(t){if("Symbol"===r(t))throw TypeError("Cannot convert a Symbol value to a string");return i(t)}},function(t,e,n){var r=n(100),i=n(1),o=n(39),s=n(14),u=n(10),a=n(28),l=i([].push),c=function(t){var e=1==t,n=2==t,i=3==t,c=4==t,f=6==t,p=7==t,h=5==t||f;return function(d,v,g,y){for(var b,m,x=s(d),_=o(x),O=r(v,g),w=u(_),S=0,E=y||a,L=e?E(d,w):n||p?E(d,0):void 0;w>S;S++)if((h||S in _)&&(b=_[S],m=O(b,S,x),t))if(e)L[S]=m;else if(m)switch(t){case 3:return!0;case 5:return b;case 6:return S;case 2:l(L,b)}else switch(t){case 4:return!1;case 7:l(L,b)}return f?-1:i||c?c:L}};t.exports={forEach:c(0),map:c(1),filter:c(2),some:c(3),every:c(4),find:c(5),findIndex:c(6),filterReject:c(7)}},function(t,e){var n=TypeError;t.exports=function(t){if(t>9007199254740991)throw n("Maximum allowed index exceeded");return t}},function(t,e,n){var r,i,o=n(4),s=n(97),u=o.process,a=o.Deno,l=u&&u.versions||a&&a.version,c=l&&l.v8;c&&(r=c.split("."),i=r[0]>0&&r[0]<4?1:+(r[0]+r[1])),!i&&s&&(!(r=s.match(/Edge\/(\d+)/))||r[1]>=74)&&(r=s.match(/Chrome\/(\d+)/))&&(i=+r[1]),t.exports=i},function(t,e,n){var r=n(40),i=TypeError;t.exports=function(t){if(r(t))throw i("Can't call method on "+t);return t}},function(t,e,n){var r=n(2),i=n(74),o=TypeError;t.exports=function(t){if(r(t))return t;throw o(i(t)+" is not a function")}},function(t,e,n){"use strict";var r=n(0);t.exports=function(t,e){var n=[][t];return!!n&&r(function(){n.call(null,e||function(){return 1},1)})}},function(t,e,n){"use strict";var r=n(5),i=n(18),o=TypeError,s=Object.getOwnPropertyDescriptor,u=r&&!function(){if(void 0!==this)return!0;try{Object.defineProperty([],"length",{writable:!1}).length=1}catch(t){return t instanceof TypeError}}();t.exports=u?function(t,e){if(i(t)&&!s(t,"length").writable)throw o("Cannot set read only .length");return t.length=e}:function(t,e){return t.length=e}},function(t,e,n){var r=n(94);t.exports=function(t,e){return new(r(t))(0===e?0:e)}},function(t,e,n){var r=n(51),i=n(2),o=n(15),s=n(9),u=s("toStringTag"),a=Object,l="Arguments"==o(function(){return arguments}()),c=function(t,e){try{return t[e]}catch(t){}};t.exports=r?o:function(t){var e,n,r;return void 0===t?"Undefined":null===t?"Null":"string"==typeof(n=c(e=a(t),u))?n:l?o(e):"Object"==(r=o(e))&&i(e.callee)?"Arguments":r}},function(t,e,n){var r=n(5),i=n(13),o=n(31);t.exports=r?function(t,e,n){return i.f(t,e,o(1,n))}:function(t,e,n){return t[e]=n,t}},function(t,e){t.exports=function(t,e){return{enumerable:!(1&t),configurable:!(2&t),writable:!(4&t),value:e}}},function(t,e,n){"use strict";var r=n(50),i=n(13),o=n(31);t.exports=function(t,e,n){var s=r(e);s in t?i.f(t,s,o(0,n)):t[s]=n}},function(t,e,n){var r=n(4),i=Object.defineProperty;t.exports=function(t,e){try{i(r,t,{value:e,configurable:!0,writable:!0})}catch(n){r[t]=e}return e}},function(t,e){t.exports=["constructor","hasOwnProperty","isPrototypeOf","propertyIsEnumerable","toLocaleString","toString","valueOf"]},function(t,e,n){var r=n(0);t.exports=!r(function(){var t=function(){}.bind();return"function"!=typeof t||t.hasOwnProperty("prototype")})},function(t,e,n){var r=n(5),i=n(7),o=Function.prototype,s=r&&Object.getOwnPropertyDescriptor,u=i(o,"name"),a=u&&"something"===function(){}.name,l=u&&(!r||r&&s(o,"name").configurable);t.exports={EXISTS:u,PROPER:a,CONFIGURABLE:l}},function(t,e,n){var r=n(15),i=n(1);t.exports=function(t){if("Function"===r(t))return i(t)}},function(t,e){t.exports={}},function(t,e,n){var r=n(1),i=n(0),o=n(15),s=Object,u=r("".split);t.exports=i(function(){return!s("z").propertyIsEnumerable(0)})?function(t){return"String"==o(t)?u(t,""):s(t)}:s},function(t,e){t.exports=function(t){return null===t||void 0===t}},function(t,e,n){var r=n(17),i=n(2),o=n(44),s=n(76),u=Object;t.exports=s?function(t){return"symbol"==typeof t}:function(t){var e=r("Symbol");return i(e)&&o(e.prototype,u(t))}},function(t,e,n){var r,i=n(6),o=n(107),s=n(34),u=n(38),a=n(101),l=n(60),c=n(70),f=c("IE_PROTO"),p=function(){},h=function(t){return"<script>"+t+"<\/script>"},d=function(t){t.write(h("")),t.close();var e=t.parentWindow.Object;return t=null,e},v=function(){var t,e=l("iframe");return e.style.display="none",a.appendChild(e),e.src=String("javascript:"),t=e.contentWindow.document,t.open(),t.write(h("document.F=Object")),t.close(),t.F},g=function(){try{r=new ActiveXObject("htmlfile")}catch(t){}g="undefined"!=typeof document?document.domain&&r?d(r):v():d(r);for(var t=s.length;t--;)delete g.prototype[s[t]];return g()};u[f]=!0,t.exports=Object.create||function(t,e){var n;return null!==t?(p.prototype=i(t),n=new p,p.prototype=null,n[f]=t):n=g(),void 0===e?n:o.f(n,e)}},function(t,e,n){var r=n(5),i=n(12),o=n(110),s=n(31),u=n(19),a=n(50),l=n(7),c=n(62),f=Object.getOwnPropertyDescriptor;e.f=r?f:function(t,e){if(t=u(t),e=a(e),c)try{return f(t,e)}catch(t){}if(l(t,e))return s(!i(o.f,t,e),t[e])}},function(t,e,n){var r=n(1);t.exports=r({}.isPrototypeOf)},function(t,e,n){"use strict";var r=n(12),i=n(1),o=n(20),s=n(69),u=n(117),a=n(47),l=n(42),c=n(64).get,f=n(118),p=n(119),h=a("native-string-replace",String.prototype.replace),d=RegExp.prototype.exec,v=d,g=i("".charAt),y=i("".indexOf),b=i("".replace),m=i("".slice),x=function(){var t=/a/,e=/b*/g;return r(d,t,"a"),r(d,e,"a"),0!==t.lastIndex||0!==e.lastIndex}(),_=u.BROKEN_CARET,O=void 0!==/()??/.exec("")[1];(x||O||_||f||p)&&(v=function(t){var e,n,i,u,a,f,p,w=this,S=c(w),E=o(t),L=S.raw;if(L)return L.lastIndex=w.lastIndex,e=r(v,L,E),w.lastIndex=L.lastIndex,e;var k=S.groups,P=_&&w.sticky,j=r(s,w),T=w.source,A=0,V=E;if(P&&(j=b(j,"y",""),-1===y(j,"g")&&(j+="g"),V=m(E,w.lastIndex),w.lastIndex>0&&(!w.multiline||w.multiline&&"\n"!==g(E,w.lastIndex-1))&&(T="(?: "+T+")",V=" "+V,A++),n=new RegExp("^(?:"+T+")",j)),O&&(n=new RegExp("^"+T+"$(?!\\s)",j)),x&&(i=w.lastIndex),u=r(d,P?n:w,V),P?u?(u.input=m(u.input,A),u[0]=m(u[0],A),u.index=w.lastIndex,w.lastIndex+=u[0].length):w.lastIndex=0:x&&u&&(w.lastIndex=w.global?u.index+u[0].length:i),O&&u&&u.length>1&&r(h,u[0],n,function(){for(a=1;a<arguments.length-2;a++)void 0===arguments[a]&&(u[a]=void 0)}),u&&k)for(u.groups=f=l(null),a=0;a<k.length;a++)p=k[a],f[p[0]]=u[p[1]];return u}),t.exports=v},function(t,e,n){var r=n(4),i=n(33),o=r["__core-js_shared__"]||i("__core-js_shared__",{});t.exports=o},function(t,e,n){var r=n(103),i=n(46);(t.exports=function(t,e){return i[t]||(i[t]=void 0!==e?e:{})})("versions",[]).push({version:"3.26.1",mode:r?"pure":"global",copyright:"© 2014-2022 Denis Pushkarev (zloirock.ru)",license:"https://github.com/zloirock/core-js/blob/v3.26.1/LICENSE",source:"https://github.com/zloirock/core-js"})},function(t,e,n){var r=n(49),i=Math.max,o=Math.min;t.exports=function(t,e){var n=r(t);return n<0?i(n+e,0):o(n,e)}},function(t,e,n){var r=n(105);t.exports=function(t){var e=+t;return e!==e||0===e?0:r(e)}},function(t,e,n){var r=n(73),i=n(41);t.exports=function(t){var e=r(t,"string");return i(e)?e:e+""}},function(t,e,n){var r=n(9),i=r("toStringTag"),o={};o[i]="z",t.exports="[object z]"===String(o)},function(t,e,n){"use strict";var r=n(5),i=n(4),o=n(1),s=n(66),u=n(11),a=n(7),l=n(102),c=n(44),f=n(41),p=n(73),h=n(0),d=n(67).f,v=n(43).f,g=n(13).f,y=n(122),b=n(71).trim,m=i.Number,x=m.prototype,_=i.TypeError,O=o("".slice),w=o("".charCodeAt),S=function(t){var e=p(t,"number");return"bigint"==typeof e?e:E(e)},E=function(t){var e,n,r,i,o,s,u,a,l=p(t,"number");if(f(l))throw _("Cannot convert a Symbol value to a number");if("string"==typeof l&&l.length>2)if(l=b(l),43===(e=w(l,0))||45===e){if(88===(n=w(l,2))||120===n)return NaN}else if(48===e){switch(w(l,1)){case 66:case 98:r=2,i=49;break;case 79:case 111:r=8,i=55;break;default:return+l}for(o=O(l,2),s=o.length,u=0;u<s;u++)if((a=w(o,u))<48||a>i)return NaN;return parseInt(o,r)}return+l};if(s("Number",!m(" 0o1")||!m("0b1")||m("+0x1"))){for(var L,k=function(t){var e=arguments.length<1?0:m(S(t)),n=this;return c(x,n)&&h(function(){y(n)})?l(Object(e),n,k):e},P=r?d(m):"MAX_VALUE,MIN_VALUE,NaN,NEGATIVE_INFINITY,POSITIVE_INFINITY,EPSILON,MAX_SAFE_INTEGER,MIN_SAFE_INTEGER,isFinite,isInteger,isNaN,isSafeInteger,parseFloat,parseInt,fromString,range".split(","),j=0;P.length>j;j++)a(m,L=P[j])&&!a(k,L)&&g(k,L,v(m,L));k.prototype=x,x.constructor=k,u(i,"Number",k,{constructor:!0})}},function(t,e,n){"use strict";var r=n(3),i=n(45);r({target:"RegExp",proto:!0,forced:/./.exec!==i},{exec:i})},function(t,e,n){"use strict";function r(t){return 0!==t&&(!(!Array.isArray(t)||0!==t.length)||!t)}function i(t){return function(){return!t.apply(void 0,arguments)}}function o(t,e){return void 0===t&&(t="undefined"),null===t&&(t="null"),!1===t&&(t="false"),-1!==t.toString().toLowerCase().indexOf(e.trim())}function s(t,e,n,r){return t.filter(function(t){return o(r(t,n),e)})}function u(t){return t.filter(function(t){return!t.$isLabel})}function a(t,e){return function(n){return n.reduce(function(n,r){return r[t]&&r[t].length?(n.push({$groupLabel:r[e],$isLabel:!0}),n.concat(r[t])):n},[])}}function l(t,e,r,i,o){return function(u){return u.map(function(u){var a;if(!u[r])return console.warn("Options passed to vue-multiselect do not contain groups, despite the config."),[];var l=s(u[r],t,e,o);return l.length?(a={},n.i(f.a)(a,i,u[i]),n.i(f.a)(a,r,l),a):[]})}}var c=n(88),f=n(87),p=n(129),h=(n.n(p),n(82)),d=(n.n(h),n(81)),v=(n.n(d),n(83)),g=(n.n(v),n(84)),y=(n.n(g),n(128)),b=(n.n(y),n(135)),m=(n.n(b),n(127)),x=(n.n(m),n(132)),_=(n.n(x),n(131)),O=(n.n(_),n(125)),w=(n.n(O),n(130)),S=(n.n(w),n(52)),E=(n.n(S),n(53)),L=(n.n(E),n(85)),k=(n.n(L),n(134)),P=(n.n(k),n(80)),j=(n.n(P),n(79)),T=(n.n(j),n(133)),A=(n.n(T),n(126)),V=(n.n(A),function(){for(var t=arguments.length,e=new Array(t),n=0;n<t;n++)e[n]=arguments[n];return function(t){return e.reduce(function(t,e){return e(t)},t)}});e.a={data:function(){return{search:"",isOpen:!1,preferredOpenDirection:"below",optimizedHeight:this.maxHeight}},props:{internalSearch:{type:Boolean,default:!0},options:{type:Array,required:!0},multiple:{type:Boolean,default:!1},value:{type:null,default:function(){return[]}},trackBy:{type:String},label:{type:String},searchable:{type:Boolean,default:!0},clearOnSelect:{type:Boolean,default:!0},hideSelected:{type:Boolean,default:!1},placeholder:{type:String,default:"Select option"},allowEmpty:{type:Boolean,default:!0},resetAfter:{type:Boolean,default:!1},closeOnSelect:{type:Boolean,default:!0},customLabel:{type:Function,default:function(t,e){return r(t)?"":e?t[e]:t}},taggable:{type:Boolean,default:!1},tagPlaceholder:{type:String,default:"Press enter to create a tag"},tagPosition:{type:String,default:"top"},max:{type:[Number,Boolean],default:!1},id:{default:null},optionsLimit:{type:Number,default:1e3},groupValues:{type:String},groupLabel:{type:String},groupSelect:{type:Boolean,default:!1},blockKeys:{type:Array,default:function(){return[]}},preserveSearch:{type:Boolean,default:!1},preselectFirst:{type:Boolean,default:!1},preventAutofocus:{type:Boolean,default:!1}},mounted:function(){!this.multiple&&this.max&&console.warn("[Vue-Multiselect warn]: Max prop should not be used when prop Multiple equals false."),this.preselectFirst&&!this.internalValue.length&&this.options.length&&this.select(this.filteredOptions[0])},computed:{internalValue:function(){return this.value||0===this.value?Array.isArray(this.value)?this.value:[this.value]:[]},filteredOptions:function(){var t=this.search||"",e=t.toLowerCase().trim(),n=this.options.concat();return n=this.internalSearch?this.groupValues?this.filterAndFlat(n,e,this.label):s(n,e,this.label,this.customLabel):this.groupValues?a(this.groupValues,this.groupLabel)(n):n,n=this.hideSelected?n.filter(i(this.isSelected)):n,this.taggable&&e.length&&!this.isExistingOption(e)&&("bottom"===this.tagPosition?n.push({isTag:!0,label:t}):n.unshift({isTag:!0,label:t})),n.slice(0,this.optionsLimit)},valueKeys:function(){var t=this;return this.trackBy?this.internalValue.map(function(e){return e[t.trackBy]}):this.internalValue},optionKeys:function(){var t=this;return(this.groupValues?this.flatAndStrip(this.options):this.options).map(function(e){return t.customLabel(e,t.label).toString().toLowerCase()})},currentOptionLabel:function(){return this.multiple?this.searchable?"":this.placeholder:this.internalValue.length?this.getOptionLabel(this.internalValue[0]):this.searchable?"":this.placeholder}},watch:{internalValue:function(){this.resetAfter&&this.internalValue.length&&(this.search="",this.$emit("input",this.multiple?[]:null))},search:function(){this.$emit("search-change",this.search,this.id)}},methods:{getValue:function(){return this.multiple?this.internalValue:0===this.internalValue.length?null:this.internalValue[0]},filterAndFlat:function(t,e,n){return V(l(e,n,this.groupValues,this.groupLabel,this.customLabel),a(this.groupValues,this.groupLabel))(t)},flatAndStrip:function(t){return V(a(this.groupValues,this.groupLabel),u)(t)},updateSearch:function(t){this.search=t},isExistingOption:function(t){return!!this.options&&this.optionKeys.indexOf(t)>-1},isSelected:function(t){var e=this.trackBy?t[this.trackBy]:t;return this.valueKeys.indexOf(e)>-1},isOptionDisabled:function(t){return!!t.$isDisabled},getOptionLabel:function(t){if(r(t))return"";if(t.isTag)return t.label;if(t.$isLabel)return t.$groupLabel;var e=this.customLabel(t,this.label);return r(e)?"":e},select:function(t,e){if(t.$isLabel&&this.groupSelect)return void this.selectGroup(t);if(!(-1!==this.blockKeys.indexOf(e)||this.disabled||t.$isDisabled||t.$isLabel)&&(!this.max||!this.multiple||this.internalValue.length!==this.max)&&("Tab"!==e||this.pointerDirty)){if(t.isTag)this.$emit("tag",t.label,this.id),this.search="",this.closeOnSelect&&!this.multiple&&this.deactivate();else{if(this.isSelected(t))return void("Tab"!==e&&this.removeElement(t));this.multiple?this.$emit("input",this.internalValue.concat([t]),this.id):this.$emit("input",t,this.id),this.$emit("select",t,this.id),this.clearOnSelect&&(this.search="")}this.closeOnSelect&&this.deactivate()}},selectGroup:function(t){var e=this,n=this.options.find(function(n){return n[e.groupLabel]===t.$groupLabel});if(n){if(this.wholeGroupSelected(n)){this.$emit("remove",n[this.groupValues],this.id);var r=this.internalValue.filter(function(t){return-1===n[e.groupValues].indexOf(t)});this.$emit("input",r,this.id)}else{var i=n[this.groupValues].filter(function(t){return!(e.isOptionDisabled(t)||e.isSelected(t))});this.max&&i.splice(this.max-this.internalValue.length),this.$emit("select",i,this.id),this.$emit("input",this.internalValue.concat(i),this.id)}this.closeOnSelect&&this.deactivate()}},wholeGroupSelected:function(t){var e=this;return t[this.groupValues].every(function(t){return e.isSelected(t)||e.isOptionDisabled(t)})},wholeGroupDisabled:function(t){return t[this.groupValues].every(this.isOptionDisabled)},removeElement:function(t){var e=!(arguments.length>1&&void 0!==arguments[1])||arguments[1];if(!this.disabled&&!t.$isDisabled){if(!this.allowEmpty&&this.internalValue.length<=1)return void this.deactivate();var r="object"===n.i(c.a)(t)?this.valueKeys.indexOf(t[this.trackBy]):this.valueKeys.indexOf(t);if(this.multiple){var i=this.internalValue.slice(0,r).concat(this.internalValue.slice(r+1));this.$emit("input",i,this.id)}else this.$emit("input",null,this.id);this.$emit("remove",t,this.id),this.closeOnSelect&&e&&this.deactivate()}},removeLastElement:function(){-1===this.blockKeys.indexOf("Delete")&&0===this.search.length&&Array.isArray(this.internalValue)&&this.internalValue.length&&this.removeElement(this.internalValue[this.internalValue.length-1],!1)},activate:function(){var t=this;this.isOpen||this.disabled||(this.adjustPosition(),this.groupValues&&0===this.pointer&&this.filteredOptions.length&&(this.pointer=1),this.isOpen=!0,this.searchable?(this.preserveSearch||(this.search=""),this.preventAutofocus||this.$nextTick(function(){return t.$refs.search&&t.$refs.search.focus()})):this.preventAutofocus||void 0!==this.$el&&this.$el.focus(),this.$emit("open",this.id))},deactivate:function(){this.isOpen&&(this.isOpen=!1,this.searchable?null!==this.$refs.search&&void 0!==this.$refs.search&&this.$refs.search.blur():void 0!==this.$el&&this.$el.blur(),this.preserveSearch||(this.search=""),this.$emit("close",this.getValue(),this.id))},toggle:function(){this.isOpen?this.deactivate():this.activate()},adjustPosition:function(){if("undefined"!=typeof window){var t=this.$el.getBoundingClientRect().top,e=window.innerHeight-this.$el.getBoundingClientRect().bottom;e>this.maxHeight||e>t||"below"===this.openDirection||"bottom"===this.openDirection?(this.preferredOpenDirection="below",this.optimizedHeight=Math.min(e-40,this.maxHeight)):(this.preferredOpenDirection="above",this.optimizedHeight=Math.min(t-40,this.maxHeight))}}}}},function(t,e,n){"use strict";var r=n(52),i=(n.n(r),n(53)),o=(n.n(i),n(85)),s=(n.n(o),n(82)),u=(n.n(s),n(81)),a=(n.n(u),n(83)),l=(n.n(a),n(84)),c=(n.n(l),n(79));n.n(c);e.a={data:function(){return{pointer:0,pointerDirty:!1}},props:{showPointer:{type:Boolean,default:!0},optionHeight:{type:Number,default:40}},computed:{pointerPosition:function(){return this.pointer*this.optionHeight},visibleElements:function(){return this.optimizedHeight/this.optionHeight}},watch:{filteredOptions:function(){this.pointerAdjust()},isOpen:function(){this.pointerDirty=!1},pointer:function(){this.$refs.search&&this.$refs.search.setAttribute("aria-activedescendant",this.id+"-"+this.pointer.toString())}},methods:{optionHighlight:function(t,e){return{"multiselect__option--highlight":t===this.pointer&&this.showPointer,"multiselect__option--selected":this.isSelected(e)}},groupHighlight:function(t,e){var n=this;if(!this.groupSelect)return["multiselect__option--disabled",{"multiselect__option--group":e.$isLabel}];var r=this.options.find(function(t){return t[n.groupLabel]===e.$groupLabel});return r&&!this.wholeGroupDisabled(r)?["multiselect__option--group",{"multiselect__option--highlight":t===this.pointer&&this.showPointer},{"multiselect__option--group-selected":this.wholeGroupSelected(r)}]:"multiselect__option--disabled"},addPointerElement:function(){var t=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"Enter",e=t.key;this.filteredOptions.length>0&&this.select(this.filteredOptions[this.pointer],e),this.pointerReset()},pointerForward:function(){this.pointer<this.filteredOptions.length-1&&(this.pointer++,this.$refs.list.scrollTop<=this.pointerPosition-(this.visibleElements-1)*this.optionHeight&&(this.$refs.list.scrollTop=this.pointerPosition-(this.visibleElements-1)*this.optionHeight),this.filteredOptions[this.pointer]&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerForward()),this.pointerDirty=!0},pointerBackward:function(){this.pointer>0?(this.pointer--,this.$refs.list.scrollTop>=this.pointerPosition&&(this.$refs.list.scrollTop=this.pointerPosition),this.filteredOptions[this.pointer]&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerBackward()):this.filteredOptions[this.pointer]&&this.filteredOptions[0].$isLabel&&!this.groupSelect&&this.pointerForward(),this.pointerDirty=!0},pointerReset:function(){this.closeOnSelect&&(this.pointer=0,this.$refs.list&&(this.$refs.list.scrollTop=0))},pointerAdjust:function(){this.pointer>=this.filteredOptions.length-1&&(this.pointer=this.filteredOptions.length?this.filteredOptions.length-1:0),this.filteredOptions.length>0&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerForward()},pointerSet:function(t){this.pointer=t,this.pointerDirty=!0}}}},function(t,e,n){"use strict";var r=n(52),i=(n.n(r),n(80)),o=(n.n(i),n(54)),s=n(55);e.a={name:"vue-multiselect",mixins:[o.a,s.a],props:{name:{type:String,default:""},selectLabel:{type:String,default:"Press enter to select"},selectGroupLabel:{type:String,default:"Press enter to select group"},selectedLabel:{type:String,default:"Selected"},deselectLabel:{type:String,default:"Press enter to remove"},deselectGroupLabel:{type:String,default:"Press enter to deselect group"},showLabels:{type:Boolean,default:!0},limit:{type:Number,default:99999},maxHeight:{type:Number,default:300},limitText:{type:Function,default:function(t){return"and ".concat(t," more")}},loading:{type:Boolean,default:!1},disabled:{type:Boolean,default:!1},openDirection:{type:String,default:""},showNoOptions:{type:Boolean,default:!0},showNoResults:{type:Boolean,default:!0},tabindex:{type:Number,default:0}},computed:{hasOptionGroup:function(){return this.groupValues&&this.groupLabel&&this.groupSelect},isSingleLabelVisible:function(){return(this.singleValue||0===this.singleValue)&&(!this.isOpen||!this.searchable)&&!this.visibleValues.length},isPlaceholderVisible:function(){return!(this.internalValue.length||this.searchable&&this.isOpen)},visibleValues:function(){return this.multiple?this.internalValue.slice(0,this.limit):[]},singleValue:function(){return this.internalValue[0]},deselectLabelText:function(){return this.showLabels?this.deselectLabel:""},deselectGroupLabelText:function(){return this.showLabels?this.deselectGroupLabel:""},selectLabelText:function(){return this.showLabels?this.selectLabel:""},selectGroupLabelText:function(){return this.showLabels?this.selectGroupLabel:""},selectedLabelText:function(){return this.showLabels?this.selectedLabel:""},inputStyle:function(){return this.searchable||this.multiple&&this.value&&this.value.length?this.isOpen?{width:"100%"}:{width:"0",position:"absolute",padding:"0"}:""},contentStyle:function(){return this.options.length?{display:"inline-block"}:{display:"block"}},isAbove:function(){return"above"===this.openDirection||"top"===this.openDirection||"below"!==this.openDirection&&"bottom"!==this.openDirection&&"above"===this.preferredOpenDirection},showSearchInput:function(){return this.searchable&&(!this.hasSingleSelectedSlot||!this.visibleSingleValue&&0!==this.visibleSingleValue||this.isOpen)}}}},function(t,e,n){var r=n(19),i=n(48),o=n(10),s=function(t){return function(e,n,s){var u,a=r(e),l=o(a),c=i(s,l);if(t&&n!=n){for(;l>c;)if((u=a[c++])!=u)return!0}else for(;l>c;c++)if((t||c in a)&&a[c]===n)return t||c||0;return!t&&-1}};t.exports={includes:s(!0),indexOf:s(!1)}},function(t,e,n){"use strict";var r=n(74),i=TypeError;t.exports=function(t,e){if(!delete t[e])throw i("Cannot delete property "+r(e)+" of "+r(t))}},function(t,e){var n="object"==typeof document&&document.all,r=void 0===n&&void 0!==n;t.exports={all:n,IS_HTMLDDA:r}},function(t,e,n){var r=n(4),i=n(8),o=r.document,s=i(o)&&i(o.createElement);t.exports=function(t){return s?o.createElement(t):{}}},function(t,e,n){var r=n(25),i=n(40);t.exports=function(t,e){var n=t[e];return i(n)?void 0:r(n)}},function(t,e,n){var r=n(5),i=n(0),o=n(60);t.exports=!r&&!i(function(){return 7!=Object.defineProperty(o("div"),"a",{get:function(){return 7}}).a})},function(t,e,n){var r=n(1),i=n(2),o=n(46),s=r(Function.toString);i(o.inspectSource)||(o.inspectSource=function(t){return s(t)}),t.exports=o.inspectSource},function(t,e,n){var r,i,o,s=n(124),u=n(4),a=n(8),l=n(30),c=n(7),f=n(46),p=n(70),h=n(38),d=u.TypeError,v=u.WeakMap,g=function(t){return o(t)?i(t):r(t,{})},y=function(t){return function(e){var n;if(!a(e)||(n=i(e)).type!==t)throw d("Incompatible receiver, "+t+" required");return n}};if(s||f.state){var b=f.state||(f.state=new v);b.get=b.get,b.has=b.has,b.set=b.set,r=function(t,e){if(b.has(t))throw d("Object already initialized");return e.facade=t,b.set(t,e),e},i=function(t){return b.get(t)||{}},o=function(t){return b.has(t)}}else{var m=p("state");h[m]=!0,r=function(t,e){if(c(t,m))throw d("Object already initialized");return e.facade=t,l(t,m,e),e},i=function(t){return c(t,m)?t[m]:{}},o=function(t){return c(t,m)}}t.exports={set:r,get:i,has:o,enforce:g,getterFor:y}},function(t,e,n){var r=n(1),i=n(0),o=n(2),s=n(29),u=n(17),a=n(63),l=function(){},c=[],f=u("Reflect","construct"),p=/^\s*(?:class|function)\b/,h=r(p.exec),d=!p.exec(l),v=function(t){if(!o(t))return!1;try{return f(l,c,t),!0}catch(t){return!1}},g=function(t){if(!o(t))return!1;switch(s(t)){case"AsyncFunction":case"GeneratorFunction":case"AsyncGeneratorFunction":return!1}try{return d||!!h(p,a(t))}catch(t){return!0}};g.sham=!0,t.exports=!f||i(function(){var t;return v(v.call)||!v(Object)||!v(function(){t=!0})||t})?g:v},function(t,e,n){var r=n(0),i=n(2),o=/#|\.prototype\./,s=function(t,e){var n=a[u(t)];return n==c||n!=l&&(i(e)?r(e):!!e)},u=s.normalize=function(t){return String(t).replace(o,".").toLowerCase()},a=s.data={},l=s.NATIVE="N",c=s.POLYFILL="P";t.exports=s},function(t,e,n){var r=n(68),i=n(34),o=i.concat("length","prototype");e.f=Object.getOwnPropertyNames||function(t){return r(t,o)}},function(t,e,n){var r=n(1),i=n(7),o=n(19),s=n(57).indexOf,u=n(38),a=r([].push);t.exports=function(t,e){var n,r=o(t),l=0,c=[];for(n in r)!i(u,n)&&i(r,n)&&a(c,n);for(;e.length>l;)i(r,n=e[l++])&&(~s(c,n)||a(c,n));return c}},function(t,e,n){"use strict";var r=n(6);t.exports=function(){var t=r(this),e="";return t.hasIndices&&(e+="d"),t.global&&(e+="g"),t.ignoreCase&&(e+="i"),t.multiline&&(e+="m"),t.dotAll&&(e+="s"),t.unicode&&(e+="u"),t.unicodeSets&&(e+="v"),t.sticky&&(e+="y"),e}},function(t,e,n){var r=n(47),i=n(75),o=r("keys");t.exports=function(t){return o[t]||(o[t]=i(t))}},function(t,e,n){var r=n(1),i=n(24),o=n(20),s=n(78),u=r("".replace),a="["+s+"]",l=RegExp("^"+a+a+"*"),c=RegExp(a+a+"*$"),f=function(t){return function(e){var n=o(i(e));return 1&t&&(n=u(n,l,"")),2&t&&(n=u(n,c,"")),n}};t.exports={start:f(1),end:f(2),trim:f(3)}},function(t,e,n){var r=n(23),i=n(0);t.exports=!!Object.getOwnPropertySymbols&&!i(function(){var t=Symbol();return!String(t)||!(Object(t)instanceof Symbol)||!Symbol.sham&&r&&r<41})},function(t,e,n){var r=n(12),i=n(8),o=n(41),s=n(61),u=n(113),a=n(9),l=TypeError,c=a("toPrimitive");t.exports=function(t,e){if(!i(t)||o(t))return t;var n,a=s(t,c);if(a){if(void 0===e&&(e="default"),n=r(a,t,e),!i(n)||o(n))return n;throw l("Can't convert object to primitive value")}return void 0===e&&(e="number"),u(t,e)}},function(t,e){var n=String;t.exports=function(t){try{return n(t)}catch(t){return"Object"}}},function(t,e,n){var r=n(1),i=0,o=Math.random(),s=r(1..toString);t.exports=function(t){return"Symbol("+(void 0===t?"":t)+")_"+s(++i+o,36)}},function(t,e,n){var r=n(72);t.exports=r&&!Symbol.sham&&"symbol"==typeof Symbol.iterator},function(t,e,n){var r=n(5),i=n(0);t.exports=r&&i(function(){return 42!=Object.defineProperty(function(){},"prototype",{value:42,writable:!1}).prototype})},function(t,e){t.exports="\t\n\v\f\r                　\u2028\u2029\ufeff"},function(t,e,n){"use strict";var r=n(3),i=n(21).find,o=n(91),s=!0;"find"in[]&&Array(1).find(function(){s=!1}),r({target:"Array",proto:!0,forced:s},{find:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}}),o("find")},function(t,e,n){"use strict";var r=n(3),i=n(18),o=n(65),s=n(8),u=n(48),a=n(10),l=n(19),c=n(32),f=n(9),p=n(16),h=n(93),d=p("slice"),v=f("species"),g=Array,y=Math.max;r({target:"Array",proto:!0,forced:!d},{slice:function(t,e){var n,r,f,p=l(this),d=a(p),b=u(t,d),m=u(void 0===e?d:e,d);if(i(p)&&(n=p.constructor,o(n)&&(n===g||i(n.prototype))?n=void 0:s(n)&&null===(n=n[v])&&(n=void 0),n===g||void 0===n))return h(p,b,m);for(r=new(void 0===n?g:n)(y(m-b,0)),f=0;b<m;b++,f++)b in p&&c(r,f,p[b]);return r.length=f,r}})},function(t,e,n){var r=n(1),i=n(11),o=Date.prototype,s=r(o.toString),u=r(o.getTime);"Invalid Date"!=String(new Date(NaN))&&i(o,"toString",function(){var t=u(this);return t===t?s(this):"Invalid Date"})},function(t,e,n){var r=n(11),i=n(98),o=Error.prototype;o.toString!==i&&r(o,"toString",i)},function(t,e,n){var r=n(51),i=n(11),o=n(112);r||i(Object.prototype,"toString",o,{unsafe:!0})},function(t,e,n){"use strict";var r=n(36).PROPER,i=n(11),o=n(6),s=n(20),u=n(0),a=n(116),l=RegExp.prototype,c=l.toString,f=u(function(){return"/a/b"!=c.call({source:"a",flags:"b"})}),p=r&&"toString"!=c.name;(f||p)&&i(RegExp.prototype,"toString",function(){var t=o(this);return"/"+s(t.source)+"/"+s(a(t))},{unsafe:!0})},function(t,e,n){"use strict";var r=n(12),i=n(99),o=n(6),s=n(40),u=n(24),a=n(120),l=n(20),c=n(61),f=n(115);i("search",function(t,e,n){return[function(e){var n=u(this),i=s(e)?void 0:c(e,t);return i?r(i,e,n):new RegExp(e)[t](l(n))},function(t){var r=o(this),i=l(t),s=n(e,r,i);if(s.done)return s.value;var u=r.lastIndex;a(u,0)||(r.lastIndex=0);var c=f(r,i);return a(r.lastIndex,u)||(r.lastIndex=u),null===c?-1:c.index}]})},function(t,e,n){"use strict";function r(t){n(136)}var i=n(56),o=n(138),s=n(137),u=r,a=s(i.a,o.a,!1,u,null,null);e.a=a.exports},function(t,e,n){"use strict";function r(t,e,n){return e in t?Object.defineProperty(t,e,{value:n,enumerable:!0,configurable:!0,writable:!0}):t[e]=n,t}e.a=r},function(t,e,n){"use strict";function r(t){"@babel/helpers - typeof";return(r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(t){return typeof t}:function(t){return t&&"function"==typeof Symbol&&t.constructor===Symbol&&t!==Symbol.prototype?"symbol":typeof t})(t)}e.a=r},function(t,e,n){"use strict";Object.defineProperty(e,"__esModule",{value:!0});var r=n(86),i=n(54),o=n(55);n.d(e,"Multiselect",function(){return r.a}),n.d(e,"multiselectMixin",function(){return i.a}),n.d(e,"pointerMixin",function(){return o.a}),e.default=r.a},function(t,e,n){var r=n(2),i=String,o=TypeError;t.exports=function(t){if("object"==typeof t||r(t))return t;throw o("Can't set "+i(t)+" as a prototype")}},function(t,e,n){var r=n(9),i=n(42),o=n(13).f,s=r("unscopables"),u=Array.prototype;void 0==u[s]&&o(u,s,{configurable:!0,value:i(null)}),t.exports=function(t){u[s][t]=!0}},function(t,e,n){var r=n(25),i=n(14),o=n(39),s=n(10),u=TypeError,a=function(t){return function(e,n,a,l){r(n);var c=i(e),f=o(c),p=s(c),h=t?p-1:0,d=t?-1:1;if(a<2)for(;;){if(h in f){l=f[h],h+=d;break}if(h+=d,t?h<0:p<=h)throw u("Reduce of empty array with no initial value")}for(;t?h>=0:p>h;h+=d)h in f&&(l=n(l,f[h],h,c));return l}};t.exports={left:a(!1),right:a(!0)}},function(t,e,n){var r=n(1);t.exports=r([].slice)},function(t,e,n){var r=n(18),i=n(65),o=n(8),s=n(9),u=s("species"),a=Array;t.exports=function(t){var e;return r(t)&&(e=t.constructor,i(e)&&(e===a||r(e.prototype))?e=void 0:o(e)&&null===(e=e[u])&&(e=void 0)),void 0===e?a:e}},function(t,e,n){var r=n(7),i=n(114),o=n(43),s=n(13);t.exports=function(t,e,n){for(var u=i(e),a=s.f,l=o.f,c=0;c<u.length;c++){var f=u[c];r(t,f)||n&&r(n,f)||a(t,f,l(e,f))}}},function(t,e,n){var r=n(15),i=n(4);t.exports="process"==r(i.process)},function(t,e,n){var r=n(17);t.exports=r("navigator","userAgent")||""},function(t,e,n){"use strict";var r=n(5),i=n(0),o=n(6),s=n(42),u=n(106),a=Error.prototype.toString,l=i(function(){if(r){var t=s(Object.defineProperty({},"name",{get:function(){return this===t}}));if("true"!==a.call(t))return!0}return"2: 1"!==a.call({message:1,name:2})||"Error"!==a.call({})});t.exports=l?function(){var t=o(this),e=u(t.name,"Error"),n=u(t.message);return e?n?e+": "+n:e:n}:a},function(t,e,n){"use strict";n(53);var r=n(37),i=n(11),o=n(45),s=n(0),u=n(9),a=n(30),l=u("species"),c=RegExp.prototype;t.exports=function(t,e,n,f){var p=u(t),h=!s(function(){var e={};return e[p]=function(){return 7},7!=""[t](e)}),d=h&&!s(function(){var e=!1,n=/a/;return"split"===t&&(n={},n.constructor={},n.constructor[l]=function(){return n},n.flags="",n[p]=/./[p]),n.exec=function(){return e=!0,null},n[p](""),!e});if(!h||!d||n){var v=r(/./[p]),g=e(p,""[t],function(t,e,n,i,s){var u=r(t),a=e.exec;return a===o||a===c.exec?h&&!s?{done:!0,value:v(e,n,i)}:{done:!0,value:u(n,e,i)}:{done:!1}});i(String.prototype,t,g[0]),i(c,p,g[1])}f&&a(c[p],"sham",!0)}},function(t,e,n){var r=n(37),i=n(25),o=n(35),s=r(r.bind);t.exports=function(t,e){return i(t),void 0===e?t:o?s(t,e):function(){return t.apply(e,arguments)}}},function(t,e,n){var r=n(17);t.exports=r("document","documentElement")},function(t,e,n){var r=n(2),i=n(8),o=n(111);t.exports=function(t,e,n){var s,u;return o&&r(s=e.constructor)&&s!==n&&i(u=s.prototype)&&u!==n.prototype&&o(t,u),t}},function(t,e){t.exports=!1},function(t,e,n){var r=n(0),i=n(2),o=n(7),s=n(5),u=n(36).CONFIGURABLE,a=n(63),l=n(64),c=l.enforce,f=l.get,p=Object.defineProperty,h=s&&!r(function(){return 8!==p(function(){},"length",{value:8}).length}),d=String(String).split("String"),v=t.exports=function(t,e,n){"Symbol("===String(e).slice(0,7)&&(e="["+String(e).replace(/^Symbol\(([^)]*)\)/,"$1")+"]"),n&&n.getter&&(e="get "+e),n&&n.setter&&(e="set "+e),(!o(t,"name")||u&&t.name!==e)&&(s?p(t,"name",{value:e,configurable:!0}):t.name=e),h&&n&&o(n,"arity")&&t.length!==n.arity&&p(t,"length",{value:n.arity});try{n&&o(n,"constructor")&&n.constructor?s&&p(t,"prototype",{writable:!1}):t.prototype&&(t.prototype=void 0)}catch(t){}var r=c(t);return o(r,"source")||(r.source=d.join("string"==typeof e?e:"")),t};Function.prototype.toString=v(function(){return i(this)&&f(this).source||a(this)},"toString")},function(t,e){var n=Math.ceil,r=Math.floor;t.exports=Math.trunc||function(t){var e=+t;return(e>0?r:n)(e)}},function(t,e,n){var r=n(20);t.exports=function(t,e){return void 0===t?arguments.length<2?"":e:r(t)}},function(t,e,n){var r=n(5),i=n(77),o=n(13),s=n(6),u=n(19),a=n(109);e.f=r&&!i?Object.defineProperties:function(t,e){s(t);for(var n,r=u(e),i=a(e),l=i.length,c=0;l>c;)o.f(t,n=i[c++],r[n]);return t}},function(t,e){e.f=Object.getOwnPropertySymbols},function(t,e,n){var r=n(68),i=n(34);t.exports=Object.keys||function(t){return r(t,i)}},function(t,e,n){"use strict";var r={}.propertyIsEnumerable,i=Object.getOwnPropertyDescriptor,o=i&&!r.call({1:2},1);e.f=o?function(t){var e=i(this,t);return!!e&&e.enumerable}:r},function(t,e,n){var r=n(1),i=n(6),o=n(90);t.exports=Object.setPrototypeOf||("__proto__"in{}?function(){var t,e=!1,n={};try{t=r(Object.getOwnPropertyDescriptor(Object.prototype,"__proto__").set),t(n,[]),e=n instanceof Array}catch(t){}return function(n,r){return i(n),o(r),e?t(n,r):n.__proto__=r,n}}():void 0)},function(t,e,n){"use strict";var r=n(51),i=n(29);t.exports=r?{}.toString:function(){return"[object "+i(this)+"]"}},function(t,e,n){var r=n(12),i=n(2),o=n(8),s=TypeError;t.exports=function(t,e){var n,u;if("string"===e&&i(n=t.toString)&&!o(u=r(n,t)))return u;if(i(n=t.valueOf)&&!o(u=r(n,t)))return u;if("string"!==e&&i(n=t.toString)&&!o(u=r(n,t)))return u;throw s("Can't convert object to primitive value")}},function(t,e,n){var r=n(17),i=n(1),o=n(67),s=n(108),u=n(6),a=i([].concat);t.exports=r("Reflect","ownKeys")||function(t){var e=o.f(u(t)),n=s.f;return n?a(e,n(t)):e}},function(t,e,n){var r=n(12),i=n(6),o=n(2),s=n(15),u=n(45),a=TypeError;t.exports=function(t,e){var n=t.exec;if(o(n)){var l=r(n,t,e);return null!==l&&i(l),l}if("RegExp"===s(t))return r(u,t,e);throw a("RegExp#exec called on incompatible receiver")}},function(t,e,n){var r=n(12),i=n(7),o=n(44),s=n(69),u=RegExp.prototype;t.exports=function(t){var e=t.flags;return void 0!==e||"flags"in u||i(t,"flags")||!o(u,t)?e:r(s,t)}},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp,s=r(function(){var t=o("a","y");return t.lastIndex=2,null!=t.exec("abcd")}),u=s||r(function(){return!o("a","y").sticky}),a=s||r(function(){var t=o("^r","gy");return t.lastIndex=2,null!=t.exec("str")});t.exports={BROKEN_CARET:a,MISSED_STICKY:u,UNSUPPORTED_Y:s}},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp;t.exports=r(function(){var t=o(".","s");return!(t.dotAll&&t.exec("\n")&&"s"===t.flags)})},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp;t.exports=r(function(){var t=o("(?<a>b)","g");return"b"!==t.exec("b").groups.a||"bc"!=="b".replace(t,"$<a>c")})},function(t,e){t.exports=Object.is||function(t,e){return t===e?0!==t||1/t==1/e:t!=t&&e!=e}},function(t,e,n){var r=n(36).PROPER,i=n(0),o=n(78),s="​᠎";t.exports=function(t){return i(function(){return!!o[t]()||s[t]()!==s||r&&o[t].name!==t})}},function(t,e,n){var r=n(1);t.exports=r(1..valueOf)},function(t,e,n){var r=n(49),i=Math.min;t.exports=function(t){return t>0?i(r(t),9007199254740991):0}},function(t,e,n){var r=n(4),i=n(2),o=r.WeakMap;t.exports=i(o)&&/native code/.test(String(o))},function(t,e,n){"use strict";var r=n(3),i=n(0),o=n(18),s=n(8),u=n(14),a=n(10),l=n(22),c=n(32),f=n(28),p=n(16),h=n(9),d=n(23),v=h("isConcatSpreadable"),g=d>=51||!i(function(){var t=[];return t[v]=!1,t.concat()[0]!==t}),y=p("concat"),b=function(t){if(!s(t))return!1;var e=t[v];return void 0!==e?!!e:o(t)};r({target:"Array",proto:!0,arity:1,forced:!g||!y},{concat:function(t){var e,n,r,i,o,s=u(this),p=f(s,0),h=0;for(e=-1,r=arguments.length;e<r;e++)if(o=-1===e?s:arguments[e],b(o))for(i=a(o),l(h+i),n=0;n<i;n++,h++)n in o&&c(p,h,o[n]);else l(h+1),c(p,h++,o);return p.length=h,p}})},function(t,e,n){"use strict";var r=n(3),i=n(21).every;r({target:"Array",proto:!0,forced:!n(26)("every")},{every:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(21).filter;r({target:"Array",proto:!0,forced:!n(16)("filter")},{filter:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(37),o=n(57).indexOf,s=n(26),u=i([].indexOf),a=!!u&&1/u([1],1,-0)<0,l=s("indexOf");r({target:"Array",proto:!0,forced:a||!l},{indexOf:function(t){var e=arguments.length>1?arguments[1]:void 0;return a?u(this,t,e)||0:o(this,t,e)}})},function(t,e,n){n(3)({target:"Array",stat:!0},{isArray:n(18)})},function(t,e,n){"use strict";var r=n(3),i=n(21).map;r({target:"Array",proto:!0,forced:!n(16)("map")},{map:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(10),s=n(27),u=n(22),a=n(0),l=a(function(){return 4294967297!==[].push.call({length:4294967296},1)}),c=!function(){try{Object.defineProperty([],"length",{writable:!1}).push()}catch(t){return t instanceof TypeError}}();r({target:"Array",proto:!0,arity:1,forced:l||c},{push:function(t){var e=i(this),n=o(e),r=arguments.length;u(n+r);for(var a=0;a<r;a++)e[n]=arguments[a],n++;return s(e,n),n}})},function(t,e,n){"use strict";var r=n(3),i=n(92).left,o=n(26),s=n(23),u=n(96),a=o("reduce"),l=!u&&s>79&&s<83;r({target:"Array",proto:!0,forced:!a||l},{reduce:function(t){var e=arguments.length;return i(this,t,e,e>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(48),s=n(49),u=n(10),a=n(27),l=n(22),c=n(28),f=n(32),p=n(58),h=n(16),d=h("splice"),v=Math.max,g=Math.min;r({target:"Array",proto:!0,forced:!d},{splice:function(t,e){var n,r,h,d,y,b,m=i(this),x=u(m),_=o(t,x),O=arguments.length;for(0===O?n=r=0:1===O?(n=0,r=x-_):(n=O-2,r=g(v(s(e),0),x-_)),l(x+n-r),h=c(m,r),d=0;d<r;d++)(y=_+d)in m&&f(h,d,m[y]);if(h.length=r,n<r){for(d=_;d<x-r;d++)y=d+r,b=d+n,y in m?m[b]=m[y]:p(m,b);for(d=x;d>x-r+n;d--)p(m,d-1)}else if(n>r)for(d=x-r;d>_;d--)y=d+r-1,b=d+n-1,y in m?m[b]=m[y]:p(m,b);for(d=0;d<n;d++)m[d+_]=arguments[d+2];return a(m,x-r+n),h}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(10),s=n(27),u=n(58),a=n(22),l=1!==[].unshift(0),c=!function(){try{Object.defineProperty([],"length",{writable:!1}).unshift()}catch(t){return t instanceof TypeError}}();r({target:"Array",proto:!0,arity:1,forced:l||c},{unshift:function(t){var e=i(this),n=o(e),r=arguments.length;if(r){a(n+r);for(var l=n;l--;){var c=l+r;l in e?e[c]=e[l]:u(e,c)}for(var f=0;f<r;f++)e[f]=arguments[f]}return s(e,n+r)}})},function(t,e,n){"use strict";var r=n(3),i=n(71).trim;r({target:"String",proto:!0,forced:n(121)("trim")},{trim:function(){return i(this)}})},function(t,e){},function(t,e){t.exports=function(t,e,n,r,i,o){var s,u=t=t||{},a=typeof t.default;"object"!==a&&"function"!==a||(s=t,u=t.default);var l="function"==typeof u?u.options:u;e&&(l.render=e.render,l.staticRenderFns=e.staticRenderFns,l._compiled=!0),n&&(l.functional=!0),i&&(l._scopeId=i);var c;if(o?(c=function(t){t=t||this.$vnode&&this.$vnode.ssrContext||this.parent&&this.parent.$vnode&&this.parent.$vnode.ssrContext,t||"undefined"==typeof __VUE_SSR_CONTEXT__||(t=__VUE_SSR_CONTEXT__),r&&r.call(this,t),t&&t._registeredComponents&&t._registeredComponents.add(o)},l._ssrRegister=c):r&&(c=r),c){var f=l.functional,p=f?l.render:l.beforeCreate;f?(l._injectStyles=c,l.render=function(t,e){return c.call(e),p(t,e)}):l.beforeCreate=p?[].concat(p,c):[c]}return{esModule:s,exports:u,options:l}}},function(t,e,n){"use strict";var r=function(){var t=this,e=t.$createElement,n=t._self._c||e;return n("div",{staticClass:"multiselect",class:{"multiselect--active":t.isOpen,"multiselect--disabled":t.disabled,"multiselect--above":t.isAbove,"multiselect--has-options-group":t.hasOptionGroup},attrs:{tabindex:t.searchable?-1:t.tabindex,role:"combobox","aria-owns":"listbox-"+t.id},on:{focus:function(e){return t.activate()},blur:function(e){!t.searchable&&t.deactivate()},keydown:[function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"down",40,e.key,["Down","ArrowDown"])?null:e.target!==e.currentTarget?null:(e.preventDefault(),t.pointerForward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"up",38,e.key,["Up","ArrowUp"])?null:e.target!==e.currentTarget?null:(e.preventDefault(),t.pointerBackward())}],keypress:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"enter",13,e.key,"Enter")&&t._k(e.keyCode,"tab",9,e.key,"Tab")?null:(e.stopPropagation(),e.target!==e.currentTarget?null:t.addPointerElement(e))},keyup:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"esc",27,e.key,["Esc","Escape"])?null:t.deactivate()}}},[t._t("caret",function(){return[n("div",{staticClass:"multiselect__select",on:{mousedown:function(e){return e.preventDefault(),e.stopPropagation(),t.toggle()}}})]},{toggle:t.toggle}),t._v(" "),t._t("clear",null,{search:t.search}),t._v(" "),n("div",{ref:"tags",staticClass:"multiselect__tags"},[t._t("selection",function(){return[n("div",{directives:[{name:"show",rawName:"v-show",value:t.visibleValues.length>0,expression:"visibleValues.length > 0"}],staticClass:"multiselect__tags-wrap"},[t._l(t.visibleValues,function(e,r){return[t._t("tag",function(){return[n("span",{key:r,staticClass:"multiselect__tag"},[n("span",{domProps:{textContent:t._s(t.getOptionLabel(e))}}),t._v(" "),n("i",{staticClass:"multiselect__tag-icon",attrs:{tabindex:"1"},on:{keypress:function(n){return!n.type.indexOf("key")&&t._k(n.keyCode,"enter",13,n.key,"Enter")?null:(n.preventDefault(),t.removeElement(e))},mousedown:function(n){return n.preventDefault(),t.removeElement(e)}}})])]},{option:e,search:t.search,remove:t.removeElement})]})],2),t._v(" "),t.internalValue&&t.internalValue.length>t.limit?[t._t("limit",function(){return[n("strong",{staticClass:"multiselect__strong",domProps:{textContent:t._s(t.limitText(t.internalValue.length-t.limit))}})]})]:t._e()]},{search:t.search,remove:t.removeElement,values:t.visibleValues,isOpen:t.isOpen}),t._v(" "),n("transition",{attrs:{name:"multiselect__loading"}},[t._t("loading",function(){return[n("div",{directives:[{name:"show",rawName:"v-show",value:t.loading,expression:"loading"}],staticClass:"multiselect__spinner"})]})],2),t._v(" "),t.searchable?n("input",{ref:"search",staticClass:"multiselect__input",style:t.inputStyle,attrs:{name:t.name,id:t.id,type:"text",autocomplete:"off",spellcheck:"false",placeholder:t.placeholder,disabled:t.disabled,tabindex:t.tabindex,"aria-controls":"listbox-"+t.id},domProps:{value:t.search},on:{input:function(e){return t.updateSearch(e.target.value)},focus:function(e){return e.preventDefault(),t.activate()},blur:function(e){return e.preventDefault(),t.deactivate()},keyup:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"esc",27,e.key,["Esc","Escape"])?null:t.deactivate()},keydown:[function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"down",40,e.key,["Down","ArrowDown"])?null:(e.preventDefault(),t.pointerForward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"up",38,e.key,["Up","ArrowUp"])?null:(e.preventDefault(),t.pointerBackward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"delete",[8,46],e.key,["Backspace","Delete","Del"])?null:(e.stopPropagation(),t.removeLastElement())}],keypress:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"enter",13,e.key,"Enter")?null:(e.preventDefault(),e.stopPropagation(),e.target!==e.currentTarget?null:t.addPointerElement(e))}}}):t._e(),t._v(" "),t.isSingleLabelVisible?n("span",{staticClass:"multiselect__single",on:{mousedown:function(e){return e.preventDefault(),t.toggle.apply(null,arguments)}}},[t._t("singleLabel",function(){return[[t._v(t._s(t.currentOptionLabel))]]},{option:t.singleValue})],2):t._e(),t._v(" "),t.isPlaceholderVisible?n("span",{staticClass:"multiselect__placeholder",on:{mousedown:function(e){return e.preventDefault(),t.toggle.apply(null,arguments)}}},[t._t("placeholder",function(){return[t._v("\n          "+t._s(t.placeholder)+"\n        ")]})],2):t._e()],2),t._v(" "),n("transition",{attrs:{name:"multiselect"}},[n("div",{directives:[{name:"show",rawName:"v-show",value:t.isOpen,expression:"isOpen"}],ref:"list",staticClass:"multiselect__content-wrapper",style:{maxHeight:t.optimizedHeight+"px"},attrs:{tabindex:"-1"},on:{focus:t.activate,mousedown:function(t){t.preventDefault()}}},[n("ul",{staticClass:"multiselect__content",style:t.contentStyle,attrs:{role:"listbox",id:"listbox-"+t.id}},[t._t("beforeList"),t._v(" "),t.multiple&&t.max===t.internalValue.length?n("li",[n("span",{staticClass:"multiselect__option"},[t._t("maxElements",function(){return[t._v("Maximum of "+t._s(t.max)+" options selected. First remove a selected option to select another.")]})],2)]):t._e(),t._v(" "),!t.max||t.internalValue.length<t.max?t._l(t.filteredOptions,function(e,r){return n("li",{key:r,staticClass:"multiselect__element",attrs:{id:t.id+"-"+r,role:e&&(e.$isLabel||e.$isDisabled)?null:"option"}},[e&&(e.$isLabel||e.$isDisabled)?t._e():n("span",{staticClass:"multiselect__option",class:t.optionHighlight(r,e),attrs:{"data-select":e&&e.isTag?t.tagPlaceholder:t.selectLabelText,"data-selected":t.selectedLabelText,"data-deselect":t.deselectLabelText},on:{click:function(n){return n.stopPropagation(),t.select(e)},mouseenter:function(e){return e.target!==e.currentTarget?null:t.pointerSet(r)}}},[t._t("option",function(){return[n("span",[t._v(t._s(t.getOptionLabel(e)))])]},{option:e,search:t.search,index:r})],2),t._v(" "),e&&(e.$isLabel||e.$isDisabled)?n("span",{staticClass:"multiselect__option",class:t.groupHighlight(r,e),attrs:{"data-select":t.groupSelect&&t.selectGroupLabelText,"data-deselect":t.groupSelect&&t.deselectGroupLabelText},on:{mouseenter:function(e){if(e.target!==e.currentTarget)return null;t.groupSelect&&t.pointerSet(r)},mousedown:function(n){return n.preventDefault(),t.selectGroup(e)}}},[t._t("option",function(){return[n("span",[t._v(t._s(t.getOptionLabel(e)))])]},{option:e,search:t.search,index:r})],2):t._e()])}):t._e(),t._v(" "),n("li",{directives:[{name:"show",rawName:"v-show",value:t.showNoResults&&0===t.filteredOptions.length&&t.search&&!t.loading,expression:"showNoResults && (filteredOptions.length === 0 && search && !loading)"}]},[n("span",{staticClass:"multiselect__option"},[t._t("noResult",function(){return[t._v("No elements found. Consider changing the search query.")]},{search:t.search})],2)]),t._v(" "),n("li",{directives:[{name:"show",rawName:"v-show",value:t.showNoOptions&&(0===t.options.length||!0===t.hasOptionGroup&&0===t.filteredOptions.length)&&!t.search&&!t.loading,expression:"showNoOptions && ((options.length === 0 || (hasOptionGroup === true && filteredOptions.length === 0)) && !search && !loading)"}]},[n("span",{staticClass:"multiselect__option"},[t._t("noOptions",function(){return[t._v("List is empty.")]})],2)]),t._v(" "),t._t("afterList")],2)])])],2)},i=[],o={render:r,staticRenderFns:i};e.a=o},function(t,e){var n;n=function(){return this}();try{n=n||Function("return this")()||(0,eval)("this")}catch(t){"object"==typeof window&&(n=window)}t.exports=n}])});
+!function(t,e){ true?module.exports=e():undefined}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="/",e(e.s=89)}([function(t,e){t.exports=function(t){try{return!!t()}catch(t){return!0}}},function(t,e,n){var r=n(35),i=Function.prototype,o=i.call,s=r&&i.bind.bind(o,o);t.exports=r?s:function(t){return function(){return o.apply(t,arguments)}}},function(t,e,n){var r=n(59),i=r.all;t.exports=r.IS_HTMLDDA?function(t){return"function"==typeof t||t===i}:function(t){return"function"==typeof t}},function(t,e,n){var r=n(4),i=n(43).f,o=n(30),s=n(11),u=n(33),a=n(95),l=n(66);t.exports=function(t,e){var n,c,f,p,h,d=t.target,v=t.global,g=t.stat;if(n=v?r:g?r[d]||u(d,{}):(r[d]||{}).prototype)for(c in e){if(p=e[c],t.dontCallGetSet?(h=i(n,c),f=h&&h.value):f=n[c],!l(v?c:d+(g?".":"#")+c,t.forced)&&void 0!==f){if(typeof p==typeof f)continue;a(p,f)}(t.sham||f&&f.sham)&&o(p,"sham",!0),s(n,c,p,t)}}},function(t,e,n){(function(e){var n=function(t){return t&&t.Math==Math&&t};t.exports=n("object"==typeof globalThis&&globalThis)||n("object"==typeof window&&window)||n("object"==typeof self&&self)||n("object"==typeof e&&e)||function(){return this}()||Function("return this")()}).call(e,n(139))},function(t,e,n){var r=n(0);t.exports=!r(function(){return 7!=Object.defineProperty({},1,{get:function(){return 7}})[1]})},function(t,e,n){var r=n(8),i=String,o=TypeError;t.exports=function(t){if(r(t))return t;throw o(i(t)+" is not an object")}},function(t,e,n){var r=n(1),i=n(14),o=r({}.hasOwnProperty);t.exports=Object.hasOwn||function(t,e){return o(i(t),e)}},function(t,e,n){var r=n(2),i=n(59),o=i.all;t.exports=i.IS_HTMLDDA?function(t){return"object"==typeof t?null!==t:r(t)||t===o}:function(t){return"object"==typeof t?null!==t:r(t)}},function(t,e,n){var r=n(4),i=n(47),o=n(7),s=n(75),u=n(72),a=n(76),l=i("wks"),c=r.Symbol,f=c&&c.for,p=a?c:c&&c.withoutSetter||s;t.exports=function(t){if(!o(l,t)||!u&&"string"!=typeof l[t]){var e="Symbol."+t;u&&o(c,t)?l[t]=c[t]:l[t]=a&&f?f(e):p(e)}return l[t]}},function(t,e,n){var r=n(123);t.exports=function(t){return r(t.length)}},function(t,e,n){var r=n(2),i=n(13),o=n(104),s=n(33);t.exports=function(t,e,n,u){u||(u={});var a=u.enumerable,l=void 0!==u.name?u.name:e;if(r(n)&&o(n,l,u),u.global)a?t[e]=n:s(e,n);else{try{u.unsafe?t[e]&&(a=!0):delete t[e]}catch(t){}a?t[e]=n:i.f(t,e,{value:n,enumerable:!1,configurable:!u.nonConfigurable,writable:!u.nonWritable})}return t}},function(t,e,n){var r=n(35),i=Function.prototype.call;t.exports=r?i.bind(i):function(){return i.apply(i,arguments)}},function(t,e,n){var r=n(5),i=n(62),o=n(77),s=n(6),u=n(50),a=TypeError,l=Object.defineProperty,c=Object.getOwnPropertyDescriptor;e.f=r?o?function(t,e,n){if(s(t),e=u(e),s(n),"function"==typeof t&&"prototype"===e&&"value"in n&&"writable"in n&&!n.writable){var r=c(t,e);r&&r.writable&&(t[e]=n.value,n={configurable:"configurable"in n?n.configurable:r.configurable,enumerable:"enumerable"in n?n.enumerable:r.enumerable,writable:!1})}return l(t,e,n)}:l:function(t,e,n){if(s(t),e=u(e),s(n),i)try{return l(t,e,n)}catch(t){}if("get"in n||"set"in n)throw a("Accessors not supported");return"value"in n&&(t[e]=n.value),t}},function(t,e,n){var r=n(24),i=Object;t.exports=function(t){return i(r(t))}},function(t,e,n){var r=n(1),i=r({}.toString),o=r("".slice);t.exports=function(t){return o(i(t),8,-1)}},function(t,e,n){var r=n(0),i=n(9),o=n(23),s=i("species");t.exports=function(t){return o>=51||!r(function(){var e=[],n=e.constructor={};return n[s]=function(){return{foo:1}},1!==e[t](Boolean).foo})}},function(t,e,n){var r=n(4),i=n(2),o=function(t){return i(t)?t:void 0};t.exports=function(t,e){return arguments.length<2?o(r[t]):r[t]&&r[t][e]}},function(t,e,n){var r=n(15);t.exports=Array.isArray||function(t){return"Array"==r(t)}},function(t,e,n){var r=n(39),i=n(24);t.exports=function(t){return r(i(t))}},function(t,e,n){var r=n(29),i=String;t.exports=function(t){if("Symbol"===r(t))throw TypeError("Cannot convert a Symbol value to a string");return i(t)}},function(t,e,n){var r=n(100),i=n(1),o=n(39),s=n(14),u=n(10),a=n(28),l=i([].push),c=function(t){var e=1==t,n=2==t,i=3==t,c=4==t,f=6==t,p=7==t,h=5==t||f;return function(d,v,g,y){for(var b,m,x=s(d),_=o(x),O=r(v,g),w=u(_),S=0,E=y||a,k=e?E(d,w):n||p?E(d,0):void 0;w>S;S++)if((h||S in _)&&(b=_[S],m=O(b,S,x),t))if(e)k[S]=m;else if(m)switch(t){case 3:return!0;case 5:return b;case 6:return S;case 2:l(k,b)}else switch(t){case 4:return!1;case 7:l(k,b)}return f?-1:i||c?c:k}};t.exports={forEach:c(0),map:c(1),filter:c(2),some:c(3),every:c(4),find:c(5),findIndex:c(6),filterReject:c(7)}},function(t,e){var n=TypeError;t.exports=function(t){if(t>9007199254740991)throw n("Maximum allowed index exceeded");return t}},function(t,e,n){var r,i,o=n(4),s=n(97),u=o.process,a=o.Deno,l=u&&u.versions||a&&a.version,c=l&&l.v8;c&&(r=c.split("."),i=r[0]>0&&r[0]<4?1:+(r[0]+r[1])),!i&&s&&(!(r=s.match(/Edge\/(\d+)/))||r[1]>=74)&&(r=s.match(/Chrome\/(\d+)/))&&(i=+r[1]),t.exports=i},function(t,e,n){var r=n(40),i=TypeError;t.exports=function(t){if(r(t))throw i("Can't call method on "+t);return t}},function(t,e,n){var r=n(2),i=n(74),o=TypeError;t.exports=function(t){if(r(t))return t;throw o(i(t)+" is not a function")}},function(t,e,n){"use strict";var r=n(0);t.exports=function(t,e){var n=[][t];return!!n&&r(function(){n.call(null,e||function(){return 1},1)})}},function(t,e,n){"use strict";var r=n(5),i=n(18),o=TypeError,s=Object.getOwnPropertyDescriptor,u=r&&!function(){if(void 0!==this)return!0;try{Object.defineProperty([],"length",{writable:!1}).length=1}catch(t){return t instanceof TypeError}}();t.exports=u?function(t,e){if(i(t)&&!s(t,"length").writable)throw o("Cannot set read only .length");return t.length=e}:function(t,e){return t.length=e}},function(t,e,n){var r=n(94);t.exports=function(t,e){return new(r(t))(0===e?0:e)}},function(t,e,n){var r=n(51),i=n(2),o=n(15),s=n(9),u=s("toStringTag"),a=Object,l="Arguments"==o(function(){return arguments}()),c=function(t,e){try{return t[e]}catch(t){}};t.exports=r?o:function(t){var e,n,r;return void 0===t?"Undefined":null===t?"Null":"string"==typeof(n=c(e=a(t),u))?n:l?o(e):"Object"==(r=o(e))&&i(e.callee)?"Arguments":r}},function(t,e,n){var r=n(5),i=n(13),o=n(31);t.exports=r?function(t,e,n){return i.f(t,e,o(1,n))}:function(t,e,n){return t[e]=n,t}},function(t,e){t.exports=function(t,e){return{enumerable:!(1&t),configurable:!(2&t),writable:!(4&t),value:e}}},function(t,e,n){"use strict";var r=n(50),i=n(13),o=n(31);t.exports=function(t,e,n){var s=r(e);s in t?i.f(t,s,o(0,n)):t[s]=n}},function(t,e,n){var r=n(4),i=Object.defineProperty;t.exports=function(t,e){try{i(r,t,{value:e,configurable:!0,writable:!0})}catch(n){r[t]=e}return e}},function(t,e){t.exports=["constructor","hasOwnProperty","isPrototypeOf","propertyIsEnumerable","toLocaleString","toString","valueOf"]},function(t,e,n){var r=n(0);t.exports=!r(function(){var t=function(){}.bind();return"function"!=typeof t||t.hasOwnProperty("prototype")})},function(t,e,n){var r=n(5),i=n(7),o=Function.prototype,s=r&&Object.getOwnPropertyDescriptor,u=i(o,"name"),a=u&&"something"===function(){}.name,l=u&&(!r||r&&s(o,"name").configurable);t.exports={EXISTS:u,PROPER:a,CONFIGURABLE:l}},function(t,e,n){var r=n(15),i=n(1);t.exports=function(t){if("Function"===r(t))return i(t)}},function(t,e){t.exports={}},function(t,e,n){var r=n(1),i=n(0),o=n(15),s=Object,u=r("".split);t.exports=i(function(){return!s("z").propertyIsEnumerable(0)})?function(t){return"String"==o(t)?u(t,""):s(t)}:s},function(t,e){t.exports=function(t){return null===t||void 0===t}},function(t,e,n){var r=n(17),i=n(2),o=n(44),s=n(76),u=Object;t.exports=s?function(t){return"symbol"==typeof t}:function(t){var e=r("Symbol");return i(e)&&o(e.prototype,u(t))}},function(t,e,n){var r,i=n(6),o=n(107),s=n(34),u=n(38),a=n(101),l=n(60),c=n(70),f=c("IE_PROTO"),p=function(){},h=function(t){return"<script>"+t+"<\/script>"},d=function(t){t.write(h("")),t.close();var e=t.parentWindow.Object;return t=null,e},v=function(){var t,e=l("iframe");return e.style.display="none",a.appendChild(e),e.src=String("javascript:"),t=e.contentWindow.document,t.open(),t.write(h("document.F=Object")),t.close(),t.F},g=function(){try{r=new ActiveXObject("htmlfile")}catch(t){}g="undefined"!=typeof document?document.domain&&r?d(r):v():d(r);for(var t=s.length;t--;)delete g.prototype[s[t]];return g()};u[f]=!0,t.exports=Object.create||function(t,e){var n;return null!==t?(p.prototype=i(t),n=new p,p.prototype=null,n[f]=t):n=g(),void 0===e?n:o.f(n,e)}},function(t,e,n){var r=n(5),i=n(12),o=n(110),s=n(31),u=n(19),a=n(50),l=n(7),c=n(62),f=Object.getOwnPropertyDescriptor;e.f=r?f:function(t,e){if(t=u(t),e=a(e),c)try{return f(t,e)}catch(t){}if(l(t,e))return s(!i(o.f,t,e),t[e])}},function(t,e,n){var r=n(1);t.exports=r({}.isPrototypeOf)},function(t,e,n){"use strict";var r=n(12),i=n(1),o=n(20),s=n(69),u=n(117),a=n(47),l=n(42),c=n(64).get,f=n(118),p=n(119),h=a("native-string-replace",String.prototype.replace),d=RegExp.prototype.exec,v=d,g=i("".charAt),y=i("".indexOf),b=i("".replace),m=i("".slice),x=function(){var t=/a/,e=/b*/g;return r(d,t,"a"),r(d,e,"a"),0!==t.lastIndex||0!==e.lastIndex}(),_=u.BROKEN_CARET,O=void 0!==/()??/.exec("")[1];(x||O||_||f||p)&&(v=function(t){var e,n,i,u,a,f,p,w=this,S=c(w),E=o(t),k=S.raw;if(k)return k.lastIndex=w.lastIndex,e=r(v,k,E),w.lastIndex=k.lastIndex,e;var L=S.groups,P=_&&w.sticky,j=r(s,w),T=w.source,V=0,A=E;if(P&&(j=b(j,"y",""),-1===y(j,"g")&&(j+="g"),A=m(E,w.lastIndex),w.lastIndex>0&&(!w.multiline||w.multiline&&"\n"!==g(E,w.lastIndex-1))&&(T="(?: "+T+")",A=" "+A,V++),n=new RegExp("^(?:"+T+")",j)),O&&(n=new RegExp("^"+T+"$(?!\\s)",j)),x&&(i=w.lastIndex),u=r(d,P?n:w,A),P?u?(u.input=m(u.input,V),u[0]=m(u[0],V),u.index=w.lastIndex,w.lastIndex+=u[0].length):w.lastIndex=0:x&&u&&(w.lastIndex=w.global?u.index+u[0].length:i),O&&u&&u.length>1&&r(h,u[0],n,function(){for(a=1;a<arguments.length-2;a++)void 0===arguments[a]&&(u[a]=void 0)}),u&&L)for(u.groups=f=l(null),a=0;a<L.length;a++)p=L[a],f[p[0]]=u[p[1]];return u}),t.exports=v},function(t,e,n){var r=n(4),i=n(33),o=r["__core-js_shared__"]||i("__core-js_shared__",{});t.exports=o},function(t,e,n){var r=n(103),i=n(46);(t.exports=function(t,e){return i[t]||(i[t]=void 0!==e?e:{})})("versions",[]).push({version:"3.26.1",mode:r?"pure":"global",copyright:"© 2014-2022 Denis Pushkarev (zloirock.ru)",license:"https://github.com/zloirock/core-js/blob/v3.26.1/LICENSE",source:"https://github.com/zloirock/core-js"})},function(t,e,n){var r=n(49),i=Math.max,o=Math.min;t.exports=function(t,e){var n=r(t);return n<0?i(n+e,0):o(n,e)}},function(t,e,n){var r=n(105);t.exports=function(t){var e=+t;return e!==e||0===e?0:r(e)}},function(t,e,n){var r=n(73),i=n(41);t.exports=function(t){var e=r(t,"string");return i(e)?e:e+""}},function(t,e,n){var r=n(9),i=r("toStringTag"),o={};o[i]="z",t.exports="[object z]"===String(o)},function(t,e,n){"use strict";var r=n(5),i=n(4),o=n(1),s=n(66),u=n(11),a=n(7),l=n(102),c=n(44),f=n(41),p=n(73),h=n(0),d=n(67).f,v=n(43).f,g=n(13).f,y=n(122),b=n(71).trim,m=i.Number,x=m.prototype,_=i.TypeError,O=o("".slice),w=o("".charCodeAt),S=function(t){var e=p(t,"number");return"bigint"==typeof e?e:E(e)},E=function(t){var e,n,r,i,o,s,u,a,l=p(t,"number");if(f(l))throw _("Cannot convert a Symbol value to a number");if("string"==typeof l&&l.length>2)if(l=b(l),43===(e=w(l,0))||45===e){if(88===(n=w(l,2))||120===n)return NaN}else if(48===e){switch(w(l,1)){case 66:case 98:r=2,i=49;break;case 79:case 111:r=8,i=55;break;default:return+l}for(o=O(l,2),s=o.length,u=0;u<s;u++)if((a=w(o,u))<48||a>i)return NaN;return parseInt(o,r)}return+l};if(s("Number",!m(" 0o1")||!m("0b1")||m("+0x1"))){for(var k,L=function(t){var e=arguments.length<1?0:m(S(t)),n=this;return c(x,n)&&h(function(){y(n)})?l(Object(e),n,L):e},P=r?d(m):"MAX_VALUE,MIN_VALUE,NaN,NEGATIVE_INFINITY,POSITIVE_INFINITY,EPSILON,MAX_SAFE_INTEGER,MIN_SAFE_INTEGER,isFinite,isInteger,isNaN,isSafeInteger,parseFloat,parseInt,fromString,range".split(","),j=0;P.length>j;j++)a(m,k=P[j])&&!a(L,k)&&g(L,k,v(m,k));L.prototype=x,x.constructor=L,u(i,"Number",L,{constructor:!0})}},function(t,e,n){"use strict";var r=n(3),i=n(45);r({target:"RegExp",proto:!0,forced:/./.exec!==i},{exec:i})},function(t,e,n){"use strict";function r(t){return 0!==t&&(!(!Array.isArray(t)||0!==t.length)||!t)}function i(t){return function(){return!t.apply(void 0,arguments)}}function o(t,e){return void 0===t&&(t="undefined"),null===t&&(t="null"),!1===t&&(t="false"),-1!==t.toString().toLowerCase().indexOf(e.trim())}function s(t,e,n,r){return t.filter(function(t){return o(r(t,n),e)})}function u(t){return t.filter(function(t){return!t.$isLabel})}function a(t,e){return function(n){return n.reduce(function(n,r){return r[t]&&r[t].length?(n.push({$groupLabel:r[e],$isLabel:!0}),n.concat(r[t])):n},[])}}function l(t,e,r,i,o){return function(u){return u.map(function(u){var a;if(!u[r])return console.warn("Options passed to vue-multiselect do not contain groups, despite the config."),[];var l=s(u[r],t,e,o);return l.length?(a={},n.i(f.a)(a,i,u[i]),n.i(f.a)(a,r,l),a):[]})}}var c=n(88),f=n(87),p=n(129),h=(n.n(p),n(82)),d=(n.n(h),n(81)),v=(n.n(d),n(83)),g=(n.n(v),n(84)),y=(n.n(g),n(128)),b=(n.n(y),n(135)),m=(n.n(b),n(127)),x=(n.n(m),n(132)),_=(n.n(x),n(131)),O=(n.n(_),n(125)),w=(n.n(O),n(130)),S=(n.n(w),n(52)),E=(n.n(S),n(53)),k=(n.n(E),n(85)),L=(n.n(k),n(134)),P=(n.n(L),n(80)),j=(n.n(P),n(79)),T=(n.n(j),n(133)),V=(n.n(T),n(126)),A=(n.n(V),function(){for(var t=arguments.length,e=new Array(t),n=0;n<t;n++)e[n]=arguments[n];return function(t){return e.reduce(function(t,e){return e(t)},t)}});e.a={data:function(){return{search:"",isOpen:!1,preferredOpenDirection:"below",optimizedHeight:this.maxHeight}},props:{internalSearch:{type:Boolean,default:!0},options:{type:Array,required:!0},multiple:{type:Boolean,default:!1},value:{type:null,default:function(){return[]}},trackBy:{type:String},label:{type:String},searchable:{type:Boolean,default:!0},clearOnSelect:{type:Boolean,default:!0},hideSelected:{type:Boolean,default:!1},placeholder:{type:String,default:"Select option"},allowEmpty:{type:Boolean,default:!0},resetAfter:{type:Boolean,default:!1},closeOnSelect:{type:Boolean,default:!0},customLabel:{type:Function,default:function(t,e){return r(t)?"":e?t[e]:t}},taggable:{type:Boolean,default:!1},tagPlaceholder:{type:String,default:"Press enter to create a tag"},tagPosition:{type:String,default:"top"},max:{type:[Number,Boolean],default:!1},id:{default:null},optionsLimit:{type:Number,default:1e3},groupValues:{type:String},groupLabel:{type:String},groupSelect:{type:Boolean,default:!1},blockKeys:{type:Array,default:function(){return[]}},preserveSearch:{type:Boolean,default:!1},preselectFirst:{type:Boolean,default:!1},preventAutofocus:{type:Boolean,default:!1}},mounted:function(){!this.multiple&&this.max&&console.warn("[Vue-Multiselect warn]: Max prop should not be used when prop Multiple equals false."),this.preselectFirst&&!this.internalValue.length&&this.options.length&&this.select(this.filteredOptions[0])},computed:{internalValue:function(){return this.value||0===this.value?Array.isArray(this.value)?this.value:[this.value]:[]},filteredOptions:function(){var t=this.search||"",e=t.toLowerCase().trim(),n=this.options.concat();return n=this.internalSearch?this.groupValues?this.filterAndFlat(n,e,this.label):s(n,e,this.label,this.customLabel):this.groupValues?a(this.groupValues,this.groupLabel)(n):n,n=this.hideSelected?n.filter(i(this.isSelected)):n,this.taggable&&e.length&&!this.isExistingOption(e)&&("bottom"===this.tagPosition?n.push({isTag:!0,label:t}):n.unshift({isTag:!0,label:t})),n.slice(0,this.optionsLimit)},valueKeys:function(){var t=this;return this.trackBy?this.internalValue.map(function(e){return e[t.trackBy]}):this.internalValue},optionKeys:function(){var t=this;return(this.groupValues?this.flatAndStrip(this.options):this.options).map(function(e){return t.customLabel(e,t.label).toString().toLowerCase()})},currentOptionLabel:function(){return this.multiple?this.searchable?"":this.placeholder:this.internalValue.length?this.getOptionLabel(this.internalValue[0]):this.searchable?"":this.placeholder}},watch:{internalValue:function(){this.resetAfter&&this.internalValue.length&&(this.search="",this.$emit("input",this.multiple?[]:null))},search:function(){this.$emit("search-change",this.search,this.id)}},methods:{getValue:function(){return this.multiple?this.internalValue:0===this.internalValue.length?null:this.internalValue[0]},filterAndFlat:function(t,e,n){return A(l(e,n,this.groupValues,this.groupLabel,this.customLabel),a(this.groupValues,this.groupLabel))(t)},flatAndStrip:function(t){return A(a(this.groupValues,this.groupLabel),u)(t)},updateSearch:function(t){this.search=t},isExistingOption:function(t){return!!this.options&&this.optionKeys.indexOf(t)>-1},isSelected:function(t){var e=this.trackBy?t[this.trackBy]:t;return this.valueKeys.indexOf(e)>-1},isOptionDisabled:function(t){return!!t.$isDisabled},getOptionLabel:function(t){if(r(t))return"";if(t.isTag)return t.label;if(t.$isLabel)return t.$groupLabel;var e=this.customLabel(t,this.label);return r(e)?"":e},select:function(t,e){if(t.$isLabel&&this.groupSelect)return void this.selectGroup(t);if(!(-1!==this.blockKeys.indexOf(e)||this.disabled||t.$isDisabled||t.$isLabel)&&(!this.max||!this.multiple||this.internalValue.length!==this.max)&&("Tab"!==e||this.pointerDirty)){if(t.isTag)this.$emit("tag",t.label,this.id),this.search="",this.closeOnSelect&&!this.multiple&&this.deactivate();else{if(this.isSelected(t))return void("Tab"!==e&&this.removeElement(t));this.multiple?this.$emit("input",this.internalValue.concat([t]),this.id):this.$emit("input",t,this.id),this.$emit("select",t,this.id),this.clearOnSelect&&(this.search="")}this.closeOnSelect&&this.deactivate()}},selectGroup:function(t){var e=this,n=this.options.find(function(n){return n[e.groupLabel]===t.$groupLabel});if(n){if(this.wholeGroupSelected(n)){this.$emit("remove",n[this.groupValues],this.id);var r=this.trackBy?n[this.groupValues].map(function(t){return t[e.trackBy]}):n[this.groupValues],i=this.internalValue.filter(function(t){return-1===r.indexOf(e.trackBy?t[e.trackBy]:t)});this.$emit("input",i,this.id)}else{var o=n[this.groupValues].filter(function(t){return!(e.isOptionDisabled(t)||e.isSelected(t))});this.max&&o.splice(this.max-this.internalValue.length),this.$emit("select",o,this.id),this.$emit("input",this.internalValue.concat(o),this.id)}this.closeOnSelect&&this.deactivate()}},wholeGroupSelected:function(t){var e=this;return t[this.groupValues].every(function(t){return e.isSelected(t)||e.isOptionDisabled(t)})},wholeGroupDisabled:function(t){return t[this.groupValues].every(this.isOptionDisabled)},removeElement:function(t){var e=!(arguments.length>1&&void 0!==arguments[1])||arguments[1];if(!this.disabled&&!t.$isDisabled){if(!this.allowEmpty&&this.internalValue.length<=1)return void this.deactivate();var r="object"===n.i(c.a)(t)?this.valueKeys.indexOf(t[this.trackBy]):this.valueKeys.indexOf(t);if(this.multiple){var i=this.internalValue.slice(0,r).concat(this.internalValue.slice(r+1));this.$emit("input",i,this.id)}else this.$emit("input",null,this.id);this.$emit("remove",t,this.id),this.closeOnSelect&&e&&this.deactivate()}},removeLastElement:function(){-1===this.blockKeys.indexOf("Delete")&&0===this.search.length&&Array.isArray(this.internalValue)&&this.internalValue.length&&this.removeElement(this.internalValue[this.internalValue.length-1],!1)},activate:function(){var t=this;this.isOpen||this.disabled||(this.adjustPosition(),this.groupValues&&0===this.pointer&&this.filteredOptions.length&&(this.pointer=1),this.isOpen=!0,this.searchable?(this.preserveSearch||(this.search=""),this.preventAutofocus||this.$nextTick(function(){return t.$refs.search&&t.$refs.search.focus()})):this.preventAutofocus||void 0!==this.$el&&this.$el.focus(),this.$emit("open",this.id))},deactivate:function(){this.isOpen&&(this.isOpen=!1,this.searchable?null!==this.$refs.search&&void 0!==this.$refs.search&&this.$refs.search.blur():void 0!==this.$el&&this.$el.blur(),this.preserveSearch||(this.search=""),this.$emit("close",this.getValue(),this.id))},toggle:function(){this.isOpen?this.deactivate():this.activate()},adjustPosition:function(){if("undefined"!=typeof window){var t=this.$el.getBoundingClientRect().top,e=window.innerHeight-this.$el.getBoundingClientRect().bottom;e>this.maxHeight||e>t||"below"===this.openDirection||"bottom"===this.openDirection?(this.preferredOpenDirection="below",this.optimizedHeight=Math.min(e-40,this.maxHeight)):(this.preferredOpenDirection="above",this.optimizedHeight=Math.min(t-40,this.maxHeight))}}}}},function(t,e,n){"use strict";var r=n(52),i=(n.n(r),n(53)),o=(n.n(i),n(85)),s=(n.n(o),n(82)),u=(n.n(s),n(81)),a=(n.n(u),n(83)),l=(n.n(a),n(84)),c=(n.n(l),n(79));n.n(c);e.a={data:function(){return{pointer:0,pointerDirty:!1}},props:{showPointer:{type:Boolean,default:!0},optionHeight:{type:Number,default:40}},computed:{pointerPosition:function(){return this.pointer*this.optionHeight},visibleElements:function(){return this.optimizedHeight/this.optionHeight}},watch:{filteredOptions:function(){this.pointerAdjust()},isOpen:function(){this.pointerDirty=!1},pointer:function(){this.$refs.search&&this.$refs.search.setAttribute("aria-activedescendant",this.id+"-"+this.pointer.toString())}},methods:{optionHighlight:function(t,e){return{"multiselect__option--highlight":t===this.pointer&&this.showPointer,"multiselect__option--selected":this.isSelected(e)}},groupHighlight:function(t,e){var n=this;if(!this.groupSelect)return["multiselect__option--disabled",{"multiselect__option--group":e.$isLabel}];var r=this.options.find(function(t){return t[n.groupLabel]===e.$groupLabel});return r&&!this.wholeGroupDisabled(r)?["multiselect__option--group",{"multiselect__option--highlight":t===this.pointer&&this.showPointer},{"multiselect__option--group-selected":this.wholeGroupSelected(r)}]:"multiselect__option--disabled"},addPointerElement:function(){var t=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"Enter",e=t.key;this.filteredOptions.length>0&&this.select(this.filteredOptions[this.pointer],e),this.pointerReset()},pointerForward:function(){this.pointer<this.filteredOptions.length-1&&(this.pointer++,this.$refs.list.scrollTop<=this.pointerPosition-(this.visibleElements-1)*this.optionHeight&&(this.$refs.list.scrollTop=this.pointerPosition-(this.visibleElements-1)*this.optionHeight),this.filteredOptions[this.pointer]&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerForward()),this.pointerDirty=!0},pointerBackward:function(){this.pointer>0?(this.pointer--,this.$refs.list.scrollTop>=this.pointerPosition&&(this.$refs.list.scrollTop=this.pointerPosition),this.filteredOptions[this.pointer]&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerBackward()):this.filteredOptions[this.pointer]&&this.filteredOptions[0].$isLabel&&!this.groupSelect&&this.pointerForward(),this.pointerDirty=!0},pointerReset:function(){this.closeOnSelect&&(this.pointer=0,this.$refs.list&&(this.$refs.list.scrollTop=0))},pointerAdjust:function(){this.pointer>=this.filteredOptions.length-1&&(this.pointer=this.filteredOptions.length?this.filteredOptions.length-1:0),this.filteredOptions.length>0&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerForward()},pointerSet:function(t){this.pointer=t,this.pointerDirty=!0}}}},function(t,e,n){"use strict";var r=n(52),i=(n.n(r),n(80)),o=(n.n(i),n(54)),s=n(55);e.a={name:"vue-multiselect",mixins:[o.a,s.a],props:{name:{type:String,default:""},selectLabel:{type:String,default:"Press enter to select"},selectGroupLabel:{type:String,default:"Press enter to select group"},selectedLabel:{type:String,default:"Selected"},deselectLabel:{type:String,default:"Press enter to remove"},deselectGroupLabel:{type:String,default:"Press enter to deselect group"},showLabels:{type:Boolean,default:!0},limit:{type:Number,default:99999},maxHeight:{type:Number,default:300},limitText:{type:Function,default:function(t){return"and ".concat(t," more")}},loading:{type:Boolean,default:!1},disabled:{type:Boolean,default:!1},openDirection:{type:String,default:""},showNoOptions:{type:Boolean,default:!0},showNoResults:{type:Boolean,default:!0},tabindex:{type:Number,default:0}},computed:{hasOptionGroup:function(){return this.groupValues&&this.groupLabel&&this.groupSelect},isSingleLabelVisible:function(){return(this.singleValue||0===this.singleValue)&&(!this.isOpen||!this.searchable)&&!this.visibleValues.length},isPlaceholderVisible:function(){return!(this.internalValue.length||this.searchable&&this.isOpen)},visibleValues:function(){return this.multiple?this.internalValue.slice(0,this.limit):[]},singleValue:function(){return this.internalValue[0]},deselectLabelText:function(){return this.showLabels?this.deselectLabel:""},deselectGroupLabelText:function(){return this.showLabels?this.deselectGroupLabel:""},selectLabelText:function(){return this.showLabels?this.selectLabel:""},selectGroupLabelText:function(){return this.showLabels?this.selectGroupLabel:""},selectedLabelText:function(){return this.showLabels?this.selectedLabel:""},inputStyle:function(){return this.searchable||this.multiple&&this.value&&this.value.length?this.isOpen?{width:"100%"}:{width:"0",position:"absolute",padding:"0"}:""},contentStyle:function(){return this.options.length?{display:"inline-block"}:{display:"block"}},isAbove:function(){return"above"===this.openDirection||"top"===this.openDirection||"below"!==this.openDirection&&"bottom"!==this.openDirection&&"above"===this.preferredOpenDirection},showSearchInput:function(){return this.searchable&&(!this.hasSingleSelectedSlot||!this.visibleSingleValue&&0!==this.visibleSingleValue||this.isOpen)}}}},function(t,e,n){var r=n(19),i=n(48),o=n(10),s=function(t){return function(e,n,s){var u,a=r(e),l=o(a),c=i(s,l);if(t&&n!=n){for(;l>c;)if((u=a[c++])!=u)return!0}else for(;l>c;c++)if((t||c in a)&&a[c]===n)return t||c||0;return!t&&-1}};t.exports={includes:s(!0),indexOf:s(!1)}},function(t,e,n){"use strict";var r=n(74),i=TypeError;t.exports=function(t,e){if(!delete t[e])throw i("Cannot delete property "+r(e)+" of "+r(t))}},function(t,e){var n="object"==typeof document&&document.all,r=void 0===n&&void 0!==n;t.exports={all:n,IS_HTMLDDA:r}},function(t,e,n){var r=n(4),i=n(8),o=r.document,s=i(o)&&i(o.createElement);t.exports=function(t){return s?o.createElement(t):{}}},function(t,e,n){var r=n(25),i=n(40);t.exports=function(t,e){var n=t[e];return i(n)?void 0:r(n)}},function(t,e,n){var r=n(5),i=n(0),o=n(60);t.exports=!r&&!i(function(){return 7!=Object.defineProperty(o("div"),"a",{get:function(){return 7}}).a})},function(t,e,n){var r=n(1),i=n(2),o=n(46),s=r(Function.toString);i(o.inspectSource)||(o.inspectSource=function(t){return s(t)}),t.exports=o.inspectSource},function(t,e,n){var r,i,o,s=n(124),u=n(4),a=n(8),l=n(30),c=n(7),f=n(46),p=n(70),h=n(38),d=u.TypeError,v=u.WeakMap,g=function(t){return o(t)?i(t):r(t,{})},y=function(t){return function(e){var n;if(!a(e)||(n=i(e)).type!==t)throw d("Incompatible receiver, "+t+" required");return n}};if(s||f.state){var b=f.state||(f.state=new v);b.get=b.get,b.has=b.has,b.set=b.set,r=function(t,e){if(b.has(t))throw d("Object already initialized");return e.facade=t,b.set(t,e),e},i=function(t){return b.get(t)||{}},o=function(t){return b.has(t)}}else{var m=p("state");h[m]=!0,r=function(t,e){if(c(t,m))throw d("Object already initialized");return e.facade=t,l(t,m,e),e},i=function(t){return c(t,m)?t[m]:{}},o=function(t){return c(t,m)}}t.exports={set:r,get:i,has:o,enforce:g,getterFor:y}},function(t,e,n){var r=n(1),i=n(0),o=n(2),s=n(29),u=n(17),a=n(63),l=function(){},c=[],f=u("Reflect","construct"),p=/^\s*(?:class|function)\b/,h=r(p.exec),d=!p.exec(l),v=function(t){if(!o(t))return!1;try{return f(l,c,t),!0}catch(t){return!1}},g=function(t){if(!o(t))return!1;switch(s(t)){case"AsyncFunction":case"GeneratorFunction":case"AsyncGeneratorFunction":return!1}try{return d||!!h(p,a(t))}catch(t){return!0}};g.sham=!0,t.exports=!f||i(function(){var t;return v(v.call)||!v(Object)||!v(function(){t=!0})||t})?g:v},function(t,e,n){var r=n(0),i=n(2),o=/#|\.prototype\./,s=function(t,e){var n=a[u(t)];return n==c||n!=l&&(i(e)?r(e):!!e)},u=s.normalize=function(t){return String(t).replace(o,".").toLowerCase()},a=s.data={},l=s.NATIVE="N",c=s.POLYFILL="P";t.exports=s},function(t,e,n){var r=n(68),i=n(34),o=i.concat("length","prototype");e.f=Object.getOwnPropertyNames||function(t){return r(t,o)}},function(t,e,n){var r=n(1),i=n(7),o=n(19),s=n(57).indexOf,u=n(38),a=r([].push);t.exports=function(t,e){var n,r=o(t),l=0,c=[];for(n in r)!i(u,n)&&i(r,n)&&a(c,n);for(;e.length>l;)i(r,n=e[l++])&&(~s(c,n)||a(c,n));return c}},function(t,e,n){"use strict";var r=n(6);t.exports=function(){var t=r(this),e="";return t.hasIndices&&(e+="d"),t.global&&(e+="g"),t.ignoreCase&&(e+="i"),t.multiline&&(e+="m"),t.dotAll&&(e+="s"),t.unicode&&(e+="u"),t.unicodeSets&&(e+="v"),t.sticky&&(e+="y"),e}},function(t,e,n){var r=n(47),i=n(75),o=r("keys");t.exports=function(t){return o[t]||(o[t]=i(t))}},function(t,e,n){var r=n(1),i=n(24),o=n(20),s=n(78),u=r("".replace),a="["+s+"]",l=RegExp("^"+a+a+"*"),c=RegExp(a+a+"*$"),f=function(t){return function(e){var n=o(i(e));return 1&t&&(n=u(n,l,"")),2&t&&(n=u(n,c,"")),n}};t.exports={start:f(1),end:f(2),trim:f(3)}},function(t,e,n){var r=n(23),i=n(0);t.exports=!!Object.getOwnPropertySymbols&&!i(function(){var t=Symbol();return!String(t)||!(Object(t)instanceof Symbol)||!Symbol.sham&&r&&r<41})},function(t,e,n){var r=n(12),i=n(8),o=n(41),s=n(61),u=n(113),a=n(9),l=TypeError,c=a("toPrimitive");t.exports=function(t,e){if(!i(t)||o(t))return t;var n,a=s(t,c);if(a){if(void 0===e&&(e="default"),n=r(a,t,e),!i(n)||o(n))return n;throw l("Can't convert object to primitive value")}return void 0===e&&(e="number"),u(t,e)}},function(t,e){var n=String;t.exports=function(t){try{return n(t)}catch(t){return"Object"}}},function(t,e,n){var r=n(1),i=0,o=Math.random(),s=r(1..toString);t.exports=function(t){return"Symbol("+(void 0===t?"":t)+")_"+s(++i+o,36)}},function(t,e,n){var r=n(72);t.exports=r&&!Symbol.sham&&"symbol"==typeof Symbol.iterator},function(t,e,n){var r=n(5),i=n(0);t.exports=r&&i(function(){return 42!=Object.defineProperty(function(){},"prototype",{value:42,writable:!1}).prototype})},function(t,e){t.exports="\t\n\v\f\r                　\u2028\u2029\ufeff"},function(t,e,n){"use strict";var r=n(3),i=n(21).find,o=n(91),s=!0;"find"in[]&&Array(1).find(function(){s=!1}),r({target:"Array",proto:!0,forced:s},{find:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}}),o("find")},function(t,e,n){"use strict";var r=n(3),i=n(18),o=n(65),s=n(8),u=n(48),a=n(10),l=n(19),c=n(32),f=n(9),p=n(16),h=n(93),d=p("slice"),v=f("species"),g=Array,y=Math.max;r({target:"Array",proto:!0,forced:!d},{slice:function(t,e){var n,r,f,p=l(this),d=a(p),b=u(t,d),m=u(void 0===e?d:e,d);if(i(p)&&(n=p.constructor,o(n)&&(n===g||i(n.prototype))?n=void 0:s(n)&&null===(n=n[v])&&(n=void 0),n===g||void 0===n))return h(p,b,m);for(r=new(void 0===n?g:n)(y(m-b,0)),f=0;b<m;b++,f++)b in p&&c(r,f,p[b]);return r.length=f,r}})},function(t,e,n){var r=n(1),i=n(11),o=Date.prototype,s=r(o.toString),u=r(o.getTime);"Invalid Date"!=String(new Date(NaN))&&i(o,"toString",function(){var t=u(this);return t===t?s(this):"Invalid Date"})},function(t,e,n){var r=n(11),i=n(98),o=Error.prototype;o.toString!==i&&r(o,"toString",i)},function(t,e,n){var r=n(51),i=n(11),o=n(112);r||i(Object.prototype,"toString",o,{unsafe:!0})},function(t,e,n){"use strict";var r=n(36).PROPER,i=n(11),o=n(6),s=n(20),u=n(0),a=n(116),l=RegExp.prototype,c=l.toString,f=u(function(){return"/a/b"!=c.call({source:"a",flags:"b"})}),p=r&&"toString"!=c.name;(f||p)&&i(RegExp.prototype,"toString",function(){var t=o(this);return"/"+s(t.source)+"/"+s(a(t))},{unsafe:!0})},function(t,e,n){"use strict";var r=n(12),i=n(99),o=n(6),s=n(40),u=n(24),a=n(120),l=n(20),c=n(61),f=n(115);i("search",function(t,e,n){return[function(e){var n=u(this),i=s(e)?void 0:c(e,t);return i?r(i,e,n):new RegExp(e)[t](l(n))},function(t){var r=o(this),i=l(t),s=n(e,r,i);if(s.done)return s.value;var u=r.lastIndex;a(u,0)||(r.lastIndex=0);var c=f(r,i);return a(r.lastIndex,u)||(r.lastIndex=u),null===c?-1:c.index}]})},function(t,e,n){"use strict";function r(t){n(136)}var i=n(56),o=n(138),s=n(137),u=r,a=s(i.a,o.a,!1,u,null,null);e.a=a.exports},function(t,e,n){"use strict";function r(t,e,n){return e in t?Object.defineProperty(t,e,{value:n,enumerable:!0,configurable:!0,writable:!0}):t[e]=n,t}e.a=r},function(t,e,n){"use strict";function r(t){"@babel/helpers - typeof";return(r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(t){return typeof t}:function(t){return t&&"function"==typeof Symbol&&t.constructor===Symbol&&t!==Symbol.prototype?"symbol":typeof t})(t)}e.a=r},function(t,e,n){"use strict";Object.defineProperty(e,"__esModule",{value:!0});var r=n(86),i=n(54),o=n(55);n.d(e,"Multiselect",function(){return r.a}),n.d(e,"multiselectMixin",function(){return i.a}),n.d(e,"pointerMixin",function(){return o.a}),e.default=r.a},function(t,e,n){var r=n(2),i=String,o=TypeError;t.exports=function(t){if("object"==typeof t||r(t))return t;throw o("Can't set "+i(t)+" as a prototype")}},function(t,e,n){var r=n(9),i=n(42),o=n(13).f,s=r("unscopables"),u=Array.prototype;void 0==u[s]&&o(u,s,{configurable:!0,value:i(null)}),t.exports=function(t){u[s][t]=!0}},function(t,e,n){var r=n(25),i=n(14),o=n(39),s=n(10),u=TypeError,a=function(t){return function(e,n,a,l){r(n);var c=i(e),f=o(c),p=s(c),h=t?p-1:0,d=t?-1:1;if(a<2)for(;;){if(h in f){l=f[h],h+=d;break}if(h+=d,t?h<0:p<=h)throw u("Reduce of empty array with no initial value")}for(;t?h>=0:p>h;h+=d)h in f&&(l=n(l,f[h],h,c));return l}};t.exports={left:a(!1),right:a(!0)}},function(t,e,n){var r=n(1);t.exports=r([].slice)},function(t,e,n){var r=n(18),i=n(65),o=n(8),s=n(9),u=s("species"),a=Array;t.exports=function(t){var e;return r(t)&&(e=t.constructor,i(e)&&(e===a||r(e.prototype))?e=void 0:o(e)&&null===(e=e[u])&&(e=void 0)),void 0===e?a:e}},function(t,e,n){var r=n(7),i=n(114),o=n(43),s=n(13);t.exports=function(t,e,n){for(var u=i(e),a=s.f,l=o.f,c=0;c<u.length;c++){var f=u[c];r(t,f)||n&&r(n,f)||a(t,f,l(e,f))}}},function(t,e,n){var r=n(15),i=n(4);t.exports="process"==r(i.process)},function(t,e,n){var r=n(17);t.exports=r("navigator","userAgent")||""},function(t,e,n){"use strict";var r=n(5),i=n(0),o=n(6),s=n(42),u=n(106),a=Error.prototype.toString,l=i(function(){if(r){var t=s(Object.defineProperty({},"name",{get:function(){return this===t}}));if("true"!==a.call(t))return!0}return"2: 1"!==a.call({message:1,name:2})||"Error"!==a.call({})});t.exports=l?function(){var t=o(this),e=u(t.name,"Error"),n=u(t.message);return e?n?e+": "+n:e:n}:a},function(t,e,n){"use strict";n(53);var r=n(37),i=n(11),o=n(45),s=n(0),u=n(9),a=n(30),l=u("species"),c=RegExp.prototype;t.exports=function(t,e,n,f){var p=u(t),h=!s(function(){var e={};return e[p]=function(){return 7},7!=""[t](e)}),d=h&&!s(function(){var e=!1,n=/a/;return"split"===t&&(n={},n.constructor={},n.constructor[l]=function(){return n},n.flags="",n[p]=/./[p]),n.exec=function(){return e=!0,null},n[p](""),!e});if(!h||!d||n){var v=r(/./[p]),g=e(p,""[t],function(t,e,n,i,s){var u=r(t),a=e.exec;return a===o||a===c.exec?h&&!s?{done:!0,value:v(e,n,i)}:{done:!0,value:u(n,e,i)}:{done:!1}});i(String.prototype,t,g[0]),i(c,p,g[1])}f&&a(c[p],"sham",!0)}},function(t,e,n){var r=n(37),i=n(25),o=n(35),s=r(r.bind);t.exports=function(t,e){return i(t),void 0===e?t:o?s(t,e):function(){return t.apply(e,arguments)}}},function(t,e,n){var r=n(17);t.exports=r("document","documentElement")},function(t,e,n){var r=n(2),i=n(8),o=n(111);t.exports=function(t,e,n){var s,u;return o&&r(s=e.constructor)&&s!==n&&i(u=s.prototype)&&u!==n.prototype&&o(t,u),t}},function(t,e){t.exports=!1},function(t,e,n){var r=n(0),i=n(2),o=n(7),s=n(5),u=n(36).CONFIGURABLE,a=n(63),l=n(64),c=l.enforce,f=l.get,p=Object.defineProperty,h=s&&!r(function(){return 8!==p(function(){},"length",{value:8}).length}),d=String(String).split("String"),v=t.exports=function(t,e,n){"Symbol("===String(e).slice(0,7)&&(e="["+String(e).replace(/^Symbol\(([^)]*)\)/,"$1")+"]"),n&&n.getter&&(e="get "+e),n&&n.setter&&(e="set "+e),(!o(t,"name")||u&&t.name!==e)&&(s?p(t,"name",{value:e,configurable:!0}):t.name=e),h&&n&&o(n,"arity")&&t.length!==n.arity&&p(t,"length",{value:n.arity});try{n&&o(n,"constructor")&&n.constructor?s&&p(t,"prototype",{writable:!1}):t.prototype&&(t.prototype=void 0)}catch(t){}var r=c(t);return o(r,"source")||(r.source=d.join("string"==typeof e?e:"")),t};Function.prototype.toString=v(function(){return i(this)&&f(this).source||a(this)},"toString")},function(t,e){var n=Math.ceil,r=Math.floor;t.exports=Math.trunc||function(t){var e=+t;return(e>0?r:n)(e)}},function(t,e,n){var r=n(20);t.exports=function(t,e){return void 0===t?arguments.length<2?"":e:r(t)}},function(t,e,n){var r=n(5),i=n(77),o=n(13),s=n(6),u=n(19),a=n(109);e.f=r&&!i?Object.defineProperties:function(t,e){s(t);for(var n,r=u(e),i=a(e),l=i.length,c=0;l>c;)o.f(t,n=i[c++],r[n]);return t}},function(t,e){e.f=Object.getOwnPropertySymbols},function(t,e,n){var r=n(68),i=n(34);t.exports=Object.keys||function(t){return r(t,i)}},function(t,e,n){"use strict";var r={}.propertyIsEnumerable,i=Object.getOwnPropertyDescriptor,o=i&&!r.call({1:2},1);e.f=o?function(t){var e=i(this,t);return!!e&&e.enumerable}:r},function(t,e,n){var r=n(1),i=n(6),o=n(90);t.exports=Object.setPrototypeOf||("__proto__"in{}?function(){var t,e=!1,n={};try{t=r(Object.getOwnPropertyDescriptor(Object.prototype,"__proto__").set),t(n,[]),e=n instanceof Array}catch(t){}return function(n,r){return i(n),o(r),e?t(n,r):n.__proto__=r,n}}():void 0)},function(t,e,n){"use strict";var r=n(51),i=n(29);t.exports=r?{}.toString:function(){return"[object "+i(this)+"]"}},function(t,e,n){var r=n(12),i=n(2),o=n(8),s=TypeError;t.exports=function(t,e){var n,u;if("string"===e&&i(n=t.toString)&&!o(u=r(n,t)))return u;if(i(n=t.valueOf)&&!o(u=r(n,t)))return u;if("string"!==e&&i(n=t.toString)&&!o(u=r(n,t)))return u;throw s("Can't convert object to primitive value")}},function(t,e,n){var r=n(17),i=n(1),o=n(67),s=n(108),u=n(6),a=i([].concat);t.exports=r("Reflect","ownKeys")||function(t){var e=o.f(u(t)),n=s.f;return n?a(e,n(t)):e}},function(t,e,n){var r=n(12),i=n(6),o=n(2),s=n(15),u=n(45),a=TypeError;t.exports=function(t,e){var n=t.exec;if(o(n)){var l=r(n,t,e);return null!==l&&i(l),l}if("RegExp"===s(t))return r(u,t,e);throw a("RegExp#exec called on incompatible receiver")}},function(t,e,n){var r=n(12),i=n(7),o=n(44),s=n(69),u=RegExp.prototype;t.exports=function(t){var e=t.flags;return void 0!==e||"flags"in u||i(t,"flags")||!o(u,t)?e:r(s,t)}},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp,s=r(function(){var t=o("a","y");return t.lastIndex=2,null!=t.exec("abcd")}),u=s||r(function(){return!o("a","y").sticky}),a=s||r(function(){var t=o("^r","gy");return t.lastIndex=2,null!=t.exec("str")});t.exports={BROKEN_CARET:a,MISSED_STICKY:u,UNSUPPORTED_Y:s}},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp;t.exports=r(function(){var t=o(".","s");return!(t.dotAll&&t.exec("\n")&&"s"===t.flags)})},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp;t.exports=r(function(){var t=o("(?<a>b)","g");return"b"!==t.exec("b").groups.a||"bc"!=="b".replace(t,"$<a>c")})},function(t,e){t.exports=Object.is||function(t,e){return t===e?0!==t||1/t==1/e:t!=t&&e!=e}},function(t,e,n){var r=n(36).PROPER,i=n(0),o=n(78),s="​᠎";t.exports=function(t){return i(function(){return!!o[t]()||s[t]()!==s||r&&o[t].name!==t})}},function(t,e,n){var r=n(1);t.exports=r(1..valueOf)},function(t,e,n){var r=n(49),i=Math.min;t.exports=function(t){return t>0?i(r(t),9007199254740991):0}},function(t,e,n){var r=n(4),i=n(2),o=r.WeakMap;t.exports=i(o)&&/native code/.test(String(o))},function(t,e,n){"use strict";var r=n(3),i=n(0),o=n(18),s=n(8),u=n(14),a=n(10),l=n(22),c=n(32),f=n(28),p=n(16),h=n(9),d=n(23),v=h("isConcatSpreadable"),g=d>=51||!i(function(){var t=[];return t[v]=!1,t.concat()[0]!==t}),y=p("concat"),b=function(t){if(!s(t))return!1;var e=t[v];return void 0!==e?!!e:o(t)};r({target:"Array",proto:!0,arity:1,forced:!g||!y},{concat:function(t){var e,n,r,i,o,s=u(this),p=f(s,0),h=0;for(e=-1,r=arguments.length;e<r;e++)if(o=-1===e?s:arguments[e],b(o))for(i=a(o),l(h+i),n=0;n<i;n++,h++)n in o&&c(p,h,o[n]);else l(h+1),c(p,h++,o);return p.length=h,p}})},function(t,e,n){"use strict";var r=n(3),i=n(21).every;r({target:"Array",proto:!0,forced:!n(26)("every")},{every:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(21).filter;r({target:"Array",proto:!0,forced:!n(16)("filter")},{filter:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(37),o=n(57).indexOf,s=n(26),u=i([].indexOf),a=!!u&&1/u([1],1,-0)<0,l=s("indexOf");r({target:"Array",proto:!0,forced:a||!l},{indexOf:function(t){var e=arguments.length>1?arguments[1]:void 0;return a?u(this,t,e)||0:o(this,t,e)}})},function(t,e,n){n(3)({target:"Array",stat:!0},{isArray:n(18)})},function(t,e,n){"use strict";var r=n(3),i=n(21).map;r({target:"Array",proto:!0,forced:!n(16)("map")},{map:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(10),s=n(27),u=n(22),a=n(0),l=a(function(){return 4294967297!==[].push.call({length:4294967296},1)}),c=!function(){try{Object.defineProperty([],"length",{writable:!1}).push()}catch(t){return t instanceof TypeError}}();r({target:"Array",proto:!0,arity:1,forced:l||c},{push:function(t){var e=i(this),n=o(e),r=arguments.length;u(n+r);for(var a=0;a<r;a++)e[n]=arguments[a],n++;return s(e,n),n}})},function(t,e,n){"use strict";var r=n(3),i=n(92).left,o=n(26),s=n(23),u=n(96),a=o("reduce"),l=!u&&s>79&&s<83;r({target:"Array",proto:!0,forced:!a||l},{reduce:function(t){var e=arguments.length;return i(this,t,e,e>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(48),s=n(49),u=n(10),a=n(27),l=n(22),c=n(28),f=n(32),p=n(58),h=n(16),d=h("splice"),v=Math.max,g=Math.min;r({target:"Array",proto:!0,forced:!d},{splice:function(t,e){var n,r,h,d,y,b,m=i(this),x=u(m),_=o(t,x),O=arguments.length;for(0===O?n=r=0:1===O?(n=0,r=x-_):(n=O-2,r=g(v(s(e),0),x-_)),l(x+n-r),h=c(m,r),d=0;d<r;d++)(y=_+d)in m&&f(h,d,m[y]);if(h.length=r,n<r){for(d=_;d<x-r;d++)y=d+r,b=d+n,y in m?m[b]=m[y]:p(m,b);for(d=x;d>x-r+n;d--)p(m,d-1)}else if(n>r)for(d=x-r;d>_;d--)y=d+r-1,b=d+n-1,y in m?m[b]=m[y]:p(m,b);for(d=0;d<n;d++)m[d+_]=arguments[d+2];return a(m,x-r+n),h}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(10),s=n(27),u=n(58),a=n(22),l=1!==[].unshift(0),c=!function(){try{Object.defineProperty([],"length",{writable:!1}).unshift()}catch(t){return t instanceof TypeError}}();r({target:"Array",proto:!0,arity:1,forced:l||c},{unshift:function(t){var e=i(this),n=o(e),r=arguments.length;if(r){a(n+r);for(var l=n;l--;){var c=l+r;l in e?e[c]=e[l]:u(e,c)}for(var f=0;f<r;f++)e[f]=arguments[f]}return s(e,n+r)}})},function(t,e,n){"use strict";var r=n(3),i=n(71).trim;r({target:"String",proto:!0,forced:n(121)("trim")},{trim:function(){return i(this)}})},function(t,e){},function(t,e){t.exports=function(t,e,n,r,i,o){var s,u=t=t||{},a=typeof t.default;"object"!==a&&"function"!==a||(s=t,u=t.default);var l="function"==typeof u?u.options:u;e&&(l.render=e.render,l.staticRenderFns=e.staticRenderFns,l._compiled=!0),n&&(l.functional=!0),i&&(l._scopeId=i);var c;if(o?(c=function(t){t=t||this.$vnode&&this.$vnode.ssrContext||this.parent&&this.parent.$vnode&&this.parent.$vnode.ssrContext,t||"undefined"==typeof __VUE_SSR_CONTEXT__||(t=__VUE_SSR_CONTEXT__),r&&r.call(this,t),t&&t._registeredComponents&&t._registeredComponents.add(o)},l._ssrRegister=c):r&&(c=r),c){var f=l.functional,p=f?l.render:l.beforeCreate;f?(l._injectStyles=c,l.render=function(t,e){return c.call(e),p(t,e)}):l.beforeCreate=p?[].concat(p,c):[c]}return{esModule:s,exports:u,options:l}}},function(t,e,n){"use strict";var r=function(){var t=this,e=t.$createElement,n=t._self._c||e;return n("div",{staticClass:"multiselect",class:{"multiselect--active":t.isOpen,"multiselect--disabled":t.disabled,"multiselect--above":t.isAbove,"multiselect--has-options-group":t.hasOptionGroup},attrs:{tabindex:t.searchable?-1:t.tabindex,role:"combobox","aria-owns":"listbox-"+t.id},on:{focus:function(e){return t.activate()},blur:function(e){!t.searchable&&t.deactivate()},keydown:[function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"down",40,e.key,["Down","ArrowDown"])?null:e.target!==e.currentTarget?null:(e.preventDefault(),t.pointerForward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"up",38,e.key,["Up","ArrowUp"])?null:e.target!==e.currentTarget?null:(e.preventDefault(),t.pointerBackward())}],keypress:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"enter",13,e.key,"Enter")&&t._k(e.keyCode,"tab",9,e.key,"Tab")?null:(e.stopPropagation(),e.target!==e.currentTarget?null:t.addPointerElement(e))},keyup:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"esc",27,e.key,["Esc","Escape"])?null:t.deactivate()}}},[t._t("caret",function(){return[n("div",{staticClass:"multiselect__select",on:{mousedown:function(e){return e.preventDefault(),e.stopPropagation(),t.toggle()}}})]},{toggle:t.toggle}),t._v(" "),t._t("clear",null,{search:t.search}),t._v(" "),n("div",{ref:"tags",staticClass:"multiselect__tags"},[t._t("selection",function(){return[n("div",{directives:[{name:"show",rawName:"v-show",value:t.visibleValues.length>0,expression:"visibleValues.length > 0"}],staticClass:"multiselect__tags-wrap"},[t._l(t.visibleValues,function(e,r){return[t._t("tag",function(){return[n("span",{key:r,staticClass:"multiselect__tag"},[n("span",{domProps:{textContent:t._s(t.getOptionLabel(e))}}),t._v(" "),n("i",{staticClass:"multiselect__tag-icon",attrs:{tabindex:"1"},on:{keypress:function(n){return!n.type.indexOf("key")&&t._k(n.keyCode,"enter",13,n.key,"Enter")?null:(n.preventDefault(),t.removeElement(e))},mousedown:function(n){return n.preventDefault(),t.removeElement(e)}}})])]},{option:e,search:t.search,remove:t.removeElement})]})],2),t._v(" "),t.internalValue&&t.internalValue.length>t.limit?[t._t("limit",function(){return[n("strong",{staticClass:"multiselect__strong",domProps:{textContent:t._s(t.limitText(t.internalValue.length-t.limit))}})]})]:t._e()]},{search:t.search,remove:t.removeElement,values:t.visibleValues,isOpen:t.isOpen}),t._v(" "),n("transition",{attrs:{name:"multiselect__loading"}},[t._t("loading",function(){return[n("div",{directives:[{name:"show",rawName:"v-show",value:t.loading,expression:"loading"}],staticClass:"multiselect__spinner"})]})],2),t._v(" "),t.searchable?n("input",{ref:"search",staticClass:"multiselect__input",style:t.inputStyle,attrs:{name:t.name,id:t.id,type:"text",autocomplete:"off",spellcheck:"false",placeholder:t.placeholder,disabled:t.disabled,tabindex:t.tabindex,"aria-controls":"listbox-"+t.id},domProps:{value:t.search},on:{input:function(e){return t.updateSearch(e.target.value)},focus:function(e){return e.preventDefault(),t.activate()},blur:function(e){return e.preventDefault(),t.deactivate()},keyup:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"esc",27,e.key,["Esc","Escape"])?null:t.deactivate()},keydown:[function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"down",40,e.key,["Down","ArrowDown"])?null:(e.preventDefault(),t.pointerForward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"up",38,e.key,["Up","ArrowUp"])?null:(e.preventDefault(),t.pointerBackward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"delete",[8,46],e.key,["Backspace","Delete","Del"])?null:(e.stopPropagation(),t.removeLastElement())}],keypress:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"enter",13,e.key,"Enter")?null:(e.preventDefault(),e.stopPropagation(),e.target!==e.currentTarget?null:t.addPointerElement(e))}}}):t._e(),t._v(" "),t.isSingleLabelVisible?n("span",{staticClass:"multiselect__single",on:{mousedown:function(e){return e.preventDefault(),t.toggle.apply(null,arguments)}}},[t._t("singleLabel",function(){return[[t._v(t._s(t.currentOptionLabel))]]},{option:t.singleValue})],2):t._e(),t._v(" "),t.isPlaceholderVisible?n("span",{staticClass:"multiselect__placeholder",on:{mousedown:function(e){return e.preventDefault(),t.toggle.apply(null,arguments)}}},[t._t("placeholder",function(){return[t._v("\n          "+t._s(t.placeholder)+"\n        ")]})],2):t._e()],2),t._v(" "),n("transition",{attrs:{name:"multiselect"}},[n("div",{directives:[{name:"show",rawName:"v-show",value:t.isOpen,expression:"isOpen"}],ref:"list",staticClass:"multiselect__content-wrapper",style:{maxHeight:t.optimizedHeight+"px"},attrs:{tabindex:"-1"},on:{focus:t.activate,mousedown:function(t){t.preventDefault()}}},[n("ul",{staticClass:"multiselect__content",style:t.contentStyle,attrs:{role:"listbox",id:"listbox-"+t.id}},[t._t("beforeList"),t._v(" "),t.multiple&&t.max===t.internalValue.length?n("li",[n("span",{staticClass:"multiselect__option"},[t._t("maxElements",function(){return[t._v("Maximum of "+t._s(t.max)+" options selected. First remove a selected option to select another.")]})],2)]):t._e(),t._v(" "),!t.max||t.internalValue.length<t.max?t._l(t.filteredOptions,function(e,r){return n("li",{key:r,staticClass:"multiselect__element",attrs:{id:t.id+"-"+r,role:e&&(e.$isLabel||e.$isDisabled)?null:"option"}},[e&&(e.$isLabel||e.$isDisabled)?t._e():n("span",{staticClass:"multiselect__option",class:t.optionHighlight(r,e),attrs:{"data-select":e&&e.isTag?t.tagPlaceholder:t.selectLabelText,"data-selected":t.selectedLabelText,"data-deselect":t.deselectLabelText},on:{click:function(n){return n.stopPropagation(),t.select(e)},mouseenter:function(e){return e.target!==e.currentTarget?null:t.pointerSet(r)}}},[t._t("option",function(){return[n("span",[t._v(t._s(t.getOptionLabel(e)))])]},{option:e,search:t.search,index:r})],2),t._v(" "),e&&(e.$isLabel||e.$isDisabled)?n("span",{staticClass:"multiselect__option",class:t.groupHighlight(r,e),attrs:{"data-select":t.groupSelect&&t.selectGroupLabelText,"data-deselect":t.groupSelect&&t.deselectGroupLabelText},on:{mouseenter:function(e){if(e.target!==e.currentTarget)return null;t.groupSelect&&t.pointerSet(r)},mousedown:function(n){return n.preventDefault(),t.selectGroup(e)}}},[t._t("option",function(){return[n("span",[t._v(t._s(t.getOptionLabel(e)))])]},{option:e,search:t.search,index:r})],2):t._e()])}):t._e(),t._v(" "),n("li",{directives:[{name:"show",rawName:"v-show",value:t.showNoResults&&0===t.filteredOptions.length&&t.search&&!t.loading,expression:"showNoResults && (filteredOptions.length === 0 && search && !loading)"}]},[n("span",{staticClass:"multiselect__option"},[t._t("noResult",function(){return[t._v("No elements found. Consider changing the search query.")]},{search:t.search})],2)]),t._v(" "),n("li",{directives:[{name:"show",rawName:"v-show",value:t.showNoOptions&&(0===t.options.length||!0===t.hasOptionGroup&&0===t.filteredOptions.length)&&!t.search&&!t.loading,expression:"showNoOptions && ((options.length === 0 || (hasOptionGroup === true && filteredOptions.length === 0)) && !search && !loading)"}]},[n("span",{staticClass:"multiselect__option"},[t._t("noOptions",function(){return[t._v("List is empty.")]})],2)]),t._v(" "),t._t("afterList")],2)])])],2)},i=[],o={render:r,staticRenderFns:i};e.a=o},function(t,e){var n;n=function(){return this}();try{n=n||Function("return this")()||(0,eval)("this")}catch(t){"object"==typeof window&&(n=window)}t.exports=n}])});
 
 /***/ }),
 
@@ -43582,7 +43557,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "watchPostEffect", function() { return watchPostEffect; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "watchSyncEffect", function() { return watchSyncEffect; });
 /*!
- * Vue.js v2.7.15
+ * Vue.js v2.7.16
  * (c) 2014-2023 Evan You
  * Released under the MIT License.
  */
@@ -43659,8 +43634,15 @@ function toString(val) {
     return val == null
         ? ''
         : Array.isArray(val) || (isPlainObject(val) && val.toString === _toString)
-            ? JSON.stringify(val, null, 2)
+            ? JSON.stringify(val, replacer, 2)
             : String(val);
+}
+function replacer(_key, val) {
+    // avoid circular deps from v3
+    if (val && val.__v_isRef) {
+        return val.value;
+    }
+    return val;
 }
 /**
  * Convert an input value to a number for persistence.
@@ -44326,6 +44308,11 @@ var __assign = function() {
     return __assign.apply(this, arguments);
 };
 
+typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+    var e = new Error(message);
+    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+};
+
 var uid$2 = 0;
 var pendingCleanupDeps = [];
 var cleanupDeps = function () {
@@ -44554,7 +44541,8 @@ function observe(value, shallow, ssrMockReactivity) {
 /**
  * Define a reactive property on an Object.
  */
-function defineReactive(obj, key, val, customSetter, shallow, mock) {
+function defineReactive(obj, key, val, customSetter, shallow, mock, observeEvenIfShallow) {
+    if (observeEvenIfShallow === void 0) { observeEvenIfShallow = false; }
     var dep = new Dep();
     var property = Object.getOwnPropertyDescriptor(obj, key);
     if (property && property.configurable === false) {
@@ -44567,7 +44555,7 @@ function defineReactive(obj, key, val, customSetter, shallow, mock) {
         (val === NO_INITIAL_VALUE || arguments.length === 2)) {
         val = obj[key];
     }
-    var childOb = !shallow && observe(val, false, mock);
+    var childOb = shallow ? val && val.__ob__ : observe(val, false, mock);
     Object.defineProperty(obj, key, {
         enumerable: true,
         configurable: true,
@@ -44613,7 +44601,7 @@ function defineReactive(obj, key, val, customSetter, shallow, mock) {
             else {
                 val = newVal;
             }
-            childOb = !shallow && observe(newVal, false, mock);
+            childOb = shallow ? newVal && newVal.__ob__ : observe(newVal, false, mock);
             if (true) {
                 dep.notify({
                     type: "set" /* TriggerOpTypes.SET */,
@@ -46092,11 +46080,10 @@ function renderMixin(Vue) {
         // to the data on the placeholder node.
         vm.$vnode = _parentVnode;
         // render self
+        var prevInst = currentInstance;
+        var prevRenderInst = currentRenderingInstance;
         var vnode;
         try {
-            // There's no need to maintain a stack because all render fns are called
-            // separately from one another. Nested component's render fns are called
-            // when parent component is patched.
             setCurrentInstance(vm);
             currentRenderingInstance = vm;
             vnode = render.call(vm._renderProxy, vm.$createElement);
@@ -46120,8 +46107,8 @@ function renderMixin(Vue) {
             }
         }
         finally {
-            currentRenderingInstance = null;
-            setCurrentInstance();
+            currentRenderingInstance = prevRenderInst;
+            setCurrentInstance(prevInst);
         }
         // if the returned array contains only a single node, allow it
         if (isArray(vnode) && vnode.length === 1) {
@@ -47031,7 +47018,10 @@ function doWatch(source, cb, _a) {
     var instance = currentInstance;
     var call = function (fn, type, args) {
         if (args === void 0) { args = null; }
-        return invokeWithErrorHandling(fn, null, args, instance, type);
+        var res = invokeWithErrorHandling(fn, null, args, instance, type);
+        if (deep && res && res.__ob__)
+            res.__ob__.dep.depend();
+        return res;
     };
     var getter;
     var forceTrigger = false;
@@ -47056,6 +47046,7 @@ function doWatch(source, cb, _a) {
                     return s.value;
                 }
                 else if (isReactive(s)) {
+                    s.__ob__.dep.depend();
                     return traverse(s);
                 }
                 else if (isFunction(s)) {
@@ -47607,7 +47598,7 @@ function onErrorCaptured(hook, target) {
 /**
  * Note: also update dist/vue.runtime.mjs when adding new exports to this file.
  */
-var version = '2.7.15';
+var version = '2.7.16';
 /**
  * @internal type is manually declared in <root>/types/v3-define-component.d.ts
  */
@@ -47925,7 +47916,7 @@ function initProps$1(vm, propsOptions) {
                         "Instead, use a data or computed property based on the prop's " +
                         "value. Prop being mutated: \"".concat(key, "\""), vm);
                 }
-            });
+            }, true /* shallow */);
         }
         else {}
         // static props are already proxied on the component's prototype
@@ -48245,6 +48236,9 @@ function initMixin$1(Vue) {
         vm.__v_skip = true;
         // effect scope
         vm._scope = new EffectScope(true /* detached */);
+        // #13134 edge case where a child component is manually created during the
+        // render of a parent component
+        vm._scope.parent = undefined;
         vm._scope._vm = true;
         // merge options
         if (options && options._isComponent) {
@@ -49493,7 +49487,7 @@ function matches(pattern, name) {
     return false;
 }
 function pruneCache(keepAliveInstance, filter) {
-    var cache = keepAliveInstance.cache, keys = keepAliveInstance.keys, _vnode = keepAliveInstance._vnode;
+    var cache = keepAliveInstance.cache, keys = keepAliveInstance.keys, _vnode = keepAliveInstance._vnode, $vnode = keepAliveInstance.$vnode;
     for (var key in cache) {
         var entry = cache[key];
         if (entry) {
@@ -49503,6 +49497,7 @@ function pruneCache(keepAliveInstance, filter) {
             }
         }
     }
+    $vnode.componentOptions.children = undefined;
 }
 function pruneCacheEntry(cache, key, keys, current) {
     var entry = cache[key];
@@ -51844,10 +51839,8 @@ function updateStyle(oldVnode, vnode) {
     }
     for (name in newStyle) {
         cur = newStyle[name];
-        if (cur !== oldStyle[name]) {
-            // ie9 setting to null has no effect, must use empty string
-            setProp(el, name, cur == null ? '' : cur);
-        }
+        // ie9 setting to null has no effect, must use empty string
+        setProp(el, name, cur == null ? '' : cur);
     }
 }
 var style$1 = {

--- a/assets/js/admin-settings-manager.js
+++ b/assets/js/admin-settings-manager.js
@@ -597,9 +597,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var vue__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! vue */ "./node_modules/vue/dist/vue.esm.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   watch: {
@@ -697,9 +697,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -941,9 +941,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 /* harmony import */ var _helpers__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 var axios = __webpack_require__(/*! axios */ "./node_modules/axios/index.js").default;
@@ -1600,9 +1600,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -2118,9 +2118,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 /* harmony import */ var _helpers__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./../helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -2276,9 +2276,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _helpers__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./../helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -2622,9 +2622,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _input_field_props_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./input-field-props.js */ "./assets/src/js/admin/vue/mixins/form-fields/input-field-props.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -3050,7 +3050,6 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
         // const confirmation_status = this.getConfirmation( updateData );
         // if ( ! confirmation_status ) { return; }
       }
-
       updateData();
     },
     getConfirmation: function getConfirmation(callback) {
@@ -3220,9 +3219,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var vuex__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! vuex */ "./node_modules/vuex/dist/vuex.esm.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -3384,43 +3383,44 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
       }
       return isChangeable;
     },
-    checkShowIfCondition: function checkShowIfCondition(payloadArray) {
-      var result = {
-        status: false,
-        // Final status (true if all conditions pass)
-        failed_conditions: 0,
-        succeed_conditions: 0,
-        matched_data: []
-      };
-
-      // Normalize condition into an array
-      var conditions = Array.isArray(payloadArray.condition) ? payloadArray.condition : [payloadArray.condition];
-      var _iterator4 = _createForOfIteratorHelper(conditions),
-        _step4;
-      try {
-        for (_iterator4.s(); !(_step4 = _iterator4.n()).done;) {
-          var payload = _step4.value;
-          var state = this.checkSingleShowIfCondition({
-            condition: payload
-          });
-          if (state.status) {
-            result.succeed_conditions += 1;
-            result.matched_data.push(payload);
-          } else {
-            result.failed_conditions += 1;
+    checkShowIfCondition: function checkShowIfCondition(payload) {
+      // Handle both single and multiple conditions
+      if (payload.condition && Array.isArray(payload.condition)) {
+        // This is a multiple condition case
+        var result = {
+          status: false,
+          failed_conditions: 0,
+          succeed_conditions: 0,
+          matched_data: []
+        };
+        var _iterator4 = _createForOfIteratorHelper(payload.condition),
+          _step4;
+        try {
+          for (_iterator4.s(); !(_step4 = _iterator4.n()).done;) {
+            var condition = _step4.value;
+            var state = this.checkSingleCondition({
+              condition: condition
+            });
+            if (state.status) {
+              result.succeed_conditions += 1;
+              result.matched_data.push(condition);
+            } else {
+              result.failed_conditions += 1;
+            }
           }
+        } catch (err) {
+          _iterator4.e(err);
+        } finally {
+          _iterator4.f();
         }
-
-        // If all conditions pass, set status to true
-      } catch (err) {
-        _iterator4.e(err);
-      } finally {
-        _iterator4.f();
+        result.status = result.failed_conditions === 0;
+        return result;
+      } else {
+        // This is a single condition case
+        return this.checkSingleCondition(payload);
       }
-      result.status = result.failed_conditions === 0;
-      return result;
     },
-    checkSingleShowIfCondition: function checkSingleShowIfCondition(payload) {
+    checkSingleCondition: function checkSingleCondition(payload) {
       var args = {
         condition: null
       };
@@ -3488,14 +3488,6 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
               sub_condition_error++;
             }
             if (sub_condition_error) {
-              failed_cond_count++;
-              continue;
-            }
-            if (!this.checkComparison({
-              data_a: sub_condition_field,
-              data_b: sub_condition.value,
-              compare: sub_compare
-            })) {
               failed_cond_count++;
               continue;
             }
@@ -3721,9 +3713,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_1__);
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 /* harmony default export */ __webpack_exports__["default"] = ({
@@ -12445,9 +12437,9 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var vue__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! vue */ "./node_modules/vue/dist/vue.esm.js");
 /* harmony import */ var vuex__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! vuex */ "./node_modules/vuex/dist/vuex.esm.js");
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 vue__WEBPACK_IMPORTED_MODULE_0__["default"].use(vuex__WEBPACK_IMPORTED_MODULE_1__["default"]);
@@ -12662,9 +12654,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/typeof */ "./node_modules/@babel/runtime/helpers/typeof.js");
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__);
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 var isObject = function isObject(value) {
   return value && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(value) === 'object' && !Array.isArray(value);
 };
@@ -12707,10 +12699,10 @@ function findObjectItem(path, data, defaultValue) {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayLikeToArray(arr, len) {
-  if (len == null || len > arr.length) len = arr.length;
-  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
-  return arr2;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
 }
 module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12724,8 +12716,8 @@ module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exp
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _arrayWithoutHoles(arr) {
-  if (Array.isArray(arr)) return arrayLikeToArray(arr);
+function _arrayWithoutHoles(r) {
+  if (Array.isArray(r)) return arrayLikeToArray(r);
 }
 module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12739,19 +12731,13 @@ module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12764,8 +12750,8 @@ module.exports = _defineProperty, module.exports.__esModule = true, module.expor
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _iterableToArray(iter) {
-  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+function _iterableToArray(r) {
+  if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r);
 }
 module.exports = _iterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12796,8 +12782,8 @@ var arrayWithoutHoles = __webpack_require__(/*! ./arrayWithoutHoles.js */ "./nod
 var iterableToArray = __webpack_require__(/*! ./iterableToArray.js */ "./node_modules/@babel/runtime/helpers/iterableToArray.js");
 var unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js");
 var nonIterableSpread = __webpack_require__(/*! ./nonIterableSpread.js */ "./node_modules/@babel/runtime/helpers/nonIterableSpread.js");
-function _toConsumableArray(arr) {
-  return arrayWithoutHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableSpread();
+function _toConsumableArray(r) {
+  return arrayWithoutHoles(r) || iterableToArray(r) || unsupportedIterableToArray(r) || nonIterableSpread();
 }
 module.exports = _toConsumableArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12811,17 +12797,17 @@ module.exports = _toConsumableArray, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -12834,11 +12820,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -12852,11 +12838,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -12870,13 +12856,12 @@ module.exports = _typeof, module.exports.__esModule = true, module.exports["defa
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _unsupportedIterableToArray(o, minLen) {
-  if (!o) return;
-  if (typeof o === "string") return arrayLikeToArray(o, minLen);
-  var n = Object.prototype.toString.call(o).slice(8, -1);
-  if (n === "Object" && o.constructor) n = o.constructor.name;
-  if (n === "Map" || n === "Set") return Array.from(o);
-  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
 }
 module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -16694,7 +16679,6 @@ __webpack_require__.r(__webpack_exports__);
       type: Number,
       default: 0 // Unlimitted
     },
-
     maxWidgetInfoText: {
       type: String,
       default: 'Up to __DATA__ item{s} can be added'
@@ -18057,11 +18041,9 @@ __webpack_require__.r(__webpack_exports__);
     canDrag: {
       default: true // move | clone
     },
-
     dragType: {
       default: 'move' // move | clone
     },
-
     itemClassName: {
       default: ''
     },
@@ -18069,7 +18051,6 @@ __webpack_require__.r(__webpack_exports__);
       default: 'div' // div | li
     }
   },
-
   computed: {
     listItemStyle: function listItemStyle() {
       var style = {
@@ -18234,9 +18215,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _mixins_helpers__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../mixins/helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   name: "form-builder-widget-list-section-component",
@@ -19476,9 +19457,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -20068,9 +20049,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -20190,7 +20171,6 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
                   _main_widget.original_widget_key = matched_field.widget_key;
                   // console.log( { widget, widget_key: matched_field.widget_key,  matched_field } );
                 }
-
                 if (typeof matched_field.label === 'string' && matched_field.label.length) {
                   _main_widget.label = matched_field.label;
                 }
@@ -20650,9 +20630,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -21220,9 +21200,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -21756,9 +21736,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -22277,9 +22257,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -22796,9 +22776,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -23443,9 +23423,9 @@ __webpack_require__.r(__webpack_exports__);
 
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -23739,7 +23719,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
       if (!placeholder.insertByButton) {
         return false;
       }
-      var findPlaceholder = function findPlaceholder(placeholderKey, placeholders) {
+      var _findPlaceholder = function findPlaceholder(placeholderKey, placeholders) {
         var _iterator4 = _createForOfIteratorHelper(placeholders),
           _step4;
         try {
@@ -23752,7 +23732,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
               continue;
             }
             if ("placeholder_group" === _placeholder.type) {
-              var _targetPlaceholder = findPlaceholder(placeholderKey, _placeholder.placeholders);
+              var _targetPlaceholder = _findPlaceholder(placeholderKey, _placeholder.placeholders);
               if (_targetPlaceholder) {
                 return _targetPlaceholder;
               }
@@ -23766,7 +23746,7 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
         }
         return null;
       };
-      var targetPlaceholder = findPlaceholder(placeholderKey, this.placeholders);
+      var targetPlaceholder = _findPlaceholder(placeholderKey, this.placeholders);
       return targetPlaceholder ? false : true;
     },
     addPlaceholder: function addPlaceholder(placeholderKey) {
@@ -24461,9 +24441,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _mixins_helpers__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../../mixins/helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -24885,16 +24865,16 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
     genarateWidgetKeyForActiveWidgets: function genarateWidgetKeyForActiveWidgets(widget_key) {
       if (typeof this.active_widget_fields[widget_key] !== "undefined") {
         var matched_keys = Object.keys(this.active_widget_fields);
-        var getUniqueKey = function getUniqueKey(current_key, new_key) {
+        var _getUniqueKey = function getUniqueKey(current_key, new_key) {
           if (matched_keys.includes(new_key)) {
             var field_id = new_key.match(/[_](\d+)$/);
             field_id = field_id ? parseInt(field_id[1]) : 1;
             var new_field_key = current_key + "_" + (field_id + 1);
-            return getUniqueKey(current_key, new_field_key);
+            return _getUniqueKey(current_key, new_field_key);
           }
           return new_key;
         };
-        return getUniqueKey(widget_key, widget_key);
+        return _getUniqueKey(widget_key, widget_key);
       }
       return widget_key;
     },
@@ -24910,16 +24890,16 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
         }
         field_keys.push(this.active_widget_fields[key].field_key);
       }
-      var getUniqueKey = function getUniqueKey(field_key) {
+      var _getUniqueKey2 = function getUniqueKey(field_key) {
         if (field_keys.includes(field_key)) {
           var field_id = field_key.match(/[-](\d+)$/);
           field_id = field_id ? parseInt(field_id[1]) : 1;
           var new_field_key = current_field_key + "-" + (field_id + 1);
-          return getUniqueKey(new_field_key);
+          return _getUniqueKey2(new_field_key);
         }
         return field_key;
       };
-      var unique_field_key = getUniqueKey(current_field_key);
+      var unique_field_key = _getUniqueKey2(current_field_key);
       return unique_field_key;
     },
     handleGroupDragStart: function handleGroupDragStart(widget_group_key) {
@@ -25460,9 +25440,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _mixins_helpers__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../../mixins/helpers */ "./assets/src/js/admin/vue/mixins/helpers.js");
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_1___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -26128,7 +26108,7 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
       return options_values.includes(value);
     }
     /* syncValidationWithLocalState( validation_log ) {
-         return validation_log;
+          return validation_log;
     } */
   }
 });
@@ -27119,41 +27099,41 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "settings-wrapper atbdp-settings-panel"
-  }, [_c("form", {
+  }, [_c('form', {
     attrs: {
-      action: "#"
+      "action": "#"
     },
     on: {
-      submit: function submit($event) {
+      "submit": function submit($event) {
         $event.preventDefault();
         return _vm.updateData.apply(null, arguments);
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "setting-top-bar"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-setting-top-bar-left"
-  }, [_c("ul", {
+  }, [_c('ul', {
     staticClass: "directorist_setting-panel__pages"
   }, _vm._l(_vm.theBreadcrumbNav, function (nav_item, nav_key) {
-    return _c("li", {
+    return _c('li', {
       key: nav_key
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "directorist_setting-panel__pages--link",
       class: {
         active: nav_item.active
       },
       attrs: {
-        href: "#"
+        "href": "#"
       }
     }, [_vm._v("\n                            " + _vm._s(nav_item.label) + "\n                        ")])]);
-  }), 0)]), _vm._v(" "), _c("div", {
+  }), 0)]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-setting-top-bar-right"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "setting-top-bar__search-field"
-  }, [_c("input", {
+  }, [_c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -27162,96 +27142,96 @@ var render = function render() {
     }],
     staticClass: "setting-search-field__input",
     attrs: {
-      type: "text",
-      placeholder: "Search settings here..."
+      "type": "text",
+      "placeholder": "Search settings here..."
     },
     domProps: {
-      value: _vm.search_query
+      "value": _vm.search_query
     },
     on: {
-      input: function input($event) {
+      "input": function input($event) {
         if ($event.target.composing) return;
         _vm.search_query = $event.target.value;
       }
     }
-  }), _vm._v(" "), _vm.searchSuggestions ? _c("div", {
+  }), _vm._v(" "), _vm.searchSuggestions ? _c('div', {
     staticClass: "setting-search-suggestions"
-  }, [_c("ul", {
+  }, [_c('ul', {
     staticClass: "search-suggestions-list"
   }, _vm._l(Object.keys(_vm.searchSuggestions), function (field_key, field_index) {
-    return _c("li", {
+    return _c('li', {
       key: field_index,
       staticClass: "search-suggestions-list--list-item"
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "search-suggestions-list--link",
       attrs: {
-        href: "#"
+        "href": "#"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.jumpToSearchResult(_vm.searchSuggestions[field_key]);
         }
       }
     }, [_vm._v("\n                                    " + _vm._s(_vm.searchSuggestions[field_key].label) + "\n                                ")])]);
-  }), 0)]) : _vm._e()]), _vm._v(" "), _c("div", {
+  }), 0)]) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "setting-top-bar__search-actions"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "setting-response-feedback"
-  }, [_vm.status_message ? _c("div", {}, [_c("span", {
+  }, [_vm.status_message ? _c('div', {}, [_c('span', {
     staticClass: "atbdp-icon atbdp-icon-fill",
     class: _vm.getIconClass(_vm.status_message.type),
     domProps: {
-      innerHTML: _vm._s(_vm.getIconHTML(_vm.status_message.type))
+      "innerHTML": _vm._s(_vm.getIconHTML(_vm.status_message.type))
     }
-  }), _vm._v("\n\n                            " + _vm._s(_vm.status_message.message) + "\n                        ")]) : _vm._e()]), _vm._v(" "), _c("button", {
+  }), _vm._v("\n\n                            " + _vm._s(_vm.status_message.message) + "\n                        ")]) : _vm._e()]), _vm._v(" "), _c('button', {
     staticClass: "settings-save-btn",
     attrs: {
-      type: "submit",
-      disabled: _vm.submit_button.is_disabled
+      "type": "submit",
+      "disabled": _vm.submit_button.is_disabled
     },
     domProps: {
-      innerHTML: _vm._s(_vm.submit_button.label)
+      "innerHTML": _vm._s(_vm.submit_button.label)
     }
-  })])])]), _vm._v(" "), _c("div", {
+  })])])]), _vm._v(" "), _c('div', {
     staticClass: "setting-body",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.resetStates();
       }
     }
-  }, [_c("sidebar-navigation", {
+  }, [_c('sidebar-navigation', {
     attrs: {
-      menu: _vm.layouts
+      "menu": _vm.layouts
     }
-  }), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {
     staticClass: "settings-contents"
-  }, [_c("tabContents", {
+  }, [_c('tabContents', {
     on: {
       "do-action": function doAction($event) {
         return _vm.doAction($event);
       }
     }
-  }), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {
     staticClass: "settings-footer"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "settings-footer-actions"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "setting-response-feedback"
-  }, [_vm.status_message ? _c("div", {}, [_c("span", {
+  }, [_vm.status_message ? _c('div', {}, [_c('span', {
     staticClass: "atbdp-icon atbdp-icon-fill",
     class: _vm.getIconClass(_vm.status_message.type),
     domProps: {
-      innerHTML: _vm._s(_vm.getIconHTML(_vm.status_message.type))
+      "innerHTML": _vm._s(_vm.getIconHTML(_vm.status_message.type))
     }
-  }), _vm._v("\n\n                                " + _vm._s(_vm.status_message.message) + "\n                            ")]) : _vm._e()]), _vm._v(" "), _c("button", {
+  }), _vm._v("\n\n                                " + _vm._s(_vm.status_message.message) + "\n                            ")]) : _vm._e()]), _vm._v(" "), _c('button', {
     staticClass: "settings-save-btn",
     attrs: {
-      type: "submit",
-      disabled: _vm.submit_button.is_disabled
+      "type": "submit",
+      "disabled": _vm.submit_button.is_disabled
     },
     domProps: {
-      innerHTML: _vm._s(_vm.submit_button.label)
+      "innerHTML": _vm._s(_vm.submit_button.label)
     }
   })])])], 1)], 1)])]);
 };
@@ -27275,46 +27255,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "atbdp-cptm-tab-contents"
   }, [_vm._l(_vm.layouts, function (menu, menu_key) {
-    return [menu.active ? _c("div", {
+    return [menu.active ? _c('div', {
       key: menu_key,
       staticClass: "atbdp-tab-content-item",
       attrs: {
-        id: menu_key
+        "id": menu_key
       }
-    }, [!menu.submenu ? [_c("h2", {
+    }, [!menu.submenu ? [_c('h2', {
       staticClass: "cptm-menu-title"
-    }, [_vm._v(_vm._s(menu.label))]), _vm._v(" "), menu.sections ? _c("div", {
+    }, [_vm._v(_vm._s(menu.label))]), _vm._v(" "), menu.sections ? _c('div', {
       staticClass: "atbdp-tab-content-body"
-    }, [menu.sections ? _c("sections-module", {
+    }, [menu.sections ? _c('sections-module', {
       attrs: {
         "menu-key": menu_key,
-        sections: menu.sections
+        "sections": menu.sections
       },
       on: {
         "do-action": function doAction($event) {
-          return _vm.doAction($event, "tab-contents");
+          return _vm.doAction($event, 'tab-contents');
         }
       }
-    }) : _vm._e()], 1) : _vm._e()] : _vm._e(), _vm._v(" "), menu.submenu ? _c("div", {
+    }) : _vm._e()], 1) : _vm._e()] : _vm._e(), _vm._v(" "), menu.submenu ? _c('div', {
       staticClass: "atbdp-tab-sub-contents"
     }, [_vm._l(menu.submenu, function (submenu, submenu_key) {
-      return [submenu.active ? _c("div", {
+      return [submenu.active ? _c('div', {
         key: submenu_key,
         staticClass: "atbdp-tab-content-item",
         attrs: {
-          id: menu_key + "__" + submenu_key
+          "id": menu_key + '__' + submenu_key
         }
-      }, [submenu.sections ? _c("sections-module", {
+      }, [submenu.sections ? _c('sections-module', {
         attrs: {
-          "menu-key": menu_key + "__" + submenu_key,
-          sections: submenu.sections
+          "menu-key": menu_key + '__' + submenu_key,
+          "sections": submenu.sections
         },
         on: {
           "do-action": function doAction($event) {
-            return _vm.doAction($event, "tab-contents");
+            return _vm.doAction($event, 'tab-contents');
           }
         }
       }) : _vm._e()], 1) : _vm._e()];
@@ -27344,99 +27324,99 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-placeholder-blcok",
     class: _vm.getContainerClass,
     on: {
-      drop: function drop($event) {
+      "drop": function drop($event) {
         $event.preventDefault();
         return _vm.placeholderOnDrop();
       },
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
-        return _vm.$emit("placeholder-dragover-on");
+        return _vm.$emit('placeholder-dragover-on');
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.placeholderOnDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.placeholderOnDragLeave();
       }
     }
-  }, [_c("p", {
+  }, [_c('p', {
     staticClass: "cptm-placeholder-label",
     class: {
       hide: _vm.selectedWidgets && _vm.selectedWidgets.length
     }
-  }, [_vm._v("\n    " + _vm._s(_vm.label) + "\n  ")]), _vm._v(" "), _c("div", {
+  }, [_vm._v("\n    " + _vm._s(_vm.label) + "\n  ")]), _vm._v(" "), _c('div', {
     staticClass: "cptm-widget-insert-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-insert-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-insert-modal-container"
-  }, [_c("widgets-window", {
+  }, [_c('widgets-window', {
     attrs: {
-      id: _vm.id,
-      availableWidgets: _vm.availableWidgets,
-      acceptedWidgets: _vm.acceptedWidgets,
-      rejectedWidgets: _vm.rejectedWidgets,
-      activeWidgets: _vm.activeWidgets,
-      selectedWidgets: _vm.selectedWidgets,
-      active: _vm.showWidgetsPickerWindow,
-      maxWidget: _vm.maxWidget,
-      maxWidgetInfoText: _vm.maxWidgetInfoText,
-      bottomAchhor: true
+      "id": _vm.id,
+      "availableWidgets": _vm.availableWidgets,
+      "acceptedWidgets": _vm.acceptedWidgets,
+      "rejectedWidgets": _vm.rejectedWidgets,
+      "activeWidgets": _vm.activeWidgets,
+      "selectedWidgets": _vm.selectedWidgets,
+      "active": _vm.showWidgetsPickerWindow,
+      "maxWidget": _vm.maxWidget,
+      "maxWidgetInfoText": _vm.maxWidgetInfoText,
+      "bottomAchhor": true
     },
     on: {
       "widget-selection": function widgetSelection($event) {
-        return _vm.$emit("insert-widget", $event);
+        return _vm.$emit('insert-widget', $event);
       },
-      close: function close($event) {
-        return _vm.$emit("close-widgets-picker-window");
+      "close": function close($event) {
+        return _vm.$emit('close-widgets-picker-window');
       }
     }
-  })], 1), _vm._v(" "), _vm.canAddMore ? _c("a", {
+  })], 1), _vm._v(" "), _vm.canAddMore ? _c('a', {
     staticClass: "cptm-widget-insert-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("open-widgets-picker-window");
+        return _vm.$emit('open-widgets-picker-window');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-plus"
-  })]) : _vm._e()])]), _vm._v(" "), _vm.selectedWidgets && _vm.selectedWidgets.length ? _c("div", {
+  })]) : _vm._e()])]), _vm._v(" "), _vm.selectedWidgets && _vm.selectedWidgets.length ? _c('div', {
     staticClass: "cptm-widget-preview-area"
   }, [_vm._l(_vm.selectedWidgets, function (widget, widget_index) {
-    return [_vm.hasValidWidget(widget) ? [_c(_vm.activeWidgets[widget].type + "-card-widget", {
+    return [_vm.hasValidWidget(widget) ? [_c(_vm.activeWidgets[widget].type + '-card-widget', {
       key: widget_index,
       tag: "component",
       attrs: {
-        label: typeof _vm.availableWidgets[widget] !== "undefined" ? _vm.availableWidgets[widget].label : "Not Available",
-        icon: typeof _vm.activeWidgets[widget].icon === "string" ? _vm.activeWidgets[widget].icon : "",
-        options: _vm.activeWidgets[widget].options,
-        widgetDropable: _vm.widgetDropable,
-        canMove: _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.activeWidgets[widget].can_move) !== undefined ? _vm.activeWidgets[widget].can_move : true,
-        canEdit: _vm.widgetHasOptions(_vm.activeWidgets[widget])
+        "label": typeof _vm.availableWidgets[widget] !== 'undefined' ? _vm.availableWidgets[widget].label : 'Not Available',
+        "icon": typeof _vm.activeWidgets[widget].icon === 'string' ? _vm.activeWidgets[widget].icon : '',
+        "options": _vm.activeWidgets[widget].options,
+        "widgetDropable": _vm.widgetDropable,
+        "canMove": _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.activeWidgets[widget].can_move) !== undefined ? _vm.activeWidgets[widget].can_move : true,
+        "canEdit": _vm.widgetHasOptions(_vm.activeWidgets[widget])
       },
       on: {
-        drag: function drag($event) {
-          return _vm.$emit("drag-widget", widget);
+        "drag": function drag($event) {
+          return _vm.$emit('drag-widget', widget);
         },
-        drop: function drop($event) {
-          return _vm.$emit("drop-widget", widget);
+        "drop": function drop($event) {
+          return _vm.$emit('drop-widget', widget);
         },
-        dragend: function dragend($event) {
-          return _vm.$emit("dragend-widget", widget);
+        "dragend": function dragend($event) {
+          return _vm.$emit('dragend-widget', widget);
         },
-        edit: function edit($event) {
-          return _vm.$emit("edit-widget", widget);
+        "edit": function edit($event) {
+          return _vm.$emit('edit-widget', widget);
         },
-        trash: function trash($event) {
-          return _vm.$emit("trash-widget", widget);
+        "trash": function trash($event) {
+          return _vm.$emit('trash-widget', widget);
         }
       }
     })] : _vm._e()];
@@ -27462,78 +27442,78 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.show ? _c("div", {
+  return _vm.show ? _c('div', {
     staticClass: "cptm-modal-container cptm-toggle-modal active"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-modal-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-modal"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-modal-content"
-  }, [_vm.showModelHeader ? _c("div", {
+  }, [_vm.showModelHeader ? _c('div', {
     staticClass: "cptm-modal-header"
-  }, [_c("h3", {
+  }, [_c('h3', {
     staticClass: "cptm-modal-header-title",
     domProps: {
-      innerHTML: _vm._s(_vm.modelHeaderText)
+      "innerHTML": _vm._s(_vm.modelHeaderText)
     }
-  }), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {
     staticClass: "cptm-modal-actions"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-modal-action-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.cancel();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-times"
-  })])])]) : _vm._e(), _vm._v(" "), _c("div", {
+  })])])]) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-modal-body cptm-center-content cptm-content-wide"
-  }, [_c("form", {
+  }, [_c('form', {
     staticClass: "cptm-import-directory-form",
     attrs: {
-      action: "#",
-      method: "post"
+      "action": "#",
+      "method": "post"
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-group-feedback cptm-text-center cptm-mb-10"
-  }), _vm._v(" "), _c("h2", {
+  }), _vm._v(" "), _c('h2', {
     staticClass: "cptm-modal-confirmation-title",
     domProps: {
-      innerHTML: _vm._s(_vm.confirmationText)
+      "innerHTML": _vm._s(_vm.confirmationText)
     }
-  }), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {
     staticClass: "cptm-file-input-wrap"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-rounded",
     class: _vm.cancelButtonClass,
     attrs: {
-      type: "button"
+      "type": "button"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.cancelButtonLabel)
+      "innerHTML": _vm._s(_vm.cancelButtonLabel)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.cancel();
       }
     }
-  }), _vm._v(" "), _c("button", {
+  }), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-btn-rounded",
     class: _vm.confirmButtonClass,
     attrs: {
-      type: "button"
+      "type": "button"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.confirmButtonLabel)
+      "innerHTML": _vm._s(_vm.confirmButtonLabel)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.confirm();
       }
     }
@@ -27559,95 +27539,95 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     ref: "dropable_element",
     staticClass: "cptm-dropable-element",
     class: _vm.parentClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-dropable-placeholder cptm-dropable-placeholder-before",
     class: _vm.dropablePlaceholderBeforeClass
-  }), _vm._v(" "), _c("div", {}, [_vm._t("default")], 2), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {}, [_vm._t("default")], 2), _vm._v(" "), _c('div', {
     staticClass: "cptm-dropable-placeholder cptm-dropable-placeholder-after",
     class: _vm.dropablePlaceholderAfterClass
-  }), _vm._v(" "), _vm.dropable ? _c("div", {
+  }), _vm._v(" "), _vm.dropable ? _c('div', {
     staticClass: "cptm-dropable-area"
-  }, [_vm.dropInside ? _c("span", {
+  }, [_vm.dropInside ? _c('span', {
     staticClass: "cptm-dropable-area-inside",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_inside = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_inside = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedInside();
       }
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === "horizontal" ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === 'horizontal' ? _c('span', {
     staticClass: "cptm-dropable-area-left",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_left = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_left = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedBefore();
       }
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === "horizontal" ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === 'horizontal' ? _c('span', {
     staticClass: "cptm-dropable-area-right",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_right = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_right = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedAfter();
       }
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === "vertical" ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === 'vertical' ? _c('span', {
     staticClass: "cptm-dropable-area-top",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_top = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_top = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedBefore();
       }
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === "vertical" ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), !_vm.dropInside && _vm.dropDirection === 'vertical' ? _c('span', {
     staticClass: "cptm-dropable-area-bottom",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.drag_enter_dropable_area_bottom = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.drag_enter_dropable_area_bottom = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedAfter();
       }
     }
@@ -27676,30 +27656,30 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.field_list && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.field_list) === "object" ? _c("div", {
+  return _vm.field_list && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.field_list) === 'object' ? _c('div', {
     staticClass: "directorist-form-fields-area"
   }, [_vm._l(_vm.visibleFields, function (field, field_key) {
-    return field.type ? _c(field.type + "-field", _vm._b({
+    return field.type ? _c(field.type + '-field', _vm._b({
       key: field_key,
       tag: "component",
       attrs: {
         "section-id": _vm.sectionId,
         "field-id": "".concat(_vm.sectionId, "_").concat(field_key),
-        root: _vm.field_list
+        "root": _vm.field_list
       },
       on: {
-        update: function update($event) {
+        "update": function update($event) {
           return _vm.update({
             key: field_key,
             value: $event
           });
         }
       }
-    }, "component", _vm.excludeShowIfCondition(field), false)) : _vm._e();
-  }), _vm._v(" "), _vm.hasAdvancedFields ? _c("button", {
+    }, 'component', _vm.excludeShowIfCondition(field), false)) : _vm._e();
+  }), _vm._v(" "), _vm.hasAdvancedFields ? _c('button', {
     staticClass: "cptm-form-builder-group-options__advanced-toggle",
     on: {
-      click: _vm.toggleAdvanced
+      "click": _vm.toggleAdvanced
     }
   }, [_vm._v("\n    " + _vm._s(_vm.showAdvanced ? "Basic" : "Advanced") + "\n  ")]) : _vm._e()], 2) : _vm._e();
 };
@@ -27723,15 +27703,15 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.validationMessages ? _c("div", {
+  return _vm.validationMessages ? _c('div', {
     staticClass: "cptm-form-group-feedback"
   }, _vm._l(Object.values(_vm.validationMessages), function (alert, alert_key) {
-    return _c("div", {
+    return _c('div', {
       key: alert_key,
       staticClass: "cptm-form-alert",
-      class: "cptm-" + (alert.type ? alert.type : ""),
+      class: 'cptm-' + (alert.type ? alert.type : ''),
       domProps: {
-        innerHTML: _vm._s(alert.message ? alert.message : "")
+        "innerHTML": _vm._s(alert.message ? alert.message : '')
       }
     });
   }), 0) : _vm._e();
@@ -27756,43 +27736,43 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-option-card",
     class: _vm.mainWrapperClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-option-card-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-option-card-header-title-section"
-  }, [_c("h3", {
+  }, [_c('h3', {
     staticClass: "cptm-option-card-header-title"
-  }, [_vm._v(_vm._s(_vm.title))]), _vm._v(" "), _c("div", {
+  }, [_vm._v(_vm._s(_vm.title))]), _vm._v(" "), _c('div', {
     staticClass: "cptm-header-action-area"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-header-action-link cptm-header-action-close",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("close");
+        return _vm.$emit('close');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-times"
-  })])])])]), _vm._v(" "), _c("div", {
+  })])])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-option-card-body"
   }, [_vm.local_fields ? _vm._l(_vm.local_fields, function (field, field_key) {
-    return _c(field.type + "-field", _vm._b({
+    return _c(field.type + '-field', _vm._b({
       key: field_key,
       tag: "component",
       on: {
-        update: function update($event) {
+        "update": function update($event) {
           return _vm.updateFieldData($event, field_key);
         }
       }
-    }, "component", field, false));
-  }) : _vm._e()], 2), _vm._v(" "), _vm.bottomAchhor ? _c("span", {
+    }, 'component', field, false));
+  }) : _vm._e()], 2), _vm._v(" "), _vm.bottomAchhor ? _c('span', {
     staticClass: "cptm-anchor-down"
   }) : _vm._e()]);
 };
@@ -27819,144 +27799,144 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-tab-content",
     class: _vm.containerClass
   }, [_vm._l(_vm.sections, function (section, section_key) {
-    return _c("div", {
+    return _c('div', {
       key: section_key,
       staticClass: "cptm-section",
       class: _vm.sectionClass(section)
-    }, [["submission_form_fields", "search_form_fields", "single_listing_header", "single_listings_contents", "listings_card_grid_view", "listings_card_list_view"].includes(section.fields[0]) ? _c("div", {
+    }, [['submission_form_fields', 'search_form_fields', 'single_listing_header', 'single_listings_contents', 'listings_card_grid_view', 'listings_card_list_view'].includes(section.fields[0]) ? _c('div', {
       staticClass: "directorist-form-doc"
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "directorist-form-doc-left"
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "directorist-form-doc-title",
       domProps: {
-        innerHTML: _vm._s(section.title)
+        "innerHTML": _vm._s(section.title)
       }
-    }), _vm._v(" "), _vm.video && ["submission_form_fields", "search_form_fields"].includes(section.fields[0]) ? _c("a", {
+    }), _vm._v(" "), _vm.video && ['submission_form_fields', 'search_form_fields'].includes(section.fields[0]) ? _c('a', {
       staticClass: "directorist-form-doc__watch-tutorial",
       attrs: {
-        href: "#"
+        "href": "#"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.openVideoPopup.apply(null, arguments);
         }
       }
-    }, [_c("svg", {
+    }, [_c('svg', {
       attrs: {
-        xmlns: "http://www.w3.org/2000/svg",
-        width: "14",
-        height: "14",
-        viewBox: "0 0 14 14",
-        fill: "none"
+        "xmlns": "http://www.w3.org/2000/svg",
+        "width": "14",
+        "height": "14",
+        "viewBox": "0 0 14 14",
+        "fill": "none"
       }
-    }, [_c("path", {
+    }, [_c('path', {
       attrs: {
         "fill-rule": "evenodd",
         "clip-rule": "evenodd",
-        d: "M3.94256 2.33333H7.14074C7.6103 2.33332 7.99785 2.33331 8.31355 2.35911C8.64143 2.3859 8.94285 2.44339 9.22596 2.58765C9.665 2.81135 10.022 3.16831 10.2457 3.60735C10.3899 3.89046 10.4474 4.19187 10.4742 4.51976C10.4981 4.81257 10.4999 5.16718 10.5 5.59171L11.6396 4.45212C11.7511 4.34058 11.8607 4.23096 11.9567 4.15052C12.0424 4.07876 12.223 3.93485 12.473 3.91517C12.7522 3.8932 13.0251 4.00622 13.207 4.21921C13.3699 4.40993 13.3958 4.63932 13.4056 4.75068C13.4167 4.87549 13.4167 5.03051 13.4166 5.18822V8.81177C13.4167 8.96948 13.4167 9.1245 13.4056 9.24931C13.3958 9.36067 13.3699 9.59006 13.207 9.78078C13.0251 9.99377 12.7522 10.1068 12.473 10.0848C12.223 10.0651 12.0424 9.92123 11.9567 9.84947C11.8607 9.76904 11.7511 9.65941 11.6396 9.54787L10.5 8.40828C10.4999 8.83281 10.4981 9.18742 10.4742 9.48023C10.4474 9.80812 10.3899 10.1095 10.2457 10.3926C10.022 10.8317 9.665 11.1886 9.22596 11.4123C8.94285 11.5566 8.64144 11.6141 8.31355 11.6409C7.99784 11.6667 7.6103 11.6667 7.14072 11.6667H3.94257C3.473 11.6667 3.08545 11.6667 2.76975 11.6409C2.44186 11.6141 2.14045 11.5566 1.85734 11.4123C1.41829 11.1886 1.06134 10.8317 0.837632 10.3926C0.693379 10.1095 0.635883 9.80812 0.609093 9.48023C0.5833 9.16453 0.583306 8.77699 0.583313 8.30742V5.69257C0.583306 5.22301 0.5833 4.83546 0.609093 4.51976C0.635883 4.19187 0.693379 3.89046 0.837632 3.60735C1.06134 3.16831 1.41829 2.81135 1.85734 2.58765C2.14045 2.44339 2.44186 2.3859 2.76975 2.35911C3.08545 2.33331 3.47299 2.33332 3.94256 2.33333ZM9.33331 5.71666C9.33331 5.21699 9.33286 4.87732 9.31141 4.61477C9.29051 4.35903 9.25264 4.22824 9.20615 4.13701C9.0943 3.91748 8.91582 3.73901 8.6963 3.62715C8.60507 3.58067 8.47428 3.5428 8.21854 3.5219C7.95599 3.50045 7.61632 3.5 7.11665 3.5H3.96665C3.46698 3.5 3.1273 3.50045 2.86475 3.5219C2.60901 3.5428 2.47822 3.58067 2.38699 3.62715C2.16747 3.73901 1.98899 3.91748 1.87714 4.13701C1.83065 4.22824 1.79278 4.35903 1.77189 4.61477C1.75043 4.87732 1.74998 5.21699 1.74998 5.71666V8.28333C1.74998 8.783 1.75043 9.12267 1.77189 9.38522C1.79278 9.64097 1.83065 9.77175 1.87714 9.86298C1.98899 10.0825 2.16747 10.261 2.38699 10.3728C2.47822 10.4193 2.60901 10.4572 2.86475 10.4781C3.1273 10.4995 3.46698 10.5 3.96665 10.5H7.11665C7.61632 10.5 7.95599 10.4995 8.21854 10.4781C8.47428 10.4572 8.60507 10.4193 8.6963 10.3728C8.91582 10.261 9.0943 10.0825 9.20615 9.86298C9.25264 9.77175 9.29051 9.64097 9.31141 9.38522C9.33286 9.12267 9.33331 8.783 9.33331 8.28333V5.71666ZM10.7416 7L12.25 8.50837V5.49162L10.7416 7Z",
-        fill: "currentColor"
+        "d": "M3.94256 2.33333H7.14074C7.6103 2.33332 7.99785 2.33331 8.31355 2.35911C8.64143 2.3859 8.94285 2.44339 9.22596 2.58765C9.665 2.81135 10.022 3.16831 10.2457 3.60735C10.3899 3.89046 10.4474 4.19187 10.4742 4.51976C10.4981 4.81257 10.4999 5.16718 10.5 5.59171L11.6396 4.45212C11.7511 4.34058 11.8607 4.23096 11.9567 4.15052C12.0424 4.07876 12.223 3.93485 12.473 3.91517C12.7522 3.8932 13.0251 4.00622 13.207 4.21921C13.3699 4.40993 13.3958 4.63932 13.4056 4.75068C13.4167 4.87549 13.4167 5.03051 13.4166 5.18822V8.81177C13.4167 8.96948 13.4167 9.1245 13.4056 9.24931C13.3958 9.36067 13.3699 9.59006 13.207 9.78078C13.0251 9.99377 12.7522 10.1068 12.473 10.0848C12.223 10.0651 12.0424 9.92123 11.9567 9.84947C11.8607 9.76904 11.7511 9.65941 11.6396 9.54787L10.5 8.40828C10.4999 8.83281 10.4981 9.18742 10.4742 9.48023C10.4474 9.80812 10.3899 10.1095 10.2457 10.3926C10.022 10.8317 9.665 11.1886 9.22596 11.4123C8.94285 11.5566 8.64144 11.6141 8.31355 11.6409C7.99784 11.6667 7.6103 11.6667 7.14072 11.6667H3.94257C3.473 11.6667 3.08545 11.6667 2.76975 11.6409C2.44186 11.6141 2.14045 11.5566 1.85734 11.4123C1.41829 11.1886 1.06134 10.8317 0.837632 10.3926C0.693379 10.1095 0.635883 9.80812 0.609093 9.48023C0.5833 9.16453 0.583306 8.77699 0.583313 8.30742V5.69257C0.583306 5.22301 0.5833 4.83546 0.609093 4.51976C0.635883 4.19187 0.693379 3.89046 0.837632 3.60735C1.06134 3.16831 1.41829 2.81135 1.85734 2.58765C2.14045 2.44339 2.44186 2.3859 2.76975 2.35911C3.08545 2.33331 3.47299 2.33332 3.94256 2.33333ZM9.33331 5.71666C9.33331 5.21699 9.33286 4.87732 9.31141 4.61477C9.29051 4.35903 9.25264 4.22824 9.20615 4.13701C9.0943 3.91748 8.91582 3.73901 8.6963 3.62715C8.60507 3.58067 8.47428 3.5428 8.21854 3.5219C7.95599 3.50045 7.61632 3.5 7.11665 3.5H3.96665C3.46698 3.5 3.1273 3.50045 2.86475 3.5219C2.60901 3.5428 2.47822 3.58067 2.38699 3.62715C2.16747 3.73901 1.98899 3.91748 1.87714 4.13701C1.83065 4.22824 1.79278 4.35903 1.77189 4.61477C1.75043 4.87732 1.74998 5.21699 1.74998 5.71666V8.28333C1.74998 8.783 1.75043 9.12267 1.77189 9.38522C1.79278 9.64097 1.83065 9.77175 1.87714 9.86298C1.98899 10.0825 2.16747 10.261 2.38699 10.3728C2.47822 10.4193 2.60901 10.4572 2.86475 10.4781C3.1273 10.4995 3.46698 10.5 3.96665 10.5H7.11665C7.61632 10.5 7.95599 10.4995 8.21854 10.4781C8.47428 10.4572 8.60507 10.4193 8.6963 10.3728C8.91582 10.261 9.0943 10.0825 9.20615 9.86298C9.25264 9.77175 9.29051 9.64097 9.31141 9.38522C9.33286 9.12267 9.33331 8.783 9.33331 8.28333V5.71666ZM10.7416 7L12.25 8.50837V5.49162L10.7416 7Z",
+        "fill": "currentColor"
       }
-    })]), _vm._v("\n          " + _vm._s(_vm.video.button_text) + "\n        ")]) : _vm._e(), _vm._v(" "), _vm.learn_more ? _c("a", {
+    })]), _vm._v("\n          " + _vm._s(_vm.video.button_text) + "\n        ")]) : _vm._e(), _vm._v(" "), _vm.learn_more ? _c('a', {
       staticClass: "directorist-form-doc__link",
       attrs: {
-        href: _vm.learn_more.url,
-        target: "_blank"
+        "href": _vm.learn_more.url,
+        "target": "_blank"
       },
       domProps: {
-        innerHTML: _vm._s(_vm.learn_more.title)
+        "innerHTML": _vm._s(_vm.learn_more.title)
       }
-    }) : _vm._e()]), _vm._v(" "), section.fields[0] === "submission_form_fields" ? _c("div", {
+    }) : _vm._e()]), _vm._v(" "), section.fields[0] === 'submission_form_fields' ? _c('div', {
       staticClass: "directorist-form-doc-right"
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "directorist-form-doc__preview",
       attrs: {
-        href: "#",
-        target: "_blank"
+        "href": "#",
+        "target": "_blank"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           return _vm.saveData();
         }
       }
-    }, [_c("svg", {
+    }, [_c('svg', {
       attrs: {
-        xmlns: "http://www.w3.org/2000/svg",
-        width: "16",
-        height: "16",
-        viewBox: "0 0 16 16",
-        fill: "none"
+        "xmlns": "http://www.w3.org/2000/svg",
+        "width": "16",
+        "height": "16",
+        "viewBox": "0 0 16 16",
+        "fill": "none"
       }
-    }, [_c("path", {
+    }, [_c('path', {
       attrs: {
         "fill-rule": "evenodd",
         "clip-rule": "evenodd",
-        d: "M5.33749 1.86822C5.34546 1.87353 5.35345 1.87886 5.36147 1.88421L12.394 6.57255C12.5975 6.70817 12.7861 6.83392 12.931 6.95077C13.0822 7.07273 13.2605 7.24185 13.3631 7.48925C13.4987 7.81625 13.4987 8.18376 13.3631 8.51077C13.2605 8.75817 13.0822 8.92729 12.931 9.04924C12.7861 9.1661 12.5975 9.29184 12.394 9.42746L5.33751 14.1318C5.08879 14.2976 4.86513 14.4468 4.67535 14.5496C4.48544 14.6525 4.22477 14.7701 3.92052 14.752C3.53135 14.7287 3.17185 14.5363 2.93665 14.2254C2.75276 13.9823 2.70602 13.7002 2.68631 13.4851C2.66662 13.2701 2.66664 13.0014 2.66666 12.7024L2.66666 3.32643C2.66666 3.31679 2.66666 3.30718 2.66666 3.2976C2.66664 2.99867 2.66662 2.72987 2.68631 2.51492C2.70602 2.29982 2.75276 2.01769 2.93665 1.77461C3.17185 1.46369 3.53135 1.27129 3.92052 1.24806C4.22477 1.22989 4.48545 1.3475 4.67536 1.45042C4.86513 1.55326 5.08878 1.70238 5.33749 1.86822ZM4.01674 2.61031C4.01584 2.61839 4.01495 2.62713 4.01409 2.63658C4.00066 2.78307 3.99999 2.98946 3.99999 3.32643V12.6736C3.99999 13.0106 4.00066 13.2169 4.01409 13.3634C4.01495 13.3729 4.01584 13.3816 4.01674 13.3897C4.02396 13.386 4.03173 13.3819 4.04007 13.3773C4.1694 13.3073 4.3415 13.1933 4.62187 13.0064L11.6322 8.33283C11.8655 8.17735 12.0022 8.08542 12.094 8.01137C12.099 8.00736 12.1036 8.00357 12.1079 8.00001C12.1036 7.99644 12.099 7.99265 12.094 7.98864C12.0022 7.9146 11.8655 7.82267 11.6322 7.66719L4.62187 2.99361C4.3415 2.80669 4.1694 2.69277 4.04007 2.62267C4.03173 2.61815 4.02396 2.61405 4.01674 2.61031Z",
-        fill: "currentColor"
+        "d": "M5.33749 1.86822C5.34546 1.87353 5.35345 1.87886 5.36147 1.88421L12.394 6.57255C12.5975 6.70817 12.7861 6.83392 12.931 6.95077C13.0822 7.07273 13.2605 7.24185 13.3631 7.48925C13.4987 7.81625 13.4987 8.18376 13.3631 8.51077C13.2605 8.75817 13.0822 8.92729 12.931 9.04924C12.7861 9.1661 12.5975 9.29184 12.394 9.42746L5.33751 14.1318C5.08879 14.2976 4.86513 14.4468 4.67535 14.5496C4.48544 14.6525 4.22477 14.7701 3.92052 14.752C3.53135 14.7287 3.17185 14.5363 2.93665 14.2254C2.75276 13.9823 2.70602 13.7002 2.68631 13.4851C2.66662 13.2701 2.66664 13.0014 2.66666 12.7024L2.66666 3.32643C2.66666 3.31679 2.66666 3.30718 2.66666 3.2976C2.66664 2.99867 2.66662 2.72987 2.68631 2.51492C2.70602 2.29982 2.75276 2.01769 2.93665 1.77461C3.17185 1.46369 3.53135 1.27129 3.92052 1.24806C4.22477 1.22989 4.48545 1.3475 4.67536 1.45042C4.86513 1.55326 5.08878 1.70238 5.33749 1.86822ZM4.01674 2.61031C4.01584 2.61839 4.01495 2.62713 4.01409 2.63658C4.00066 2.78307 3.99999 2.98946 3.99999 3.32643V12.6736C3.99999 13.0106 4.00066 13.2169 4.01409 13.3634C4.01495 13.3729 4.01584 13.3816 4.01674 13.3897C4.02396 13.386 4.03173 13.3819 4.04007 13.3773C4.1694 13.3073 4.3415 13.1933 4.62187 13.0064L11.6322 8.33283C11.8655 8.17735 12.0022 8.08542 12.094 8.01137C12.099 8.00736 12.1036 8.00357 12.1079 8.00001C12.1036 7.99644 12.099 7.99265 12.094 7.98864C12.0022 7.9146 11.8655 7.82267 11.6322 7.66719L4.62187 2.99361C4.3415 2.80669 4.1694 2.69277 4.04007 2.62267C4.03173 2.61815 4.02396 2.61405 4.01674 2.61031Z",
+        "fill": "currentColor"
       }
-    })]), _vm._v("\n          preview\n        ")])]) : _vm._e()]) : _vm._e(), _vm._v(" "), section.fields[0] !== "submission_form_fields" && section.fields[0] !== "search_form_fields" && section.fields[0] !== "single_listing_header" && section.fields[0] !== "single_listing_header" && section.fields[0] !== "single_listings_contents" && section.fields[0] !== "listings_card_grid_view" && section.fields[0] !== "listings_card_list_view" ? _c("div", {
+    })]), _vm._v("\n          preview\n        ")])]) : _vm._e()]) : _vm._e(), _vm._v(" "), section.fields[0] !== 'submission_form_fields' && section.fields[0] !== 'search_form_fields' && section.fields[0] !== 'single_listing_header' && section.fields[0] !== 'single_listing_header' && section.fields[0] !== 'single_listings_contents' && section.fields[0] !== 'listings_card_grid_view' && section.fields[0] !== 'listings_card_list_view' ? _c('div', {
       staticClass: "cptm-title-area",
       class: _vm.sectionTitleAreaClass(section)
-    }, [section.title ? _c("h3", {
+    }, [section.title ? _c('h3', {
       staticClass: "cptm-title",
       domProps: {
-        innerHTML: _vm._s(section.title)
+        "innerHTML": _vm._s(section.title)
       }
-    }) : _vm._e(), _vm._v(" "), section.description ? _c("div", {
+    }) : _vm._e(), _vm._v(" "), section.description ? _c('div', {
       staticClass: "cptm-des",
       domProps: {
-        innerHTML: _vm._s(section.description)
+        "innerHTML": _vm._s(section.description)
       }
-    }) : _vm._e()]) : _vm._e(), _vm._v(" "), _vm.sectionFields(section) ? _c("div", {
+    }) : _vm._e()]) : _vm._e(), _vm._v(" "), _vm.sectionFields(section) ? _c('div', {
       staticClass: "cptm-form-fields"
     }, _vm._l(_vm.sectionFields(section), function (field, field_key) {
-      return _vm.fields[field].group !== "container" ? _c("div", {
+      return _vm.fields[field].group !== 'container' ? _c('div', {
         key: field_key
       }, [_vm.fields[field] ? _c(_vm.getFormFieldName(_vm.fields[field].type), _vm._b({
         ref: field,
         refInFor: true,
         tag: "component",
-        class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "highlight-field", _vm.getHighlightState(field)),
+        class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, 'highlight-field', _vm.getHighlightState(field)),
         attrs: {
           "field-id": field_key,
-          fieldKey: field,
-          id: _vm.menuKey + "__" + section_key + "__" + field,
+          "fieldKey": field,
+          "id": _vm.menuKey + '__' + section_key + '__' + field,
           "cached-data": _vm.cached_fields[field],
-          listing_type_id: _vm.listing_type_id
+          "listing_type_id": _vm.listing_type_id
         },
         on: {
-          update: function update($event) {
+          "update": function update($event) {
             return _vm.updateFieldValue(field, $event);
           },
-          save: function save($event) {
-            return _vm.$emit("save", $event);
+          "save": function save($event) {
+            return _vm.$emit('save', $event);
           },
-          validate: function validate($event) {
+          "validate": function validate($event) {
             return _vm.updateFieldValidationState(field, $event);
           },
           "is-visible": function isVisible($event) {
-            return _vm.updateFieldData(field, "isVisible", $event);
+            return _vm.updateFieldData(field, 'isVisible', $event);
           },
           "do-action": function doAction($event) {
-            return _vm.doAction($event, "sections-module");
+            return _vm.doAction($event, 'sections-module');
           }
         }
-      }, "component", _vm.fields[field], false)) : _vm._e(), _vm._v(" "), field === "way_to_show_preview" && _vm.groupedContainerFields.length > 0 ? _c("div", {
+      }, 'component', _vm.fields[field], false)) : _vm._e(), _vm._v(" "), field === 'way_to_show_preview' && _vm.groupedContainerFields.length > 0 ? _c('div', {
         staticClass: "cptm-field-group-container"
-      }, [_c("div", {
+      }, [_c('div', {
         staticClass: "atbdp-row"
-      }, [_c("div", {
+      }, [_c('div', {
         staticClass: "atbdp-col atbdp-col-4"
-      }, [_c("label", {
+      }, [_c('label', {
         staticClass: "cptm-field-group-container__label"
-      }, [_c("span", [_vm._v(_vm._s(_vm.containerGroupLabel))])])]), _vm._v(" "), _c("div", {
+      }, [_c('span', [_vm._v(_vm._s(_vm.containerGroupLabel))])])]), _vm._v(" "), _c('div', {
         staticClass: "atbdp-col atbdp-col-8"
-      }, [_c("div", {
+      }, [_c('div', {
         staticClass: "cptm-container-group-fields"
       }, _vm._l(_vm.groupedContainerFields, function (groupedField, groupedFieldKey) {
         return _c(_vm.getFormFieldName(_vm.fields[groupedField].type), _vm._b({
@@ -27964,36 +27944,36 @@ var render = function render() {
           ref: groupedField,
           refInFor: true,
           tag: "component",
-          class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "highlight-field", _vm.getHighlightState(groupedField)),
+          class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, 'highlight-field', _vm.getHighlightState(groupedField)),
           attrs: {
             "field-id": groupedFieldKey,
-            id: _vm.menuKey + "__" + section_key + "__" + groupedField,
+            "id": _vm.menuKey + '__' + section_key + '__' + groupedField,
             "cached-data": _vm.cached_fields[groupedField]
           },
           on: {
-            update: function update($event) {
+            "update": function update($event) {
               return _vm.updateFieldValue(groupedField, $event);
             },
-            save: function save($event) {
-              return _vm.$emit("save", $event);
+            "save": function save($event) {
+              return _vm.$emit('save', $event);
             },
-            validate: function validate($event) {
+            "validate": function validate($event) {
               return _vm.updateFieldValidationState(groupedField, $event);
             },
             "is-visible": function isVisible($event) {
-              return _vm.updateFieldData(groupedField, "isVisible", $event);
+              return _vm.updateFieldData(groupedField, 'isVisible', $event);
             },
             "do-action": function doAction($event) {
-              return _vm.doAction($event, "sections-module");
+              return _vm.doAction($event, 'sections-module');
             }
           }
-        }, "component", _vm.fields[groupedField], false));
+        }, 'component', _vm.fields[groupedField], false));
       }), 1)])])]) : _vm._e()], 1) : _vm._e();
     }), 0) : _vm._e()]);
-  }), _vm._v(" "), _vm.video ? _c("form-builder-widget-video-component", {
+  }), _vm._v(" "), _vm.video ? _c('form-builder-widget-video-component', {
     attrs: {
-      videoOpened: _vm.showVideo,
-      video: _vm.video
+      "videoOpened": _vm.showVideo,
+      "video": _vm.video
     },
     on: {
       "close-video": _vm.closeVideoPopup
@@ -28023,50 +28003,50 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "setting-left-sibebar"
-  }, [_c("ul", {
+  }, [_c('ul', {
     staticClass: "settings-nav"
   }, _vm._l(_vm.menu, function (meue_item, menu_key) {
-    return _c("li", {
+    return _c('li', {
       key: menu_key,
       staticClass: "settings-nav__item",
       class: {
         active: meue_item.active
       }
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "settings-nav__item__link",
-      class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "nav-has-dropdwon", meue_item.submenu),
+      class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, 'nav-has-dropdwon', meue_item.submenu),
       attrs: {
-        href: "#"
+        "href": "#"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.swichToNav({
             menu_key: menu_key
           }, $event);
         }
       }
-    }, [meue_item.icon ? _c("span", {
+    }, [meue_item.icon ? _c('span', {
       staticClass: "settings-nav__item__icon",
       domProps: {
-        innerHTML: _vm._s(meue_item.icon)
+        "innerHTML": _vm._s(meue_item.icon)
       }
-    }) : _vm._e(), _vm._v(" \n        " + _vm._s(meue_item.label) + " "), meue_item.submenu ? _c("span", {
+    }) : _vm._e(), _vm._v(" \n        " + _vm._s(meue_item.label) + " "), meue_item.submenu ? _c('span', {
       staticClass: "drop-toggle-caret"
-    }) : _vm._e()]), _vm._v(" "), meue_item.submenu ? _c("ul", _vm._l(meue_item.submenu, function (submeue_item, submenu_key) {
-      return _c("li", {
+    }) : _vm._e()]), _vm._v(" "), meue_item.submenu ? _c('ul', _vm._l(meue_item.submenu, function (submeue_item, submenu_key) {
+      return _c('li', {
         key: submenu_key
-      }, [_c("a", {
+      }, [_c('a', {
         class: {
           active: submeue_item.active
         },
         attrs: {
-          href: "#"
+          "href": "#"
         },
         on: {
-          click: function click($event) {
+          "click": function click($event) {
             $event.preventDefault();
             return _vm.swichToNav({
               menu_key: menu_key,
@@ -28074,10 +28054,10 @@ var render = function render() {
             }, $event);
           }
         }
-      }, [submeue_item.icon ? _c("span", {
+      }, [submeue_item.icon ? _c('span', {
         staticClass: "settings-nav__item__icon",
         domProps: {
-          innerHTML: _vm._s(submeue_item.icon)
+          "innerHTML": _vm._s(submeue_item.icon)
         }
       }) : _vm._e(), _vm._v(" \n              " + _vm._s(submeue_item.label) + "\n            ")])]);
     }), 0) : _vm._e()]);
@@ -28103,36 +28083,36 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.option_fields ? _c("div", {
+  return _vm.option_fields ? _c('div', {
     staticClass: "cptm-fields"
   }, _vm._l(Object.keys(_vm.option_fields), function (field_key, field_index) {
-    return _c("div", {
+    return _c('div', {
       key: field_index,
       class: _vm.fieldWrapperClass(field_key, _vm.option_fields[field_key])
-    }, [_c(_vm.option_fields[field_key].type + "-field", _vm._b({
+    }, [_c(_vm.option_fields[field_key].type + '-field', _vm._b({
       key: field_index,
       ref: field_key,
       refInFor: true,
       tag: "component",
       attrs: {
-        root: _vm.option_fields,
+        "root": _vm.option_fields,
         "field-id": field_key
       },
       on: {
-        update: function update($event) {
+        "update": function update($event) {
           return _vm.updateOptionFieldValue(field_key, $event);
         },
-        validate: function validate($event) {
+        "validate": function validate($event) {
           return _vm.updateOptionFieldValidationState(field_key, $event);
         },
         "is-visible": function isVisible($event) {
-          return _vm.updateOptionFieldData(field_key, "isVisible", $event);
+          return _vm.updateOptionFieldData(field_key, 'isVisible', $event);
         },
         "do-action": function doAction($event) {
-          return _vm.doAction($event, "sub-fields");
+          return _vm.doAction($event, 'sub-fields');
         }
       }
-    }, "component", _vm.option_fields[field_key], false))], 1);
+    }, 'component', _vm.option_fields[field_key], false))], 1);
   }), 0) : _vm._e();
 };
 var staticRenderFns = [];
@@ -28155,20 +28135,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("ul", {
+  return _c('ul', {
     staticClass: "cptm-sub-navigation"
   }, _vm._l(_vm.navLists, function (nav, index) {
-    return _c("li", {
+    return _c('li', {
       key: index,
       staticClass: "cptm-sub-nav__item"
-    }, [_c("a", {
+    }, [_c('a', {
       staticClass: "cptm-sub-nav__item-link",
       class: _vm.getActiveClass(index, _vm.active_nav),
       attrs: {
-        href: "#"
+        "href": "#"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.swichNav(index);
         }
@@ -28196,11 +28176,11 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", [_c("div", {
+  return _c('div', [_c('div', {
     staticClass: "cptm-tab-content-header"
-  }, [_c("sub-navigation", {
+  }, [_c('sub-navigation', {
     attrs: {
-      navLists: _vm.navList
+      "navLists": _vm.navList
     },
     model: {
       value: _vm.active_sub_nav,
@@ -28209,46 +28189,46 @@ var render = function render() {
       },
       expression: "active_sub_nav"
     }
-  }), _vm._v(" "), _vm.currentVideo ? _c("a", {
+  }), _vm._v(" "), _vm.currentVideo ? _c('a', {
     staticClass: "directorist-form-doc__watch-tutorial",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.openVideoPopup.apply(null, arguments);
       }
     }
-  }, [_c("svg", {
+  }, [_c('svg', {
     attrs: {
-      xmlns: "http://www.w3.org/2000/svg",
-      width: "14",
-      height: "14",
-      viewBox: "0 0 14 14",
-      fill: "none"
+      "xmlns": "http://www.w3.org/2000/svg",
+      "width": "14",
+      "height": "14",
+      "viewBox": "0 0 14 14",
+      "fill": "none"
     }
-  }, [_c("path", {
+  }, [_c('path', {
     attrs: {
       "fill-rule": "evenodd",
       "clip-rule": "evenodd",
-      d: "M3.94256 2.33333H7.14074C7.6103 2.33332 7.99785 2.33331 8.31355 2.35911C8.64143 2.3859 8.94285 2.44339 9.22596 2.58765C9.665 2.81135 10.022 3.16831 10.2457 3.60735C10.3899 3.89046 10.4474 4.19187 10.4742 4.51976C10.4981 4.81257 10.4999 5.16718 10.5 5.59171L11.6396 4.45212C11.7511 4.34058 11.8607 4.23096 11.9567 4.15052C12.0424 4.07876 12.223 3.93485 12.473 3.91517C12.7522 3.8932 13.0251 4.00622 13.207 4.21921C13.3699 4.40993 13.3958 4.63932 13.4056 4.75068C13.4167 4.87549 13.4167 5.03051 13.4166 5.18822V8.81177C13.4167 8.96948 13.4167 9.1245 13.4056 9.24931C13.3958 9.36067 13.3699 9.59006 13.207 9.78078C13.0251 9.99377 12.7522 10.1068 12.473 10.0848C12.223 10.0651 12.0424 9.92123 11.9567 9.84947C11.8607 9.76904 11.7511 9.65941 11.6396 9.54787L10.5 8.40828C10.4999 8.83281 10.4981 9.18742 10.4742 9.48023C10.4474 9.80812 10.3899 10.1095 10.2457 10.3926C10.022 10.8317 9.665 11.1886 9.22596 11.4123C8.94285 11.5566 8.64144 11.6141 8.31355 11.6409C7.99784 11.6667 7.6103 11.6667 7.14072 11.6667H3.94257C3.473 11.6667 3.08545 11.6667 2.76975 11.6409C2.44186 11.6141 2.14045 11.5566 1.85734 11.4123C1.41829 11.1886 1.06134 10.8317 0.837632 10.3926C0.693379 10.1095 0.635883 9.80812 0.609093 9.48023C0.5833 9.16453 0.583306 8.77699 0.583313 8.30742V5.69257C0.583306 5.22301 0.5833 4.83546 0.609093 4.51976C0.635883 4.19187 0.693379 3.89046 0.837632 3.60735C1.06134 3.16831 1.41829 2.81135 1.85734 2.58765C2.14045 2.44339 2.44186 2.3859 2.76975 2.35911C3.08545 2.33331 3.47299 2.33332 3.94256 2.33333ZM9.33331 5.71666C9.33331 5.21699 9.33286 4.87732 9.31141 4.61477C9.29051 4.35903 9.25264 4.22824 9.20615 4.13701C9.0943 3.91748 8.91582 3.73901 8.6963 3.62715C8.60507 3.58067 8.47428 3.5428 8.21854 3.5219C7.95599 3.50045 7.61632 3.5 7.11665 3.5H3.96665C3.46698 3.5 3.1273 3.50045 2.86475 3.5219C2.60901 3.5428 2.47822 3.58067 2.38699 3.62715C2.16747 3.73901 1.98899 3.91748 1.87714 4.13701C1.83065 4.22824 1.79278 4.35903 1.77189 4.61477C1.75043 4.87732 1.74998 5.21699 1.74998 5.71666V8.28333C1.74998 8.783 1.75043 9.12267 1.77189 9.38522C1.79278 9.64097 1.83065 9.77175 1.87714 9.86298C1.98899 10.0825 2.16747 10.261 2.38699 10.3728C2.47822 10.4193 2.60901 10.4572 2.86475 10.4781C3.1273 10.4995 3.46698 10.5 3.96665 10.5H7.11665C7.61632 10.5 7.95599 10.4995 8.21854 10.4781C8.47428 10.4572 8.60507 10.4193 8.6963 10.3728C8.91582 10.261 9.0943 10.0825 9.20615 9.86298C9.25264 9.77175 9.29051 9.64097 9.31141 9.38522C9.33286 9.12267 9.33331 8.783 9.33331 8.28333V5.71666ZM10.7416 7L12.25 8.50837V5.49162L10.7416 7Z",
-      fill: "currentColor"
+      "d": "M3.94256 2.33333H7.14074C7.6103 2.33332 7.99785 2.33331 8.31355 2.35911C8.64143 2.3859 8.94285 2.44339 9.22596 2.58765C9.665 2.81135 10.022 3.16831 10.2457 3.60735C10.3899 3.89046 10.4474 4.19187 10.4742 4.51976C10.4981 4.81257 10.4999 5.16718 10.5 5.59171L11.6396 4.45212C11.7511 4.34058 11.8607 4.23096 11.9567 4.15052C12.0424 4.07876 12.223 3.93485 12.473 3.91517C12.7522 3.8932 13.0251 4.00622 13.207 4.21921C13.3699 4.40993 13.3958 4.63932 13.4056 4.75068C13.4167 4.87549 13.4167 5.03051 13.4166 5.18822V8.81177C13.4167 8.96948 13.4167 9.1245 13.4056 9.24931C13.3958 9.36067 13.3699 9.59006 13.207 9.78078C13.0251 9.99377 12.7522 10.1068 12.473 10.0848C12.223 10.0651 12.0424 9.92123 11.9567 9.84947C11.8607 9.76904 11.7511 9.65941 11.6396 9.54787L10.5 8.40828C10.4999 8.83281 10.4981 9.18742 10.4742 9.48023C10.4474 9.80812 10.3899 10.1095 10.2457 10.3926C10.022 10.8317 9.665 11.1886 9.22596 11.4123C8.94285 11.5566 8.64144 11.6141 8.31355 11.6409C7.99784 11.6667 7.6103 11.6667 7.14072 11.6667H3.94257C3.473 11.6667 3.08545 11.6667 2.76975 11.6409C2.44186 11.6141 2.14045 11.5566 1.85734 11.4123C1.41829 11.1886 1.06134 10.8317 0.837632 10.3926C0.693379 10.1095 0.635883 9.80812 0.609093 9.48023C0.5833 9.16453 0.583306 8.77699 0.583313 8.30742V5.69257C0.583306 5.22301 0.5833 4.83546 0.609093 4.51976C0.635883 4.19187 0.693379 3.89046 0.837632 3.60735C1.06134 3.16831 1.41829 2.81135 1.85734 2.58765C2.14045 2.44339 2.44186 2.3859 2.76975 2.35911C3.08545 2.33331 3.47299 2.33332 3.94256 2.33333ZM9.33331 5.71666C9.33331 5.21699 9.33286 4.87732 9.31141 4.61477C9.29051 4.35903 9.25264 4.22824 9.20615 4.13701C9.0943 3.91748 8.91582 3.73901 8.6963 3.62715C8.60507 3.58067 8.47428 3.5428 8.21854 3.5219C7.95599 3.50045 7.61632 3.5 7.11665 3.5H3.96665C3.46698 3.5 3.1273 3.50045 2.86475 3.5219C2.60901 3.5428 2.47822 3.58067 2.38699 3.62715C2.16747 3.73901 1.98899 3.91748 1.87714 4.13701C1.83065 4.22824 1.79278 4.35903 1.77189 4.61477C1.75043 4.87732 1.74998 5.21699 1.74998 5.71666V8.28333C1.74998 8.783 1.75043 9.12267 1.77189 9.38522C1.79278 9.64097 1.83065 9.77175 1.87714 9.86298C1.98899 10.0825 2.16747 10.261 2.38699 10.3728C2.47822 10.4193 2.60901 10.4572 2.86475 10.4781C3.1273 10.4995 3.46698 10.5 3.96665 10.5H7.11665C7.61632 10.5 7.95599 10.4995 8.21854 10.4781C8.47428 10.4572 8.60507 10.4193 8.6963 10.3728C8.91582 10.261 9.0943 10.0825 9.20615 9.86298C9.25264 9.77175 9.29051 9.64097 9.31141 9.38522C9.33286 9.12267 9.33331 8.783 9.33331 8.28333V5.71666ZM10.7416 7L12.25 8.50837V5.49162L10.7416 7Z",
+      "fill": "currentColor"
     }
-  })]), _vm._v("\n            " + _vm._s(_vm.currentVideo.button_text) + "\n        ")]) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  })]), _vm._v("\n            " + _vm._s(_vm.currentVideo.button_text) + "\n        ")]) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-tab-content-body"
   }, [_vm._l(_vm.subNavigation, function (sub_tab, sub_tab_index) {
-    return [(_vm.active_sub_nav === sub_tab_index ? true : false) ? _c("div", {
+    return [(_vm.active_sub_nav === sub_tab_index ? true : false) ? _c('div', {
       key: sub_tab_index,
       staticClass: "cptm-tab-sub-content-item",
       class: {
         active: _vm.active_sub_nav === sub_tab_index ? true : false
       }
-    }, [_c("sections-module", _vm._b({}, "sections-module", sub_tab, false))], 1) : _vm._e()];
-  })], 2), _vm._v(" "), _vm.currentVideo ? _c("form-builder-widget-video-component", {
+    }, [_c('sections-module', _vm._b({}, 'sections-module', sub_tab, false))], 1) : _vm._e()];
+  })], 2), _vm._v(" "), _vm.currentVideo ? _c('form-builder-widget-video-component', {
     attrs: {
-      video: _vm.currentVideo,
-      videoOpened: _vm.showVideo
+      "video": _vm.currentVideo,
+      "videoOpened": _vm.showVideo
     },
     on: {
       "close-video": _vm.closeVideoPopup
@@ -28275,49 +28255,49 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-actions-tools"
-  }, [_vm.canMove ? _c("a", {
+  }, [_vm.canMove ? _c('a', {
     attrs: {
-      href: "#",
-      draggable: "true"
+      "href": "#",
+      "draggable": "true"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
       },
-      drag: function drag($event) {
-        return _vm.$emit("drag");
+      "drag": function drag($event) {
+        return _vm.$emit('drag');
       },
-      dragend: function dragend($event) {
-        return _vm.$emit("dragend");
+      "dragend": function dragend($event) {
+        return _vm.$emit('dragend');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-expand-arrows"
-  })]) : _vm._e(), _vm._v(" "), _vm.canEdit ? _c("a", {
+  })]) : _vm._e(), _vm._v(" "), _vm.canEdit ? _c('a', {
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("edit");
+        return _vm.$emit('edit');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-cog"
-  })]) : _vm._e(), _vm._v(" "), _vm.canTrash ? _c("a", {
+  })]) : _vm._e(), _vm._v(" "), _vm.canTrash ? _c('a', {
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("trash");
+        return _vm.$emit('trash');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-trash-alt"
   })]) : _vm._e()]);
 };
@@ -28341,39 +28321,39 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-control-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-control"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-widget-control-action cptm-widget-control-action-move",
     attrs: {
-      draggable: "true"
+      "draggable": "true"
     },
     on: {
-      drag: function drag($event) {
-        return _vm.$emit("drag");
+      "drag": function drag($event) {
+        return _vm.$emit('drag');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-expand-arrows"
-  })]), _vm._v(" "), _c("span", {
+  })]), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-control-action cptm-widget-control-action-edit",
     on: {
-      click: function click($event) {
-        return _vm.$emit("edit");
+      "click": function click($event) {
+        return _vm.$emit('edit');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-cog"
-  })]), _vm._v(" "), _c("span", {
+  })]), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-control-action cptm-widget-control-action-trash",
     on: {
-      click: function click($event) {
-        return _vm.$emit("trash");
+      "click": function click($event) {
+        return _vm.$emit('trash');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-trash-alt"
   })])])]);
 };
@@ -28397,62 +28377,62 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-option-card",
     class: _vm.mainWrapperClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-option-card-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-option-card-header-title-section"
-  }, [_c("h3", {
+  }, [_c('h3', {
     staticClass: "cptm-option-card-header-title"
-  }, [_vm._v("Insert Element")]), _vm._v(" "), _c("div", {
+  }, [_vm._v("Insert Element")]), _vm._v(" "), _c('div', {
     staticClass: "cptm-header-action-area"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-header-action-link cptm-header-action-close",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("close");
+        return _vm.$emit('close');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-times"
-  })])])])]), _vm._v(" "), _c("div", {
+  })])])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-option-card-body"
-  }, [_vm.infoTexts.length ? _c("div", {
+  }, [_vm.infoTexts.length ? _c('div', {
     staticClass: "cptm-info-text-area"
   }, _vm._l(_vm.infoTexts, function (info, text_key) {
-    return _c("p", {
+    return _c('p', {
       key: text_key,
       staticClass: "cptm-info-text",
-      class: "cptm-" + info.type
+      class: 'cptm-' + info.type
     }, [_vm._v("\n                " + _vm._s(info.text) + "\n            ")]);
-  }), 0) : _vm._e(), _vm._v(" "), Object.keys(_vm.unSelectedWidgetsList).length ? _c("ul", {
+  }), 0) : _vm._e(), _vm._v(" "), Object.keys(_vm.unSelectedWidgetsList).length ? _c('ul', {
     staticClass: "cptm-form-builder-field-list"
   }, _vm._l(_vm.unSelectedWidgetsList, function (widget, widget_key) {
-    return _c("li", {
+    return _c('li', {
       key: widget_key,
       staticClass: "cptm-form-builder-field-list-item",
       class: _vm.widgetListClass(widget_key),
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           return _vm.selectWidget(widget_key);
         }
       }
-    }, [_c("pre", [_vm._v(_vm._s(widget.in_used))]), _vm._v(" "), _c("span", {
+    }, [_c('pre', [_vm._v(_vm._s(widget.in_used))]), _vm._v(" "), _c('span', {
       staticClass: "cptm-form-builder-field-list-icon"
-    }, [_c("span", {
+    }, [_c('span', {
       class: widget.icon
-    })]), _vm._v(" "), _c("span", {
+    })]), _vm._v(" "), _c('span', {
       staticClass: "cptm-form-builder-field-list-label"
     }, [_vm._v("\n                        " + _vm._s(widget.label) + "\n                    ")])]);
-  }), 0) : _c("p", {
+  }), 0) : _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v("Nothing available")])]), _vm._v(" "), _vm.bottomAchhor ? _c("span", {
+  }, [_vm._v("Nothing available")])]), _vm._v(" "), _vm.bottomAchhor ? _c('span', {
     staticClass: "cptm-anchor-down"
   }) : _vm._e()]);
 };
@@ -28476,44 +28456,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._m(0), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._m(0), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28522,12 +28502,12 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("p", {
+  return _c('p', {
     staticClass: "cptm-placeholder-author-thumb"
-  }, [_c("img", {
+  }, [_c('img', {
     attrs: {
-      src: "https://via.placeholder.com/150",
-      alt: ""
+      "src": "https://via.placeholder.com/150",
+      "alt": ""
     }
   })]);
 }];
@@ -28550,44 +28530,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28613,44 +28593,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28676,44 +28656,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28739,44 +28719,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28802,44 +28782,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28865,52 +28845,52 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-block-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-list-item-card cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-list-item"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-list-item-icon"
-  }, [_c("span", {
+  }, [_c('span', {
     class: _vm.listIcon
-  })]), _vm._v(" "), _c("span", {
+  })]), _vm._v(" "), _c('span', {
     staticClass: "cptm-list-item-label"
-  }, [_vm._v(_vm._s(_vm.label))])]), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._v(_vm._s(_vm.label))])]), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28936,44 +28916,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -28999,44 +28979,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29062,44 +29042,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29125,44 +29105,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c("widget-action-tools", {
+  }, [_vm._v("\n        " + _vm._s(_vm.label) + "\n        \n        "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29188,46 +29168,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-block-wrap cptm-widget-title-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-title-card cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-title-block"
-  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29253,46 +29233,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-thumb cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._m(0), _vm._v(" "), _c("div", {
+  }, [_vm._m(0), _vm._v(" "), _c('div', {
     staticClass: "cptm-widget-label"
-  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29301,9 +29281,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-thumb-icon"
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-image-v"
   })]);
 }];
@@ -29326,46 +29306,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-block-wrap cptm-widget-title-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-title-card cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-title-block"
-  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._v("\n            " + _vm._s(_vm.label) + "\n        ")]), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29391,44 +29371,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-widget-card-wrap cptm-widget-card-inline-wrap cptm-widget-badge-card-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-card cptm-widget-badge cptm-has-widget-control cptm-widget-actions-tools-wrap"
-  }, [_vm._m(0), _vm._v(" "), _c("widget-action-tools", {
+  }, [_vm._m(0), _vm._v(" "), _c('widget-action-tools', {
     attrs: {
-      canEdit: _vm.canEdit,
-      canMove: _vm.canMove,
-      canTrash: _vm.canTrash
+      "canEdit": _vm.canEdit,
+      "canMove": _vm.canMove,
+      "canTrash": _vm.canTrash
     },
     on: {
-      drag: function drag($event) {
+      "drag": function drag($event) {
         return _vm.dragStart();
       },
-      dragend: function dragend($event) {
+      "dragend": function dragend($event) {
         return _vm.dragEnd();
       },
-      edit: function edit($event) {
-        return _vm.$emit("edit");
+      "edit": function edit($event) {
+        return _vm.$emit('edit');
       },
-      trash: function trash($event) {
-        return _vm.$emit("trash");
+      "trash": function trash($event) {
+        return _vm.$emit('trash');
       }
     }
-  })], 1), _vm._v(" "), _c("span", {
+  })], 1), _vm._v(" "), _c('span', {
     staticClass: "cptm-widget-card-drop-append",
     class: _vm.dropAppendClass,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         return _vm.handleDragEnter();
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         return _vm.handleDragLeave();
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDrop();
       }
     }
@@ -29437,11 +29417,11 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("span", {
+  return _c('span', {
     staticStyle: {
       "font-size": "16px"
     }
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-eye"
   }), _vm._v("\n            0\n        ")]);
 }];
@@ -29464,32 +29444,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.listType === "div" ? _c("div", {
+  return _vm.listType === 'div' ? _c('div', {
     staticClass: "directorist-draggable-list-item",
     class: _vm.itemClassName,
     style: _vm.listItemStyle,
     attrs: {
-      draggable: _vm.canDrag
+      "draggable": _vm.canDrag
     },
     on: {
-      dragstart: _vm.dragStart,
-      dragend: _vm.dragEnd
+      "dragstart": _vm.dragStart,
+      "dragend": _vm.dragEnd
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-draggable-list-item-slot",
     style: _vm.slotStyle
-  }, [_vm._t("default")], 2)]) : _c("li", {
+  }, [_vm._t("default")], 2)]) : _c('li', {
     staticClass: "directorist-draggable-list-item",
     class: _vm.itemClassName,
     style: _vm.listItemStyle,
     attrs: {
-      draggable: "canDrag"
+      "draggable": "canDrag"
     },
     on: {
-      dragstart: _vm.dragStart,
-      dragend: _vm.dragEnd
+      "dragstart": _vm.dragStart,
+      "dragend": _vm.dragEnd
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-draggable-list-item-slot",
     style: _vm.slotStyle
   }, [_vm._t("default")], 2)]);
@@ -29514,53 +29494,53 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "directorist-draggable-list-item-wrapper",
     style: _vm.wrapperStyle,
     attrs: {
       "data-list-id": _vm.listId
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-droppable-area-wrap",
     class: _vm.className,
     style: {
-      display: _vm.droppable ? "flex" : "none"
+      display: _vm.droppable ? 'flex' : 'none'
     }
-  }, [_vm.droppableBefore ? _c("span", {
+  }, [_vm.droppableBefore ? _c('span', {
     staticClass: "directorist-droppable-area directorist-droppable-area-top",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.dragenterBeforeItem = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.dragenterBeforeItem = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedBefore();
       }
     }
-  }) : _vm._e(), _vm._v(" "), _vm.droppableAfter ? _c("span", {
+  }) : _vm._e(), _vm._v(" "), _vm.droppableAfter ? _c('span', {
     staticClass: "directorist-droppable-area directorist-droppable-area-bottom",
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: function dragenter($event) {
+      "dragenter": function dragenter($event) {
         _vm.dragenterAfterItem = true;
       },
-      dragleave: function dragleave($event) {
+      "dragleave": function dragleave($event) {
         _vm.dragenterAfterItem = false;
       },
-      drop: function drop($event) {
+      "drop": function drop($event) {
         return _vm.handleDroppedAfter();
       }
     }
-  }) : _vm._e()]), _vm._v(" "), _vm.dragenterBeforeItem ? _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _vm.dragenterBeforeItem ? _c('div', {
     staticClass: "directorist-droppable-item-preview directorist-droppable-item-preview-before"
-  }) : _vm._e(), _vm._v(" "), _vm._t("default"), _vm._v(" "), _vm.dragenterAfterItem ? _c("div", {
+  }) : _vm._e(), _vm._v(" "), _vm._t("default"), _vm._v(" "), _vm.dragenterAfterItem ? _c('div', {
     staticClass: "directorist-droppable-item-preview directorist-droppable-item-preview-after"
   }) : _vm._e()], 2);
 };
@@ -29584,18 +29564,18 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-group-field-drop-area",
     class: _vm.className,
     on: {
-      dragover: function dragover($event) {
+      "dragover": function dragover($event) {
         $event.preventDefault();
       },
-      dragenter: _vm.handleDragenter,
-      dragleave: _vm.handleDragleave,
-      drop: _vm.handleDrop
+      "dragenter": _vm.handleDragenter,
+      "dragleave": _vm.handleDragleave,
+      "drop": _vm.handleDrop
     }
-  }, [_c("p", {
+  }, [_c('p', {
     staticClass: "cptm-form-builder-group-field-drop-area-label"
   }, [_vm._v("\n    Add field by dragging it into this area\n  ")])]);
 };
@@ -29619,65 +29599,65 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-preset-fields"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-preset-fields-header"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-form-builder-preset-fields-header-action-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.togglePresetExpanded.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-form-builder-preset-fields-header-action-text"
-  }, [_vm._v("\n        " + _vm._s(_vm.title))]), _vm._v(" "), _c("span", {
+  }, [_vm._v("\n        " + _vm._s(_vm.title))]), _vm._v(" "), _c('span', {
     staticClass: "cptm-form-builder-preset-fields-header-action-icon",
-    class: _vm.isPresetExpanded ? "action-collapse-up" : "action-collapse-down"
-  }, [_c("span", {
+    class: _vm.isPresetExpanded ? 'action-collapse-up' : 'action-collapse-down'
+  }, [_c('span', {
     staticClass: "uil uil-angle-down",
     attrs: {
       "aria-hidden": "true"
     }
-  })])])]), _vm._v(" "), _c("slide-up-down", {
+  })])])]), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.isPresetExpanded,
-      duration: 500
+      "active": _vm.isPresetExpanded,
+      "duration": 500
     }
-  }, [_vm.filtered_widget_list ? _c("ul", {
+  }, [_vm.filtered_widget_list ? _c('ul', {
     staticClass: "cptm-form-builder-field-list"
   }, _vm._l(_vm.filtered_widget_list, function (widget, widget_key) {
-    return _c("draggable-list-item", {
+    return _c('draggable-list-item', {
       key: widget_key,
       attrs: {
         "list-type": "li",
         "item-class-name": "cptm-form-builder-field-list-item",
-        "drag-type": _vm.allowMultiple || widget.allowMultiple ? "clone" : "move"
+        "drag-type": _vm.allowMultiple || widget.allowMultiple ? 'clone' : 'move'
       },
       on: {
         "drag-start": function dragStart($event) {
-          return _vm.$emit("drag-start", {
+          return _vm.$emit('drag-start', {
             widget_key: widget_key,
             widget: widget
           });
         },
         "drag-end": function dragEnd($event) {
-          return _vm.$emit("drag-end", {
+          return _vm.$emit('drag-end', {
             widget_key: widget_key,
             widget: widget
           });
         }
       }
-    }, [_c("span", {
+    }, [_c('span', {
       staticClass: "cptm-form-builder-field-list-icon"
-    }, [widget.icon && widget.icon.length ? _c("span", {
+    }, [widget.icon && widget.icon.length ? _c('span', {
       class: widget.icon
-    }) : _vm._e()]), _vm._v(" "), _c("span", {
+    }) : _vm._e()]), _vm._v(" "), _c('span', {
       staticClass: "cptm-form-builder-field-list-label"
     }, [_vm._v(_vm._s(widget.label))])]);
   }), 1) : _vm._e()])], 1);
@@ -29705,108 +29685,108 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.widget_fields && Object.keys(_vm.widget_fields).length > 0 ? _c("div", {
+  return _vm.widget_fields && Object.keys(_vm.widget_fields).length > 0 ? _c('div', {
     staticClass: "cptm-form-builder-group-field-item",
-    class: _vm.expandState ? "expanded" : ""
-  }, [_vm.canMoveWidget ? _c("draggable-list-item", {
+    class: _vm.expandState ? 'expanded' : ''
+  }, [_vm.canMoveWidget ? _c('draggable-list-item', {
     on: {
       "drag-start": function dragStart($event) {
-        return _vm.$emit("drag-start");
+        return _vm.$emit('drag-start');
       },
       "drag-end": function dragEnd($event) {
-        return _vm.$emit("drag-end");
+        return _vm.$emit('drag-end');
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-field-item-drag"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-draggabledots",
     attrs: {
       "aria-hidden": "true"
     }
-  })])]) : _vm._e(), _vm._v(" "), _c("form-builder-widget-titlebar-component", {
+  })])]) : _vm._e(), _vm._v(" "), _c('form-builder-widget-titlebar-component', {
     attrs: {
-      label: _vm.widgetTitle,
-      sublabel: _vm.widgetSubtitle,
-      icon: _vm.widgetIcon,
-      expanded: _vm.expandState
+      "label": _vm.widgetTitle,
+      "sublabel": _vm.widgetSubtitle,
+      "icon": _vm.widgetIcon,
+      "expanded": _vm.expandState
     },
     on: {
       "toggle-expand": _vm.toggleExpand
     }
-  }), _vm._v(" "), _c("slide-up-down", {
+  }), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.expandState,
-      duration: 500
+      "active": _vm.expandState,
+      "duration": 500
     }
-  }, [_vm.widget_fields && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.widget_fields) === "object" ? _c("div", {
+  }, [_vm.widget_fields && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.widget_fields) === 'object' ? _c('div', {
     staticClass: "cptm-form-builder-group-field-item-body"
-  }, [_c("field-list-component", {
+  }, [_c('field-list-component', {
     attrs: {
-      root: _vm.activeWidgets,
+      "root": _vm.activeWidgets,
       "section-id": _vm.widgetKey,
       "field-list": _vm.widget_fields,
-      value: _vm.activeWidgets[_vm.widgetKey] ? _vm.activeWidgets[_vm.widgetKey] : ""
+      "value": _vm.activeWidgets[_vm.widgetKey] ? _vm.activeWidgets[_vm.widgetKey] : ''
     },
     on: {
-      update: function update($event) {
-        return _vm.$emit("update-widget-field", {
+      "update": function update($event) {
+        return _vm.$emit('update-widget-field', {
           widget_key: _vm.widgetKey,
           payload: $event
         });
       }
     }
-  })], 1) : _vm._e()]), _vm._v(" "), _c("div", {
+  })], 1) : _vm._e()]), _vm._v(" "), _c('div', {
     ref: "dropdownContent",
     staticClass: "cptm-form-builder-group-actions-dropdown cptm-form-builder-group-actions-dropdown--field"
-  }, [_vm.canTrashWidget ? _c("a", {
+  }, [_vm.canTrashWidget ? _c('a', {
     staticClass: "cptm-form-builder-group-actions-dropdown-btn",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.toggleExpandedDropdown.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-ellipsis-h",
     attrs: {
       "aria-hidden": "true"
     }
-  })]) : _vm._e(), _vm._v(" "), _c("slide-up-down", {
+  })]) : _vm._e(), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.expandedDropdown,
-      duration: 500
+      "active": _vm.expandedDropdown,
+      "duration": 500
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-actions-dropdown-content",
-    class: _vm.expandedDropdown ? "expanded" : ""
-  }, [_c("a", {
+    class: _vm.expandedDropdown ? 'expanded' : ''
+  }, [_c('a', {
     staticClass: "cptm-form-builder-field-item-action-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.handleTrashClick.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-trash-alt",
     attrs: {
       "aria-hidden": "true"
     }
-  }), _vm._v("\n          Remove Field\n        ")])])])], 1), _vm._v(" "), _c("confirmation-modal", {
+  }), _vm._v("\n          Remove Field\n        ")])])])], 1), _vm._v(" "), _c('confirmation-modal', {
     attrs: {
-      visible: _vm.showConfirmationModal,
-      widgetName: _vm.widgetName
+      "visible": _vm.showConfirmationModal,
+      "widgetName": _vm.widgetName
     },
     on: {
-      confirm: _vm.trashWidget,
-      cancel: _vm.closeConfirmationModal
+      "confirm": _vm.trashWidget,
+      "cancel": _vm.closeConfirmationModal
     }
   })], 1) : _vm._e();
 };
@@ -29830,37 +29810,37 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-group-field-item-header"
-  }, [_c("h4", {
+  }, [_c('h4', {
     staticClass: "cptm-title-3"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-title-icon",
     class: _vm.icon
-  }), _vm._v(" "), _c("span", {
+  }), _vm._v(" "), _c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.label)
+      "innerHTML": _vm._s(_vm.label)
     }
-  }), _vm._v(" "), _vm.sublabel.length ? _c("span", {
+  }), _vm._v(" "), _vm.sublabel.length ? _c('span', {
     staticClass: "cptm-text-gray cptm-px-5",
     domProps: {
-      innerHTML: _vm._s(_vm.sublabel)
+      "innerHTML": _vm._s(_vm.sublabel)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "cptm-form-builder-group-field-item-header-actions"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-form-builder-header-action-link",
-    class: _vm.expanded ? "action-collapse-down" : "action-collapse-up",
+    class: _vm.expanded ? 'action-collapse-down' : 'action-collapse-up',
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("toggle-expand");
+        return _vm.$emit('toggle-expand');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-angle-down",
     attrs: {
       "aria-hidden": "true"
@@ -29887,26 +29867,26 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.visible ? _c("div", {
+  return _vm.visible ? _c('div', {
     staticClass: "cptm-widget-trash-confirmation-modal-overlay",
     on: {
-      click: _vm.handleOverlayClick
+      "click": _vm.handleOverlayClick
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-trash-confirmation-modal",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.stopPropagation();
       }
     }
-  }, [_c("h2", [_vm._v("Are you sure you want to proceed?")]), _vm._v(" "), _c("p", [_vm._v('\n      Removing "'), _c("strong", [_vm._v(_vm._s(_vm.widgetName))]), _vm._v('" field will also remove it from the single and search pages.\n    ')]), _vm._v(" "), _c("button", {
+  }, [_c('h2', [_vm._v("Are you sure you want to proceed?")]), _vm._v(" "), _c('p', [_vm._v("\n      Removing \""), _c('strong', [_vm._v(_vm._s(_vm.widgetName))]), _vm._v("\" field will also remove it from the single and search pages.\n    ")]), _vm._v(" "), _c('button', {
     on: {
-      click: _vm.confirmDelete
+      "click": _vm.confirmDelete
     }
-  }, [_vm._v("Yes, delete")]), _vm._v(" "), _c("button", {
+  }, [_vm._v("Yes, delete")]), _vm._v(" "), _c('button', {
     staticClass: "cptm-widget-trash-confirmation-modal-action-btn__cancel",
     on: {
-      click: _vm.cancelDelete
+      "click": _vm.cancelDelete
     }
   }, [_vm._v("\n      Cancel\n    ")])])]) : _vm._e();
 };
@@ -29930,42 +29910,42 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.videoOpened ? _c("div", {
+  return _vm.videoOpened ? _c('div', {
     staticClass: "video-popup-overlay",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("close-video");
+        return _vm.$emit('close-video');
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "video-popup-content",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.stopPropagation();
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "video-container"
-  }, [_c("iframe", {
+  }, [_c('iframe', {
     attrs: {
-      width: "560",
-      height: "315",
-      src: _vm.video.url,
-      frameborder: "0",
-      allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
-      allowfullscreen: "",
-      title: _vm.video.title
+      "width": "560",
+      "height": "315",
+      "src": _vm.video.url,
+      "frameborder": "0",
+      "allow": "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
+      "allowfullscreen": "",
+      "title": _vm.video.title
     }
-  })])]), _vm._v(" "), _c("button", {
+  })])]), _vm._v(" "), _c('button', {
     staticClass: "close-btn",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("close-video");
+        return _vm.$emit('close-video');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "la la-close"
   })])]) : _vm._e();
 };
@@ -29989,9 +29969,9 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-active-fields-group"
-  }, [_c("form-builder-widget-group-header-component", _vm._b({
+  }, [_c('form-builder-widget-group-header-component', _vm._b({
     attrs: {
       "widgets-expanded": _vm.widgetsExpandState,
       "can-trash": _vm.canTrashGroup,
@@ -29999,46 +29979,46 @@ var render = function render() {
     },
     on: {
       "update-group-field": function updateGroupField($event) {
-        return _vm.$emit("update-group-field", $event);
+        return _vm.$emit('update-group-field', $event);
       },
       "toggle-expand-widgets": _vm.toggleExpandWidgets,
       "trash-group": function trashGroup($event) {
-        return _vm.$emit("trash-group");
+        return _vm.$emit('trash-group');
       },
       "drag-start": function dragStart($event) {
-        return _vm.$emit("group-drag-start");
+        return _vm.$emit('group-drag-start');
       },
       "drag-end": function dragEnd($event) {
-        return _vm.$emit("group-drag-end");
+        return _vm.$emit('group-drag-end');
       }
     }
-  }, "form-builder-widget-group-header-component", _vm.$props, false)), _vm._v(" "), _c("slide-up-down", {
+  }, 'form-builder-widget-group-header-component', _vm.$props, false)), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.widgetsExpandState,
-      duration: 800
+      "active": _vm.widgetsExpandState,
+      "duration": 800
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-fields"
   }, _vm._l(_vm.groupData.fields, function (widget_key, widget_index) {
-    return _c("draggable-list-item-wrapper", {
+    return _c('draggable-list-item-wrapper', {
       key: widget_index,
       attrs: {
         "list-id": "widget-item",
-        "is-dragging-self": _vm.currentDraggingWidget && "active_widgets" === _vm.currentDraggingWidget.from && widget_key === _vm.currentDraggingWidget.widget_key,
+        "is-dragging-self": _vm.currentDraggingWidget && 'active_widgets' === _vm.currentDraggingWidget.from && widget_key === _vm.currentDraggingWidget.widget_key,
         "class-name": "directorist-draggable-form-list-wrap",
-        droppables: true,
-        droppable: _vm.isDroppable(widget_index)
+        "droppables": true,
+        "droppable": _vm.isDroppable(widget_index)
       },
       on: {
-        drop: function drop($event) {
-          return _vm.$emit("drop-widget", {
+        "drop": function drop($event) {
+          return _vm.$emit('drop-widget', {
             widget_key: widget_key,
             widget_index: widget_index,
             drop_direction: $event.drop_direction
           });
         }
       }
-    }, [_c("form-builder-widget-component", {
+    }, [_c('form-builder-widget-component', {
       attrs: {
         "widget-key": widget_key,
         "active-widgets": _vm.activeWidgets,
@@ -30052,31 +30032,31 @@ var render = function render() {
           return _vm.updateDetectedUntrashableWidgets(widget_key);
         },
         "update-widget-field": function updateWidgetField($event) {
-          return _vm.$emit("update-widget-field", $event);
+          return _vm.$emit('update-widget-field', $event);
         },
         "trash-widget": function trashWidget($event) {
-          return _vm.$emit("trash-widget", {
+          return _vm.$emit('trash-widget', {
             widget_key: widget_key
           });
         },
         "drag-start": function dragStart($event) {
-          return _vm.$emit("widget-drag-start", {
+          return _vm.$emit('widget-drag-start', {
             widget_index: widget_index,
             widget_key: widget_key
           });
         },
         "drag-end": function dragEnd($event) {
-          return _vm.$emit("widget-drag-end", {
+          return _vm.$emit('widget-drag-end', {
             widget_index: widget_index,
             widget_key: widget_key
           });
         }
       }
     })], 1);
-  }), 1), _vm._v(" "), _vm.canShowWidgetDropPlaceholder ? _c("form-builder-droppable-placeholder", {
+  }), 1), _vm._v(" "), _vm.canShowWidgetDropPlaceholder ? _c('form-builder-droppable-placeholder', {
     on: {
-      drop: function drop($event) {
-        return _vm.$emit("append-widget");
+      "drop": function drop($event) {
+        return _vm.$emit('append-widget');
       }
     }
   }) : _vm._e()], 1)], 1);
@@ -30101,108 +30081,108 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-group-header-section",
-    class: _vm.groupFieldsExpandState ? "expanded" : ""
-  }, [_c("div", {
+    class: _vm.groupFieldsExpandState ? 'expanded' : ''
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-header"
-  }, [_c("draggable-list-item", {
+  }, [_c('draggable-list-item', {
     attrs: {
       "can-drag": _vm.isEnabledGroupDragging
     },
     on: {
       "drag-start": function dragStart($event) {
-        return _vm.$emit("drag-start");
+        return _vm.$emit('drag-start');
       },
       "drag-end": function dragEnd($event) {
-        return _vm.$emit("drag-end");
+        return _vm.$emit('drag-end');
       }
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-field-item-drag"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-draggabledots",
     attrs: {
       "aria-hidden": "true"
     }
-  })])]), _vm._v(" "), _c("form-builder-widget-group-titlebar-component", _vm._b({
+  })])]), _vm._v(" "), _c('form-builder-widget-group-titlebar-component', _vm._b({
     attrs: {
       "widgets-expanded": _vm.widgetsExpanded
     },
     on: {
       "toggle-expand-group": _vm.toggleGroupFieldsExpand,
       "toggle-expand-widgets": function toggleExpandWidgets($event) {
-        return _vm.$emit("toggle-expand-widgets");
+        return _vm.$emit('toggle-expand-widgets');
       }
     }
-  }, "form-builder-widget-group-titlebar-component", _vm.$props, false)), _vm._v(" "), _c("div", {
+  }, 'form-builder-widget-group-titlebar-component', _vm.$props, false)), _vm._v(" "), _c('div', {
     ref: "dropdownContent",
     staticClass: "cptm-form-builder-group-actions-dropdown cptm-form-builder-group-actions-dropdown--group"
-  }, [_vm.canTrash ? _c("a", {
+  }, [_vm.canTrash ? _c('a', {
     staticClass: "cptm-form-builder-group-actions-dropdown-btn",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.toggleGroupExpandedDropdown.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-ellipsis-h",
     attrs: {
       "aria-hidden": "true"
     }
-  })]) : _vm._e(), _vm._v(" "), _c("slide-up-down", {
+  })]) : _vm._e(), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.groupExpandedDropdown,
-      duration: 500
+      "active": _vm.groupExpandedDropdown,
+      "duration": 500
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-actions-dropdown-content",
-    class: _vm.groupExpandedDropdown ? "expanded" : ""
-  }, [_c("a", {
+    class: _vm.groupExpandedDropdown ? 'expanded' : ''
+  }, [_c('a', {
     staticClass: "cptm-form-builder-field-item-action-link",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.handleGroupDelete.apply(null, arguments);
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-trash-alt",
     attrs: {
       "aria-hidden": "true"
     }
-  }), _vm._v("\n            Remove Section\n          ")])])])], 1)], 1), _vm._v(" "), _c("slide-up-down", {
+  }), _vm._v("\n            Remove Section\n          ")])])])], 1)], 1), _vm._v(" "), _c('slide-up-down', {
     attrs: {
-      active: _vm.groupFieldsExpandState,
-      duration: 500
+      "active": _vm.groupFieldsExpandState,
+      "duration": 500
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-group-options"
-  }, [_c("field-list-component", {
+  }, [_c('field-list-component', {
     attrs: {
       "field-list": _vm.finalGroupFields,
-      value: _vm.groupData
+      "value": _vm.groupData
     },
     on: {
-      update: function update($event) {
-        return _vm.$emit("update-group-field", $event);
+      "update": function update($event) {
+        return _vm.$emit('update-group-field', $event);
       }
     }
-  })], 1)]), _vm._v(" "), _c("confirmation-modal", {
+  })], 1)]), _vm._v(" "), _c('confirmation-modal', {
     attrs: {
-      visible: _vm.showConfirmationModal,
-      groupName: _vm.groupName
+      "visible": _vm.showConfirmationModal,
+      "groupName": _vm.groupName
     },
     on: {
-      confirm: _vm.trashGroup,
-      cancel: _vm.closeConfirmationModal
+      "confirm": _vm.trashGroup,
+      "cancel": _vm.closeConfirmationModal
     }
   })], 1);
 };
@@ -30229,46 +30209,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder-group-title-area",
-    class: _vm.widgetsExpanded ? "expanded" : ""
-  }, [_c("h3", {
+    class: _vm.widgetsExpanded ? 'expanded' : ''
+  }, [_c('h3', {
     staticClass: "cptm-form-builder-group-title"
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.label)
+      "innerHTML": _vm._s(_vm.label)
     }
-  }), _vm._v(" "), _vm.groupFields && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.groupFields) === "object" ? _c("a", {
+  }), _vm._v(" "), _vm.groupFields && _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.groupFields) === 'object' ? _c('a', {
     staticClass: "cptm-form-builder-header-action-link cptm-ml-5 cptm-link-light",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("toggle-expand-group");
+        return _vm.$emit('toggle-expand-group');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fa fa-cog",
     attrs: {
       "aria-hidden": "true"
     }
-  }), _vm._v(" Options\n    ")]) : _vm._e()]), _vm._v(" "), _vm.groupData && _vm.groupData.fields && _vm.groupData.fields.length ? _c("div", {
+  }), _vm._v(" Options\n    ")]) : _vm._e()]), _vm._v(" "), _vm.groupData && _vm.groupData.fields && _vm.groupData.fields.length ? _c('div', {
     staticClass: "cptm-form-builder-group-title-actions"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "cptm-form-builder-header-action-link",
-    class: _vm.widgetsExpanded ? "action-collapse-down" : "action-collapse-up",
+    class: _vm.widgetsExpanded ? 'action-collapse-down' : 'action-collapse-up',
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
-        return _vm.$emit("toggle-expand-widgets");
+        return _vm.$emit('toggle-expand-widgets');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-angle-down",
     attrs: {
       "aria-hidden": "true"
@@ -30295,26 +30275,26 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.visible ? _c("div", {
+  return _vm.visible ? _c('div', {
     staticClass: "cptm-widget-trash-confirmation-modal-overlay",
     on: {
-      click: _vm.handleOverlayClick
+      "click": _vm.handleOverlayClick
     }
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-widget-trash-confirmation-modal",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.stopPropagation();
       }
     }
-  }, [_c("h2", [_vm._v("Are you sure you want to proceed?")]), _vm._v(" "), _c("p", [_vm._v('\n      Removing "'), _c("strong", [_vm._v(_vm._s(_vm.groupName))]), _vm._v("\" group will also remove it's all fields.\n    ")]), _vm._v(" "), _c("button", {
+  }, [_c('h2', [_vm._v("Are you sure you want to proceed?")]), _vm._v(" "), _c('p', [_vm._v("\n      Removing \""), _c('strong', [_vm._v(_vm._s(_vm.groupName))]), _vm._v("\" group will also remove it's all fields.\n    ")]), _vm._v(" "), _c('button', {
     on: {
-      click: _vm.confirmDelete
+      "click": _vm.confirmDelete
     }
-  }, [_vm._v("Yes, delete")]), _vm._v(" "), _c("button", {
+  }, [_vm._v("Yes, delete")]), _vm._v(" "), _c('button', {
     staticClass: "cptm-widget-trash-confirmation-modal-action-btn__cancel",
     on: {
-      click: _vm.cancelDelete
+      "click": _vm.cancelDelete
     }
   }, [_vm._v("\n      Cancel\n    ")])])]) : _vm._e();
 };
@@ -30338,20 +30318,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("ajax-action-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('ajax-action-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -30373,17 +30353,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("button-example-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('button-example-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -30405,14 +30385,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("button-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('button-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -30434,12 +30414,12 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {}, [_vm.card_templates ? [_c("div", {
+  return _c('div', {}, [_vm.card_templates ? [_c('div', {
     staticClass: "cptm-card-top-area cptm-text-center cptm-mb-20"
-  }, [_c("select-field", {
+  }, [_c('select-field', {
     attrs: {
-      theme: "default",
-      options: _vm.theCardBiulderTemplateOptionList
+      "theme": "default",
+      "options": _vm.theCardBiulderTemplateOptionList
     },
     model: {
       value: _vm.template_id,
@@ -30452,25 +30432,25 @@ var render = function render() {
     tag: "component",
     attrs: {
       "field-id": _vm.fieldId,
-      value: _vm.theCardBiulderValue
+      "value": _vm.theCardBiulderValue
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateValue($event);
       }
     }
-  }, "component", _vm.theCurrentTemplateModel, false))] : [_c(_vm.cardBiulderTemplate, {
+  }, 'component', _vm.theCurrentTemplateModel, false))] : [_c(_vm.cardBiulderTemplate, {
     tag: "component",
     attrs: {
       "field-id": _vm.fieldId,
-      value: _vm.value,
-      widgets: _vm.widgets,
-      layout: _vm.layout,
+      "value": _vm.value,
+      "widgets": _vm.widgets,
+      "layout": _vm.layout,
       "card-options": _vm.cardOptions
     },
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
   })]], 2);
@@ -30495,46 +30475,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-top-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_top_left",
-      containerClass: "cptm-card-preview-top-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_left.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_left)
+      "id": "thumbnail_top_left",
+      "containerClass": "cptm-card-preview-top-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_left.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30568,26 +30548,26 @@ var render = function render() {
         return _vm.handleDragleaveOnPlaceholder(_vm.local_layout.thumbnail.top_left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_left");
+        return _vm.activeInsertWindow('thumbnail_top_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-top-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_top_right",
-      containerClass: "cptm-card-preview-top-right-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
+      "id": "thumbnail_top_right",
+      "containerClass": "cptm-card-preview-top-right-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30618,26 +30598,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.top_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_right");
+        return _vm.activeInsertWindow('thumbnail_top_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-bottom-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_bottom_left",
-      containerClass: "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.bottom_left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.bottom_left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.bottom_left.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.bottom_left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_bottom_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_left)
+      "id": "thumbnail_bottom_left",
+      "containerClass": "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.bottom_left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.bottom_left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.bottom_left.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.bottom_left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_bottom_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30668,26 +30648,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.bottom_left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_bottom_left");
+        return _vm.activeInsertWindow('thumbnail_bottom_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-bottom-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_bottom_right",
-      containerClass: "cptm-card-preview-bottom-right-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.bottom_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.bottom_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.bottom_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.bottom_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_bottom_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_right)
+      "id": "thumbnail_bottom_right",
+      "containerClass": "cptm-card-preview-bottom-right-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.bottom_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.bottom_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.bottom_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.bottom_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_bottom_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30718,28 +30698,28 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.bottom_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_bottom_right");
+        return _vm.activeInsertWindow('thumbnail_bottom_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-author-avatar"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_avatar",
-      containerClass: _vm.getAvatarPlaceholderClass,
-      label: _vm.local_layout.thumbnail.avatar.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.avatar.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.avatar.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.avatar.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_avatar"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.avatar)
+      "id": "thumbnail_avatar",
+      "containerClass": _vm.getAvatarPlaceholderClass,
+      "label": _vm.local_layout.thumbnail.avatar.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.avatar.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.avatar.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.avatar.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_avatar'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.avatar)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30764,24 +30744,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.thumbnail.avatar);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_avatar");
+        return _vm.activeInsertWindow('thumbnail_avatar');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_top",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-align-left",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "id": "thumbnail_body_top",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-align-left",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30806,24 +30786,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_top");
+        return _vm.activeInsertWindow('thumbnail_body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_bottom",
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "id": "thumbnail_body_bottom",
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30848,24 +30828,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_bottom");
+        return _vm.activeInsertWindow('thumbnail_body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      id: "body_excerpt",
-      containerClass: "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpr"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "id": "body_excerpt",
+      "containerClass": "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpr'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30890,26 +30870,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpr");
+        return _vm.activeInsertWindow('body_excerpr');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_left",
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "id": "thumbnail_footer_left",
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30934,24 +30914,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_right",
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "id": "thumbnail_footer_right",
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -30976,7 +30956,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -30987,9 +30967,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -31012,46 +30992,46 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget grid-view-with-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-top-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_top_left",
-      containerClass: "cptm-card-preview-top-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_left.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_left)
+      "id": "thumbnail_top_left",
+      "containerClass": "cptm-card-preview-top-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_left.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31085,26 +31065,26 @@ var render = function render() {
         return _vm.handleDragleaveOnPlaceholder(_vm.local_layout.thumbnail.top_left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_left");
+        return _vm.activeInsertWindow('thumbnail_top_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-top-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_top_right",
-      containerClass: "cptm-card-preview-top-right-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
+      "id": "thumbnail_top_right",
+      "containerClass": "cptm-card-preview-top-right-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31135,26 +31115,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.top_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_right");
+        return _vm.activeInsertWindow('thumbnail_top_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-bottom-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_bottom_left",
-      containerClass: "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.bottom_left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.bottom_left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.bottom_left.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.bottom_left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_bottom_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_left)
+      "id": "thumbnail_bottom_left",
+      "containerClass": "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.bottom_left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.bottom_left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.bottom_left.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.bottom_left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_bottom_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31185,26 +31165,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.bottom_left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_bottom_left");
+        return _vm.activeInsertWindow('thumbnail_bottom_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-preview-bottom-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_bottom_right",
-      containerClass: "cptm-card-preview-bottom-right-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.bottom_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.bottom_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.bottom_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.bottom_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_bottom_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_right)
+      "id": "thumbnail_bottom_right",
+      "containerClass": "cptm-card-preview-bottom-right-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.bottom_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.bottom_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.bottom_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.bottom_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_bottom_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.bottom_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31235,28 +31215,28 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.bottom_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_bottom_right");
+        return _vm.activeInsertWindow('thumbnail_bottom_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-author-avatar"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_avatar",
-      containerClass: _vm.getAvatarPlaceholderClass,
-      label: _vm.local_layout.thumbnail.avatar.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.avatar.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.avatar.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.avatar.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_avatar"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.avatar)
+      "id": "thumbnail_avatar",
+      "containerClass": _vm.getAvatarPlaceholderClass,
+      "label": _vm.local_layout.thumbnail.avatar.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.avatar.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.avatar.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.avatar.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_avatar'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.avatar)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31281,24 +31261,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.thumbnail.avatar);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_avatar");
+        return _vm.activeInsertWindow('thumbnail_avatar');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_top",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-align-left",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "id": "thumbnail_body_top",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-align-left",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31323,24 +31303,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_top");
+        return _vm.activeInsertWindow('thumbnail_body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_bottom",
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "id": "thumbnail_body_bottom",
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31365,24 +31345,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_bottom");
+        return _vm.activeInsertWindow('thumbnail_body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      id: "body_excerpt",
-      containerClass: "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpr"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "id": "body_excerpt",
+      "containerClass": "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpr'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31407,26 +31387,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpr");
+        return _vm.activeInsertWindow('body_excerpr');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_left",
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "id": "thumbnail_footer_left",
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31451,24 +31431,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_right",
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "id": "thumbnail_footer_right",
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31493,7 +31473,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -31504,9 +31484,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -31529,44 +31509,44 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget grid-view-without-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-placeholder-row cptm-no-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-placeholder-col cptm-placeholder-top-right-col cptm-card-light"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "body_avatar",
-      containerClass: "cptm-listing-card-author-avatar-placeholder cptm-card-light cptm-mb-20 cptm-text-center",
-      label: _vm.local_layout.body.avatar.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.avatar.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.avatar.selectedWidgets,
-      maxWidget: _vm.local_layout.body.avatar.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_avatar"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.avatar)
+      "id": "body_avatar",
+      "containerClass": "cptm-listing-card-author-avatar-placeholder cptm-card-light cptm-mb-20 cptm-text-center",
+      "label": _vm.local_layout.body.avatar.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.avatar.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.avatar.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.avatar.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_avatar'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.avatar)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31591,26 +31571,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.avatar);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_avatar");
+        return _vm.activeInsertWindow('body_avatar');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-placeholder-col cptm-placeholder-title-col"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "body_title",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20",
-      label: _vm.local_layout.body.title.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.title.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.title.selectedWidgets,
-      maxWidget: _vm.local_layout.body.title.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_title"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.title)
+      "id": "body_title",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20",
+      "label": _vm.local_layout.body.title.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.title.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.title.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.title.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_title'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.title)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31635,26 +31615,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.title);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_title");
+        return _vm.activeInsertWindow('body_title');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-card-placeholder-col cptm-placeholder-action-col"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "body_quick_actions",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-text-right",
-      label: _vm.local_layout.body.quick_actions.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.quick_actions.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.quick_actions.selectedWidgets,
-      maxWidget: _vm.local_layout.body.quick_actions.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_quick_actions"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.quick_actions)
+      "id": "body_quick_actions",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20 cptm-text-right",
+      "label": _vm.local_layout.body.quick_actions.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.quick_actions.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.quick_actions.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.quick_actions.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_quick_actions'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.quick_actions)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31679,24 +31659,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.quick_actions);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_quick_actions");
+        return _vm.activeInsertWindow('body_quick_actions');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)]), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1)]), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_quick_info",
-      containerClass: "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20",
-      label: _vm.local_layout.body.quick_info.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.quick_info.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.quick_info.selectedWidgets,
-      maxWidget: _vm.local_layout.body.quick_info.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_quick_info"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.quick_info)
+      "id": "thumbnail_quick_info",
+      "containerClass": "cptm-listing-card-preview-title-placeholder cptm-card-light cptm-mb-20",
+      "label": _vm.local_layout.body.quick_info.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.quick_info.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.quick_info.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.quick_info.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_quick_info'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.quick_info)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31721,24 +31701,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.quick_info);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_quick_info");
+        return _vm.activeInsertWindow('thumbnail_quick_info');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_body_bottom",
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "id": "thumbnail_body_bottom",
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31763,24 +31743,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_body_bottom");
+        return _vm.activeInsertWindow('thumbnail_body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      id: "body_excerpt",
-      containerClass: "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpr"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "id": "body_excerpt",
+      "containerClass": "cptm-listing-card-preview-body-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpr'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31805,26 +31785,26 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpr");
+        return _vm.activeInsertWindow('body_excerpr');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_left",
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "id": "thumbnail_footer_left",
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31849,24 +31829,24 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      id: "thumbnail_footer_right",
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "id": "thumbnail_footer_right",
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31891,7 +31871,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -31919,45 +31899,45 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget cptm-card-list-view"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-top-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
+      "containerClass": "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -31988,31 +31968,31 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.top_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_right");
+        return _vm.activeInsertWindow('thumbnail_top_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-content"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "containerClass": "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32037,25 +32017,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_top");
+        return _vm.activeInsertWindow('body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-body-header-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
-      label: _vm.local_layout.body.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.right.selectedWidgets,
-      maxWidget: _vm.local_layout.body.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.right)
+      "containerClass": "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32080,23 +32060,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_right");
+        return _vm.activeInsertWindow('body_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)]), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1)]), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32121,23 +32101,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_bottom");
+        return _vm.activeInsertWindow('body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpt"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "containerClass": "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpt'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32162,25 +32142,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpt");
+        return _vm.activeInsertWindow('body_excerpt');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32205,23 +32185,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32246,7 +32226,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -32257,9 +32237,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -32282,45 +32262,45 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget cptm-card-list-view list-view-with-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-top-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
-      label: _vm.local_layout.thumbnail.top_right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.thumbnail.top_right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.thumbnail.top_right.selectedWidgets,
-      maxWidget: _vm.local_layout.thumbnail.top_right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_top_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
+      "containerClass": "cptm-card-preview-bottom-left-placeholder cptm-card-dark",
+      "label": _vm.local_layout.thumbnail.top_right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.thumbnail.top_right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.thumbnail.top_right.selectedWidgets,
+      "maxWidget": _vm.local_layout.thumbnail.top_right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_top_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.thumbnail.top_right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32351,31 +32331,31 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.thumbnail.top_right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_top_right");
+        return _vm.activeInsertWindow('thumbnail_top_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-content"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "containerClass": "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32400,25 +32380,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_top");
+        return _vm.activeInsertWindow('body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-body-header-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
-      label: _vm.local_layout.body.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.right.selectedWidgets,
-      maxWidget: _vm.local_layout.body.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.right)
+      "containerClass": "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32443,23 +32423,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_right");
+        return _vm.activeInsertWindow('body_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)]), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1)]), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32484,23 +32464,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_bottom");
+        return _vm.activeInsertWindow('body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpt"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "containerClass": "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpt'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32525,25 +32505,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpt");
+        return _vm.activeInsertWindow('body_excerpt');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32568,23 +32548,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32609,7 +32589,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -32620,9 +32600,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -32645,45 +32625,45 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget cptm-card-list-view list-view-without-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-content"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-preview-body"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-listing-card-body-header-left"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
-      label: _vm.local_layout.body.top.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.top.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.top.selectedWidgets,
-      maxWidget: _vm.local_layout.body.top.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_top"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.top)
+      "containerClass": "cptm-listing-card-body-header-title-placeholder cptm-mb-10 cptm-card-light",
+      "label": _vm.local_layout.body.top.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.top.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.top.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.top.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_top'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.top)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32708,25 +32688,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.top);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_top");
+        return _vm.activeInsertWindow('body_top');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-body-header-right"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
-      label: _vm.local_layout.body.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.right.selectedWidgets,
-      maxWidget: _vm.local_layout.body.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.right)
+      "containerClass": "cptm-listing-card-body-header-actions-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32751,23 +32731,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_right");
+        return _vm.activeInsertWindow('body_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)]), _vm._v(" "), _c("card-widget-placeholder", {
+  })], 1)]), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-body-placeholder cptm-card-light",
-      label: _vm.local_layout.body.bottom.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.bottom.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.bottom.selectedWidgets,
-      maxWidget: _vm.local_layout.body.bottom.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_bottom"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.bottom)
+      "containerClass": "cptm-listing-card-preview-body-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.bottom.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.bottom.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.bottom.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.bottom.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_bottom'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.bottom)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32792,23 +32772,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.bottom);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_bottom");
+        return _vm.activeInsertWindow('body_bottom');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("br"), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('br'), _vm._v(" "), _vm.placeholderIsActive(_vm.local_layout.body.excerpt) ? _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
-      label: _vm.local_layout.body.excerpt.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.body.excerpt.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.body.excerpt.selectedWidgets,
-      maxWidget: _vm.local_layout.body.excerpt.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("body_excerpt"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
+      "containerClass": "cptm-listing-card-preview-excerpt-placeholder cptm-card-light",
+      "label": _vm.local_layout.body.excerpt.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.body.excerpt.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.body.excerpt.selectedWidgets,
+      "maxWidget": _vm.local_layout.body.excerpt.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('body_excerpt'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.body.excerpt)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32833,25 +32813,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.body.excerpt);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("body_excerpt");
+        return _vm.activeInsertWindow('body_excerpt');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }) : _vm._e()], 1), _vm._v(" "), _c("div", {
+  }) : _vm._e()], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.left.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.left.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.left.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.left.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_left"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.left)
+      "containerClass": "cptm-listing-card-preview-footer-left-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.left.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.left.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.left.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.left.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_left'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.left)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32876,23 +32856,23 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.left);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_left");
+        return _vm.activeInsertWindow('thumbnail_footer_left');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  }), _vm._v(" "), _c("card-widget-placeholder", {
+  }), _vm._v(" "), _c('card-widget-placeholder', {
     attrs: {
-      containerClass: "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
-      label: _vm.local_layout.footer.right.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.footer.right.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.footer.right.selectedWidgets,
-      maxWidget: _vm.local_layout.footer.right.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("thumbnail_footer_right"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.footer.right)
+      "containerClass": "cptm-listing-card-preview-footer-right-placeholder cptm-card-light",
+      "label": _vm.local_layout.footer.right.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.footer.right.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.footer.right.selectedWidgets,
+      "maxWidget": _vm.local_layout.footer.right.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('thumbnail_footer_right'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.footer.right)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -32917,7 +32897,7 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.footer.right);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("thumbnail_footer_right");
+        return _vm.activeInsertWindow('thumbnail_footer_right');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
@@ -32945,74 +32925,74 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetCardOptionsWindowActiveStatus || _vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetCardOptionsWindowActiveStatus || _vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetCardOptionsWindowActiveStatus
+      "active": _vm.widgetCardOptionsWindowActiveStatus
     },
     on: {
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeCardWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetCardOptionsWindow, false)), _vm._v(" "), _c("options-window", _vm._b({
+  }, 'options-window', _vm.widgetCardOptionsWindow, false)), _vm._v(" "), _c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-area-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-widget"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-title-bar"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-title-bar-headings cptm-card-light"
-  }, [Object.keys(_vm.card_options.general).length ? _c("div", {
+  }, [Object.keys(_vm.card_options.general).length ? _c('div', {
     staticClass: "cptm-card-options-widgets-area"
   }, [_vm._l(_vm.card_options.general, function (widget, widget_key) {
-    return [_c(widget.type + "-card-widget", {
+    return [_c(widget.type + '-card-widget', {
       key: widget_key,
       tag: "component",
       attrs: {
-        label: _vm.getWidgetLabel(widget),
-        canMove: false,
-        canTrash: false
+        "label": _vm.getWidgetLabel(widget),
+        "canMove": false,
+        "canTrash": false
       },
       on: {
-        edit: function edit($event) {
+        "edit": function edit($event) {
           return _vm.editOption(_vm.card_options.general, widget_key);
         }
       }
     })];
-  })], 2) : _vm._e()]), _vm._v(" "), _c("div", {
+  })], 2) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "cptm-title-bar-actions"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-quick-action"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "listings_header_quick_actions",
-      containerClass: "cptm-card-preview-quick-action-placeholder cptm-card-light",
-      label: _vm.local_layout.listings_header.quick_actions.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.listings_header.quick_actions.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.listings_header.quick_actions.selectedWidgets,
-      maxWidget: _vm.local_layout.listings_header.quick_actions.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_quick_actions"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.listings_header.quick_actions)
+      "id": "listings_header_quick_actions",
+      "containerClass": "cptm-card-preview-quick-action-placeholder cptm-card-light",
+      "label": _vm.local_layout.listings_header.quick_actions.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.listings_header.quick_actions.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.listings_header.quick_actions.selectedWidgets,
+      "maxWidget": _vm.local_layout.listings_header.quick_actions.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('listings_header_quick_actions'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.listings_header.quick_actions)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33046,32 +33026,32 @@ var render = function render() {
         return _vm.handleDragleaveOnPlaceholder(_vm.local_layout.listings_header.quick_actions);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("listings_header_quick_actions");
+        return _vm.activeInsertWindow('listings_header_quick_actions');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1)])]), _vm._v(" "), _c("div", {
+  })], 1)])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-header"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-overlay"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-card-preview-thumbnail-placeholer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "listings_header_thumbnail",
-      containerClass: "cptm-card-preview-thumbnail-placeholder cptm-card-dark",
-      label: _vm.local_layout.listings_header.thumbnail.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.listings_header.thumbnail.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.listings_header.thumbnail.selectedWidgets,
-      maxWidget: _vm.local_layout.listings_header.thumbnail.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_thumbnail"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.listings_header.thumbnail)
+      "id": "listings_header_thumbnail",
+      "containerClass": "cptm-card-preview-thumbnail-placeholder cptm-card-dark",
+      "label": _vm.local_layout.listings_header.thumbnail.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.listings_header.thumbnail.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.listings_header.thumbnail.selectedWidgets,
+      "maxWidget": _vm.local_layout.listings_header.thumbnail.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('listings_header_thumbnail'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.listings_header.thumbnail)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33102,26 +33082,26 @@ var render = function render() {
         return _vm.handleDragEnterOnPlaceholder(_vm.local_layout.listings_header.thumbnail);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("listings_header_thumbnail");
+        return _vm.activeInsertWindow('listings_header_thumbnail');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _vm._m(0)])])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-listing-card-preview-footer"
-  }, [_c("card-widget-placeholder", {
+  }, [_c('card-widget-placeholder', {
     attrs: {
-      id: "listings_header_quick_info",
-      containerClass: "cptm-listing-card-preview-quick-info-placeholder cptm-card-light",
-      label: _vm.local_layout.listings_header.quick_info.label,
-      availableWidgets: _vm.theAvailableWidgets,
-      activeWidgets: _vm.active_widgets,
-      acceptedWidgets: _vm.local_layout.listings_header.quick_info.acceptedWidgets,
-      selectedWidgets: _vm.local_layout.listings_header.quick_info.selectedWidgets,
-      maxWidget: _vm.local_layout.listings_header.quick_info.maxWidget,
-      showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_quick_info"),
-      widgetDropable: _vm.widgetIsDropable(_vm.local_layout.listings_header.quick_info)
+      "id": "listings_header_quick_info",
+      "containerClass": "cptm-listing-card-preview-quick-info-placeholder cptm-card-light",
+      "label": _vm.local_layout.listings_header.quick_info.label,
+      "availableWidgets": _vm.theAvailableWidgets,
+      "activeWidgets": _vm.active_widgets,
+      "acceptedWidgets": _vm.local_layout.listings_header.quick_info.acceptedWidgets,
+      "selectedWidgets": _vm.local_layout.listings_header.quick_info.selectedWidgets,
+      "maxWidget": _vm.local_layout.listings_header.quick_info.maxWidget,
+      "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('listings_header_quick_info'),
+      "widgetDropable": _vm.widgetIsDropable(_vm.local_layout.listings_header.quick_info)
     },
     on: {
       "insert-widget": function insertWidget($event) {
@@ -33146,25 +33126,25 @@ var render = function render() {
         return _vm.handleDropOnPlaceholder(_vm.local_layout.listings_header.quick_info);
       },
       "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-        return _vm.activeInsertWindow("listings_header_quick_info");
+        return _vm.activeInsertWindow('listings_header_quick_info');
       },
       "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
         return _vm.closeInsertWindow();
       }
     }
-  })], 1), _vm._v(" "), Object.keys(_vm.card_options.content_settings).length ? _c("div", {
+  })], 1), _vm._v(" "), Object.keys(_vm.card_options.content_settings).length ? _c('div', {
     staticClass: "cptm-card-options-widgets-area"
   }, [_vm._l(_vm.card_options.content_settings, function (widget, widget_key) {
-    return [_c(widget.type + "-card-widget", {
+    return [_c(widget.type + '-card-widget', {
       key: widget_key,
       tag: "component",
       attrs: {
-        label: _vm.getWidgetLabel(widget),
-        canMove: false,
-        canTrash: false
+        "label": _vm.getWidgetLabel(widget),
+        "canMove": false,
+        "canTrash": false
       },
       on: {
-        edit: function edit($event) {
+        "edit": function edit($event) {
           return _vm.editOption(_vm.card_options.content_settings, widget_key);
         }
       }
@@ -33174,9 +33154,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-card-preview-thumbnail-bg"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "uil uil-scenery"
   })]);
 }];
@@ -33199,65 +33179,65 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-builder-section"
-  }, [_vm.widgetCardOptionsWindowActiveStatus || _vm.widgetOptionsWindowActiveStatus ? _c("div", {
+  }, [_vm.widgetCardOptionsWindowActiveStatus || _vm.widgetOptionsWindowActiveStatus ? _c('div', {
     staticClass: "cptm-options-area"
-  }, [_c("options-window", _vm._b({
+  }, [_c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetCardOptionsWindowActiveStatus
+      "active": _vm.widgetCardOptionsWindowActiveStatus
     },
     on: {
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeCardWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetCardOptionsWindow, false)), _vm._v(" "), _c("options-window", _vm._b({
+  }, 'options-window', _vm.widgetCardOptionsWindow, false)), _vm._v(" "), _c('options-window', _vm._b({
     attrs: {
-      active: _vm.widgetOptionsWindowActiveStatus
+      "active": _vm.widgetOptionsWindowActiveStatus
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateWidgetOptionsData($event, _vm.widgetOptionsWindow);
       },
-      close: function close($event) {
+      "close": function close($event) {
         return _vm.closeWidgetOptionsWindow();
       }
     }
-  }, "options-window", _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, 'options-window', _vm.widgetOptionsWindow, false))], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-placeholder"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-preview-placeholder__card"
-  }, [_c("Container", {
+  }, [_c('Container', {
     attrs: {
       "drag-handle-selector": ".cptm-drag-element"
     },
     on: {
-      drop: _vm.onDrop
+      "drop": _vm.onDrop
     }
   }, _vm._l(_vm.placeholders, function (placeholderItem, index) {
-    return _c("Draggable", {
+    return _c('Draggable', {
       key: index
-    }, [placeholderItem.type == "placeholder_group" ? _c("div", {
+    }, [placeholderItem.type == 'placeholder_group' ? _c('div', {
       staticClass: "draggable-item"
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "cptm-preview-placeholder__card__item cptm-preview-placeholder__card__item--top"
     }, _vm._l(placeholderItem.placeholders, function (placeholderSubItem, subIndex) {
-      return _c("card-widget-placeholder", {
+      return _c('card-widget-placeholder', {
         key: "".concat(index, "_").concat(subIndex),
         attrs: {
-          placeholderKey: placeholderSubItem.placeholderKey,
-          id: "listings_header_".concat(index, "_").concat(subIndex),
-          containerClass: "cptm-preview-placeholder__card__box cptm-card-light",
-          label: placeholderSubItem.label,
-          availableWidgets: _vm.theAvailableWidgets,
-          activeWidgets: _vm.active_widgets,
-          acceptedWidgets: placeholderSubItem.acceptedWidgets,
-          rejectedWidgets: placeholderSubItem.rejectedWidgets,
-          selectedWidgets: placeholderSubItem.selectedWidgets,
-          maxWidget: placeholderSubItem.maxWidget,
-          showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_".concat(index, "_").concat(subIndex)),
-          widgetDropable: _vm.widgetIsDropable(placeholderSubItem)
+          "placeholderKey": placeholderSubItem.placeholderKey,
+          "id": "listings_header_".concat(index, "_").concat(subIndex),
+          "containerClass": "cptm-preview-placeholder__card__box cptm-card-light",
+          "label": placeholderSubItem.label,
+          "availableWidgets": _vm.theAvailableWidgets,
+          "activeWidgets": _vm.active_widgets,
+          "acceptedWidgets": placeholderSubItem.acceptedWidgets,
+          "rejectedWidgets": placeholderSubItem.rejectedWidgets,
+          "selectedWidgets": placeholderSubItem.selectedWidgets,
+          "maxWidget": placeholderSubItem.maxWidget,
+          "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus("listings_header_".concat(index, "_").concat(subIndex)),
+          "widgetDropable": _vm.widgetIsDropable(placeholderSubItem)
         },
         on: {
           "insert-widget": function insertWidget($event) {
@@ -33289,26 +33269,26 @@ var render = function render() {
           }
         }
       });
-    }), 1), _vm._v(" "), _c("div", {
+    }), 1), _vm._v(" "), _c('div', {
       staticClass: "cptm-drag-element las la-arrows-alt"
-    })]) : _vm._e(), _vm._v(" "), placeholderItem.type == "placeholder_item" ? _c("div", {
+    })]) : _vm._e(), _vm._v(" "), placeholderItem.type == 'placeholder_item' ? _c('div', {
       staticClass: "draggable-item"
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "cptm-preview-placeholder__card__item cptm-preview-placeholder__card__item--bottom"
-    }, [_c("card-widget-placeholder", {
+    }, [_c('card-widget-placeholder', {
       attrs: {
-        placeholderKey: placeholderItem.placeholderKey,
-        id: "listings_header_" + index,
-        containerClass: "cptm-preview-placeholder__card__box cptm-card-light",
-        label: placeholderItem.label,
-        availableWidgets: _vm.theAvailableWidgets,
-        activeWidgets: _vm.active_widgets,
-        acceptedWidgets: placeholderItem.acceptedWidgets,
-        rejectedWidgets: placeholderItem.rejectedWidgets,
-        selectedWidgets: placeholderItem.selectedWidgets,
-        maxWidget: placeholderItem.maxWidget,
-        showWidgetsPickerWindow: _vm.getActiveInsertWindowStatus("listings_header_" + index),
-        widgetDropable: _vm.widgetIsDropable(placeholderItem)
+        "placeholderKey": placeholderItem.placeholderKey,
+        "id": 'listings_header_' + index,
+        "containerClass": "cptm-preview-placeholder__card__box cptm-card-light",
+        "label": placeholderItem.label,
+        "availableWidgets": _vm.theAvailableWidgets,
+        "activeWidgets": _vm.active_widgets,
+        "acceptedWidgets": placeholderItem.acceptedWidgets,
+        "rejectedWidgets": placeholderItem.rejectedWidgets,
+        "selectedWidgets": placeholderItem.selectedWidgets,
+        "maxWidget": placeholderItem.maxWidget,
+        "showWidgetsPickerWindow": _vm.getActiveInsertWindowStatus('listings_header_' + index),
+        "widgetDropable": _vm.widgetIsDropable(placeholderItem)
       },
       on: {
         "insert-widget": function insertWidget($event) {
@@ -33333,32 +33313,32 @@ var render = function render() {
           return _vm.handleDropOnPlaceholder(placeholderItem);
         },
         "open-widgets-picker-window": function openWidgetsPickerWindow($event) {
-          return _vm.activeInsertWindow("listings_header_" + index);
+          return _vm.activeInsertWindow('listings_header_' + index);
         },
         "close-widgets-picker-window": function closeWidgetsPickerWindow($event) {
           return _vm.closeInsertWindow();
         }
       }
-    })], 1), _vm._v(" "), _c("div", {
+    })], 1), _vm._v(" "), _c('div', {
       staticClass: "cptm-drag-element las la-arrows-alt"
     })]) : _vm._e()]);
-  }), 1), _vm._v(" "), _c("div", {
+  }), 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-placeholder-buttons"
   }, [_vm._l(Object.keys(_vm.placeholdersMap), function (placeholderKey) {
-    return [_vm.canShowAddPlaceholderButton(placeholderKey) ? _c("div", {
+    return [_vm.canShowAddPlaceholderButton(placeholderKey) ? _c('div', {
       key: placeholderKey,
       staticClass: "cptm-preview-placeholder__card__action"
-    }, [_c("button", {
+    }, [_c('button', {
       staticClass: "cptm-preview-placeholder__card__btn",
       attrs: {
-        type: "button"
+        "type": "button"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           return _vm.addPlaceholder(placeholderKey);
         }
       }
-    }, [_c("span", {
+    }, [_c('span', {
       staticClass: "icon fa fa-plus"
     }), _vm._v("\n              " + _vm._s(_vm.getAddPlaceholderButtonLabel(placeholderKey)) + "\n            ")])]) : _vm._e()];
   })], 2)], 1)])]);
@@ -33383,17 +33363,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("checkbox-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('checkbox-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33415,20 +33395,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("color-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('color-field'), _vm._b({
     tag: "component",
     attrs: {
-      canChange: _vm.canChange
+      "canChange": _vm.canChange
     },
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33450,45 +33430,45 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "directorist-input-wrap directorist-footer-wrap"
-  }, [!_vm.isButtonEditable ? _c("div", {
+  }, [!_vm.isButtonEditable ? _c('div', {
     staticClass: "directorist-input"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn",
     attrs: {
-      type: "button",
+      "type": "button",
       "data-info": "Click to edit button text"
     },
     on: {
-      click: _vm.showEditableButton
+      "click": _vm.showEditableButton
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-save-text",
     domProps: {
-      innerHTML: _vm._s(_vm.value)
+      "innerHTML": _vm._s(_vm.value)
     }
-  }), _vm._v(" "), _c("span", {
+  }), _vm._v(" "), _c('span', {
     staticClass: "cptm-save-icon la la-pen"
-  })])]) : _vm._e(), _vm._v(" "), _vm.isButtonEditable ? _c("div", {
+  })])]) : _vm._e(), _vm._v(" "), _vm.isButtonEditable ? _c('div', {
     staticClass: "directorist-input"
   }, [_c("text-field", {
     ref: "formGroup",
     tag: "component",
     attrs: {
-      value: _vm.value
+      "value": _vm.value
     },
     on: {
-      enter: _vm.hideEditableButton,
-      blur: _vm.hideEditableButton,
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "enter": _vm.hideEditableButton,
+      "blur": _vm.hideEditableButton,
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
   })], 1) : _vm._e()]);
@@ -33513,14 +33493,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("export-data-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('export-data-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33542,14 +33522,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("export-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('export-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33571,20 +33551,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-multi-option-group"
-  }, [_vm.label.length ? _c("h3", {
+  }, [_vm.label.length ? _c('h3', {
     staticClass: "cptm-multi-option-label"
   }, [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _vm._l(_vm.local_fields, function (field, field_key) {
-    return [_c(field.type + "-field", _vm._b({
+    return [_c(field.type + '-field', _vm._b({
       key: field_key,
       tag: "component",
       on: {
-        update: function update($event) {
+        "update": function update($event) {
           return _vm.updateValue(field_key, $event);
         }
       }
-    }, "component", field, false))];
+    }, 'component', field, false))];
   })], 2);
 };
 var staticRenderFns = [];
@@ -33607,12 +33587,12 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-builder cptm-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-col-5 cptm-col-sticky"
   }, [_vm._l(_vm.widgets, function (widget_group, widget_group_key) {
-    return [_c("form-builder-widget-list-section-component", _vm._b({
+    return [_c('form-builder-widget-list-section-component', _vm._b({
       attrs: {
         "field-id": _vm.fieldId,
         "widget-group": widget_group_key,
@@ -33628,27 +33608,27 @@ var render = function render() {
           return _vm.handleWidgetListItemDragEnd(widget_group_key, $event);
         }
       }
-    }, "form-builder-widget-list-section-component", widget_group, false))];
-  })], 2), _vm._v(" "), _c("div", {
+    }, 'form-builder-widget-list-section-component', widget_group, false))];
+  })], 2), _vm._v(" "), _c('div', {
     staticClass: "cptm-col-7"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-active-fields"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-builder-active-fields-container cptm-col-sticky"
   }, [_vm._l(_vm.active_widget_groups, function (widget_group, widget_group_key) {
-    return _c("draggable-list-item-wrapper", {
+    return _c('draggable-list-item-wrapper', {
       key: widget_group_key,
       attrs: {
         "list-id": "widget-group",
         "is-dragging-self": _vm.currentDraggingGroup && widget_group_key === _vm.currentDraggingGroup.widget_group_key,
-        droppable: _vm.currentDraggingGroup
+        "droppable": _vm.currentDraggingGroup
       },
       on: {
-        drop: function drop($event) {
+        "drop": function drop($event) {
           return _vm.handleGroupDrop(widget_group_key, $event);
         }
       }
-    }, [_c("form-builder-widget-group-component", {
+    }, [_c('form-builder-widget-group-component', {
       attrs: {
         "group-key": widget_group_key,
         "field-id": _vm.fieldId,
@@ -33693,18 +33673,18 @@ var render = function render() {
         }
       }
     })], 1);
-  }), _vm._v(" "), _vm.showAddNewGroupButton ? _c("div", {
+  }), _vm._v(" "), _vm.showAddNewGroupButton ? _c('div', {
     staticClass: "cptm-form-builder-active-fields-footer"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.addNewGroupButtonLabel)
+      "innerHTML": _vm._s(_vm.addNewGroupButtonLabel)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.addNewGroup();
       }
     }
@@ -33730,16 +33710,16 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("text-field", _vm._b({
+  return _c('text-field', _vm._b({
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "text-field", _vm.$props, false));
+  }, 'text-field', _vm.$props, false));
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33761,9 +33741,9 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group directorist-type-icon-select"
-  }, [_c("div", {
+  }, [_c('div', {
     ref: "iconPickerElm",
     staticClass: "icon-picker-wrap"
   })]);
@@ -33788,15 +33768,15 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("label", [_vm._v(_vm._s(_vm.label))]), _vm._v(" "), _c("input", {
+  }, [_c('label', [_vm._v(_vm._s(_vm.label))]), _vm._v(" "), _c('input', {
     attrs: {
-      type: "file"
+      "type": "file"
     },
     on: {
-      change: function change($event) {
-        return _vm.$emit("update", $event.target.files);
+      "change": function change($event) {
+        return _vm.$emit('update', $event.target.files);
       }
     }
   })]);
@@ -33821,14 +33801,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("import-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('import-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -33850,35 +33830,35 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [!_vm.hidden && _vm.label.length ? _c("label", {
+  }, [!_vm.hidden && _vm.label.length ? _c('label', {
     attrs: {
-      for: _vm.name
+      "for": _vm.name
     }
-  }, [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _c("input", {
+  }, [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _c('input', {
     staticClass: "cptm-form-control",
     attrs: {
-      type: !_vm.hidden ? "text" : "hidden",
-      placeholder: _vm.placeholder
+      "type": !_vm.hidden ? 'text' : 'hidden',
+      "placeholder": _vm.placeholder
     },
     domProps: {
-      value: _vm.theValue
+      "value": _vm.theValue
     },
     on: {
-      input: function input($event) {
+      "input": function input($event) {
         return _vm.updateValue($event.target.value);
       }
     }
-  }), _vm._v(" "), !_vm.hidden && _vm.hasError ? _c("div", {
+  }), _vm._v(" "), !_vm.hidden && _vm.hasError ? _c('div', {
     staticClass: "cptm-form-group-feedback"
   }, _vm._l(_vm.validationMessages, function (alert, alert_key) {
-    return _c("div", {
+    return _c('div', {
       key: alert_key,
       staticClass: "cptm-form-alert",
-      class: "cptm-" + alert.type
-    }, [_vm._v("\n            " + _vm._s(alert.message) + "\n        ")]);
+      class: 'cptm-' + alert.type
+    }, [_vm._v("\r\n            " + _vm._s(alert.message) + "\r\n        ")]);
   }), 0) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -33901,51 +33881,51 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-multi-option-group"
-  }, [_c("h3", {
+  }, [_c('h3', {
     staticClass: "cptm-multi-option-label"
   }, [_vm._v(_vm._s(_vm.label))]), _vm._v(" "), _vm._l(_vm.theActiveGroups, function (option_group, option_group_key) {
-    return [_c("div", {
+    return [_c('div', {
       key: option_group_key,
       staticClass: "cptm-multi-option-group-section"
-    }, [_c("h3", [_vm._v("# " + _vm._s(option_group_key + 1))]), _vm._v(" "), _vm._l(option_group, function (option, option_key) {
-      return [_c(option.type + "-field", _vm._b({
+    }, [_c('h3', [_vm._v("# " + _vm._s(option_group_key + 1))]), _vm._v(" "), _vm._l(option_group, function (option, option_key) {
+      return [_c(option.type + '-field', _vm._b({
         key: "".concat(_vm.fieldId, "_").concat(option_key),
         tag: "component",
         attrs: {
-          root: option_group,
-          validation: _vm.getValidation(option_key, option_group_key, option),
-          value: option.value
+          "root": option_group,
+          "validation": _vm.getValidation(option_key, option_group_key, option),
+          "value": option.value
         },
         on: {
-          update: function update($event) {
+          "update": function update($event) {
             return _vm.updateValue(option_group_key, option_key, $event);
           }
         }
-      }, "component", _vm.getSanitizedOption(option), false))];
-    }), _vm._v(" "), _c("p", {
+      }, 'component', _vm.getSanitizedOption(option), false))];
+    }), _vm._v(" "), _c('p', {
       staticStyle: {
         "text-align": "right"
       }
-    }, [_c("button", {
+    }, [_c('button', {
       staticClass: "cptm-btn cptm-btn-secondery",
       attrs: {
-        type: "button"
+        "type": "button"
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           return _vm.removeOptionGroup(option_group_key);
         }
       }
     }, [_vm._v("\n                    " + _vm._s(_vm.removeButtonLabel) + "\n                ")])])], 2)];
-  }), _vm._v(" "), _c("button", {
+  }), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-btn-primary",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.addNewOptionGroup();
       }
     }
@@ -33971,17 +33951,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("note-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('note-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34003,19 +33983,19 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("text-field", _vm._b({
+  return _c('text-field', _vm._b({
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "text-field", _vm.$props, false));
+  }, 'text-field', _vm.$props, false));
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34037,16 +34017,16 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("text-field", _vm._b({
+  return _c('text-field', _vm._b({
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "text-field", _vm.$props, false));
+  }, 'text-field', _vm.$props, false));
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34068,14 +34048,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("radio-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('radio-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34097,17 +34077,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("range-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('range-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34129,14 +34109,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("restore-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('restore-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34158,12 +34138,12 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _c("pre", [_vm._v(_vm._s(_vm.selected))]), _vm._v(" "), _c("multiselect", {
+  }, [_vm.label.length ? _c('label', [_vm._v(_vm._s(_vm.label))]) : _vm._e(), _vm._v(" "), _c('pre', [_vm._v(_vm._s(_vm.selected))]), _vm._v(" "), _c('multiselect', {
     attrs: {
-      options: _vm.options_1
+      "options": _vm.options_1
     },
     model: {
       value: _vm.selected,
@@ -34172,11 +34152,11 @@ var render = function render() {
       },
       expression: "selected"
     }
-  }), _vm._v(" "), _vm.validationMessages ? _c("div", {
+  }), _vm._v(" "), _vm.validationMessages ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validationMessages.type
+    class: 'cptm-' + _vm.validationMessages.type
   }, [_vm._v("\n            " + _vm._s(_vm.validationMessages.message) + "\n        ")])]) : _vm._e()], 1);
 };
 var staticRenderFns = [];
@@ -34199,17 +34179,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("select-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('select-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34231,20 +34211,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("shortcode-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('shortcode-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34266,20 +34246,20 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("shortcode-list-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('shortcode-list-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34301,14 +34281,14 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("tab-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('tab-field'), _vm._b({
     tag: "component",
     on: {
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34330,29 +34310,29 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("text-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('text-field'), _vm._b({
     tag: "component",
     attrs: {
-      canChange: _vm.canChange
+      "canChange": _vm.canChange
     },
     on: {
-      enter: function enter($event) {
-        return _vm.$emit("enter", $event);
+      "enter": function enter($event) {
+        return _vm.$emit('enter', $event);
       },
-      blur: function blur($event) {
-        return _vm.$emit("blur", $event);
+      "blur": function blur($event) {
+        return _vm.$emit('blur', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       },
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34374,17 +34354,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("textarea-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('textarea-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34406,17 +34386,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("toggle-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('toggle-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34438,17 +34418,17 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _vm.canShow ? _c(_vm.getTheTheme("wp-media-picker-field"), _vm._b({
+  return _vm.canShow ? _c(_vm.getTheTheme('wp-media-picker-field'), _vm._b({
     tag: "component",
     on: {
       "do-action": function doAction($event) {
-        return _vm.$emit("do-action", $event);
+        return _vm.$emit('do-action', $event);
       },
-      update: function update($event) {
-        return _vm.$emit("update", $event);
+      "update": function update($event) {
+        return _vm.$emit('update', $event);
       }
     }
-  }, "component", _vm.$props, false)) : _vm._e();
+  }, 'component', _vm.$props, false)) : _vm._e();
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -34470,50 +34450,50 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("sub-fields-module", {
+  }, [_c('sub-fields-module', {
     attrs: {
       "option-fields": _vm.optionFields,
-      value: _vm.value
+      "value": _vm.value
     },
     on: {
-      update: function update($event) {
+      "update": function update($event) {
         return _vm.updateOptionData($event);
       }
     }
-  }), _vm._v(" "), _c("div", {
+  }), _vm._v(" "), _c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "settings-save-btn",
     attrs: {
-      type: "button",
-      disabled: _vm.button.is_disabled
+      "type": "button",
+      "disabled": _vm.button.is_disabled
     },
     domProps: {
-      innerHTML: _vm._s(_vm.button.label)
+      "innerHTML": _vm._s(_vm.button.label)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.submitAjaxRequest();
       }
     }
-  }), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback cptm-my-10"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n                    " + _vm._s(_vm.validation_message.message) + "\n                ")])]) : _vm._e()])])], 1);
 };
 var staticRenderFns = [];
@@ -34536,23 +34516,23 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-form-group-button-example",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "directorist-btn-example directorist-btn",
     class: _vm.buttonClass,
     style: _vm.buttonStyles
@@ -34578,29 +34558,29 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "settings-save-btn",
     attrs: {
-      href: _vm.formattedUrl,
-      target: _vm.openInNewTab ? "_blank" : "_self"
+      "href": _vm.formattedUrl,
+      "target": _vm.openInNewTab ? '_blank' : '_self'
     },
     domProps: {
-      innerHTML: _vm._s(_vm.buttonLabel)
+      "innerHTML": _vm._s(_vm.buttonLabel)
     }
   })])])]);
 };
@@ -34624,28 +34604,28 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-theme-butterfly"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-checkbox-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-checkbox-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -34654,20 +34634,20 @@ var render = function render() {
       }],
       staticClass: "cptm-checkbox",
       attrs: {
-        type: "checkbox",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "type": "checkbox",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId)
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, typeof option.value !== "undefined" ? option.value : "") > -1 : _vm.local_value
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '') > -1 : _vm.local_value
       },
       on: {
-        change: function change($event) {
+        "change": function change($event) {
           var $$a = _vm.local_value,
             $$el = $event.target,
             $$c = $$el.checked ? true : false;
           if (Array.isArray($$a)) {
-            var $$v = typeof option.value !== "undefined" ? option.value : "",
+            var $$v = typeof option.value !== 'undefined' ? option.value : '',
               $$i = _vm._i($$a, $$v);
             if ($$el.checked) {
               $$i < 0 && (_vm.local_value = $$a.concat([$$v]));
@@ -34679,32 +34659,32 @@ var render = function render() {
           }
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       staticClass: "cptm-checkbox-ui",
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       },
       domProps: {
-        innerHTML: _vm._s(option.label)
+        "innerHTML": _vm._s(option.label)
       }
     })]);
-  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c("p", {
+  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -34736,30 +34716,30 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-color-picker-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-color-picker"
-  }, [_c("v-input-colorpicker", {
+  }, [_c('v-input-colorpicker', {
     attrs: {
-      value: _vm.local_value,
-      picker: "sketch"
+      "value": _vm.local_value,
+      "picker": "sketch"
     },
     model: {
       value: _vm.local_value,
@@ -34768,19 +34748,19 @@ var render = function render() {
       },
       expression: "local_value"
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-color-picker-label"
-  }, [_vm._v(_vm._s(_vm.local_value))])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.local_value))])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -34812,32 +34792,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("a", {
+  }, [_c('a', {
     staticClass: "settings-save-btn",
     attrs: {
-      href: "#",
-      target: "_blank"
+      "href": "#",
+      "target": "_blank"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.button_label)
+      "innerHTML": _vm._s(_vm.button_label)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.exportData.apply(null, arguments);
       }
@@ -34864,38 +34844,38 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.exportJSON();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-download"
-  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")])]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")])]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n                " + _vm._s(_vm.validation_message.message) + "\n            ")])]) : _vm._e()])]);
 };
 var staticRenderFns = [];
@@ -34918,43 +34898,43 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("input", {
+  }, [_c('input', {
     staticClass: "cptm-d-none",
     attrs: {
-      type: "file",
-      accept: ".json",
-      id: _vm.fieldId
+      "type": "file",
+      "accept": ".json",
+      "id": _vm.fieldId
     },
     on: {
-      input: _vm.importJSON
+      "input": _vm.importJSON
     }
-  }), _vm._v(" "), _c("label", {
+  }), _vm._v(" "), _c('label', {
     staticClass: "cptm-btn cptm-label-btn cptm-btn-secondery",
     attrs: {
-      for: _vm.fieldId
+      "for": _vm.fieldId
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-upload"
-  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n                    " + _vm._s(_vm.validation_message.message) + "\n                ")])]) : _vm._e()])])]);
 };
 var staticRenderFns = [];
@@ -34977,19 +34957,19 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-note"
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "fa fa-info-circle"
-  }), _vm._v(" "), _c("div", [_c("h2", {
+  }), _vm._v(" "), _c('div', [_c('h2', {
     staticClass: "cptm-form-note-title",
     domProps: {
-      innerHTML: _vm._s(_vm.title)
+      "innerHTML": _vm._s(_vm.title)
     }
-  }), _vm._v(" "), _vm.description.length ? _c("div", {
+  }), _vm._v(" "), _vm.description.length ? _c('div', {
     staticClass: "cptm-form-note-content",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
   }) : _vm._e()])]);
 };
@@ -35013,30 +34993,30 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-preview-wrapper"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-radio-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-radio-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -35045,37 +35025,37 @@ var render = function render() {
       }],
       staticClass: "cptm-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
     }, [_vm._v("\n                " + _vm._s(option.label) + "\n              ")])]);
-  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c("p", {
+  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v("\n            " + _vm._s(_vm.infoTextForNoOption) + "\n          ")]) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v("\n            " + _vm._s(_vm.infoTextForNoOption) + "\n          ")]) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35085,12 +35065,12 @@ var render = function render() {
       },
       expression: "validationLog"
     }
-  }), _vm._v(" "), _vm.preview ? _c("div", {
+  }), _vm._v(" "), _vm.preview ? _c('div', {
     staticClass: "cptm-preview-area-archive"
   }, _vm._l(Object.keys(_vm.preview), function (previewKey) {
-    return _vm.local_value === previewKey ? _c("img", {
+    return _vm.local_value === previewKey ? _c('img', {
       attrs: {
-        src: _vm.preview[previewKey]
+        "src": _vm.preview[previewKey]
       }
     }) : _vm._e();
   }), 0) : _vm._e()], 1)])])]);
@@ -35115,33 +35095,33 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-range-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-range-bar"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_slider-range"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_range-bar"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_range-fill",
     style: _vm.rangeFillStyle
-  })]), _vm._v(" "), _c("input", {
+  })]), _vm._v(" "), _c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -35150,36 +35130,36 @@ var render = function render() {
     }],
     staticClass: "directorist_slider-input",
     attrs: {
-      type: "range",
-      id: _vm.fieldId,
-      step: _vm.theStep,
-      min: _vm.theMin,
-      max: _vm.theMax,
-      name: _vm.name
+      "type": "range",
+      "id": _vm.fieldId,
+      "step": _vm.theStep,
+      "min": _vm.theMin,
+      "max": _vm.theMax,
+      "name": _vm.name
     },
     domProps: {
-      value: _vm.range_value
+      "value": _vm.range_value
     },
     on: {
-      __r: function __r($event) {
+      "__r": function __r($event) {
         _vm.range_value = $event.target.value;
       }
     }
-  })])]), _vm._v(" "), _c("div", {
+  })])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-form-range-output"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-form-range-output-text"
-  }, [_vm._v(_vm._s(_vm.range_value))])])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.range_value))])])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35211,38 +35191,38 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("button", {
+  }, [_c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.restore();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-sync-alt"
-  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n                " + _vm._s(_vm.buttonLabel) + "\n            ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n                    " + _vm._s(_vm.validation_message.message) + "\n                ")])]) : _vm._e()])])]);
 };
 var staticRenderFns = [];
@@ -35268,118 +35248,118 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", {
+  }, [_vm.label.length ? _c('label', {
     class: {
-      "atbdp-label-icon-wrapper": _vm.icon.length
+      'atbdp-label-icon-wrapper': _vm.icon.length
     }
-  }, [_vm.icon.length ? _c("div", {
+  }, [_vm.icon.length ? _c('div', {
     staticClass: "atbdp-label-icon",
     domProps: {
-      innerHTML: _vm._s(_vm.icon)
+      "innerHTML": _vm._s(_vm.icon)
     }
   }) : _vm._e(), _vm._v(" "), _c(_vm.labelType, {
     tag: "component",
     domProps: {
-      innerHTML: _vm._s(_vm.label)
+      "innerHTML": _vm._s(_vm.label)
     }
-  })], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  })], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_dropdown",
-    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "--open", _vm.show_option_modal)
-  }, [_c("a", {
+    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, '--open', _vm.show_option_modal)
+  }, [_c('a', {
     staticClass: "directorist_dropdown-toggle",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.toggleTheOptionModal();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_dropdown-toggle__text"
-  }, [_vm._v(_vm._s(_vm.theCurrentOptionLabel))])]), _vm._v(" "), _vm.theOptions ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.theCurrentOptionLabel))])]), _vm._v(" "), _vm.theOptions ? _c('div', {
     staticClass: "directorist_dropdown-option",
-    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "--show", _vm.show_option_modal)
-  }, [_c("ul", [_vm.showDefaultOption && _vm.theDefaultOption ? _c("li", [_c("a", {
+    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, '--show', _vm.show_option_modal)
+  }, [_c('ul', [_vm.showDefaultOption && _vm.theDefaultOption ? _c('li', [_c('a', {
     attrs: {
-      href: "#"
+      "href": "#"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.theDefaultOption.label ? _vm.theDefaultOption.label : "")
+      "innerHTML": _vm._s(_vm.theDefaultOption.label ? _vm.theDefaultOption.label : '')
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.updateOption(_vm.theDefaultOption.value);
       }
     }
   })]) : _vm._e(), _vm._v(" "), _vm._l(_vm.theOptions, function (option, option_key) {
-    return _c("li", {
+    return _c('li', {
       key: option_key
-    }, [_c("a", {
+    }, [_c('a', {
       class: {
         active: option.value == _vm.value ? true : false
       },
       attrs: {
-        href: "#"
+        "href": "#"
       },
       domProps: {
-        innerHTML: _vm._s(option.label ? option.label : "")
+        "innerHTML": _vm._s(option.label ? option.label : '')
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.updateOption(option.value);
         }
       }
     })]);
-  })], 2)]) : _vm._e()]), _vm._v(" "), _c("select", {
+  })], 2)]) : _vm._e()]), _vm._v(" "), _c('select', {
     staticClass: "cptm-d-none",
     domProps: {
-      value: _vm.local_value
+      "value": _vm.local_value
     },
     on: {
-      change: function change($event) {
+      "change": function change($event) {
         return _vm.update_value($event.target.value);
       }
     }
-  }, [_vm.showDefaultOption && _vm.theDefaultOption ? _c("option", {
+  }, [_vm.showDefaultOption && _vm.theDefaultOption ? _c('option', {
     domProps: {
-      value: _vm.theDefaultOption.value
+      "value": _vm.theDefaultOption.value
     }
   }, [_vm._v(_vm._s(_vm.theDefaultOption.label))]) : _vm._e(), _vm._v(" "), _vm._l(_vm.theOptions, function (option, option_key) {
-    return _c("option", {
+    return _c('option', {
       key: option_key,
       domProps: {
-        value: option.value
+        "value": option.value
       }
     }, [_vm._v("\n                    " + _vm._s(option.label) + "\n                ")]);
-  })], 2), _vm._v(" "), _c("form-field-validatior", {
+  })], 2), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35411,38 +35391,38 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [!_vm.generateShortcode ? _c("input", {
+  }, [!_vm.generateShortcode ? _c('input', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button",
-      value: "Generate Shortcode"
+      "type": "button",
+      "value": "Generate Shortcode"
     },
     on: {
-      click: _vm.generate
+      "click": _vm.generate
     }
-  }) : _vm._e(), _vm._v(" "), _vm.generateShortcode ? _c("div", {
+  }) : _vm._e(), _vm._v(" "), _vm.generateShortcode ? _c('div', {
     ref: "shortcode",
     staticClass: "cptm-shortcode",
     on: {
-      click: _vm.copyToClip
+      "click": _vm.copyToClip
     }
-  }, [_vm._v(_vm._s(_vm.shortcode))]) : _vm._e(), _vm._v(" "), _vm.successMsg.length ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.shortcode))]) : _vm._e(), _vm._v(" "), _vm.successMsg.length ? _c('div', {
     staticClass: "cptm-info-text cptm-info-success"
   }, [_vm._v(_vm._s(_vm.successMsg))]) : _vm._e()])])]);
 };
@@ -35466,68 +35446,68 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist-mb-n20"
-  }, [_vm.successMsg.length ? _c("span", {
+  }, [_vm.successMsg.length ? _c('span', {
     staticClass: "cptm-info-text cptm-info-success directorist-center-content-inline",
     domProps: {
-      innerHTML: _vm._s(_vm.successMsg)
+      "innerHTML": _vm._s(_vm.successMsg)
     }
-  }) : _vm._e(), _vm._v(" "), _vm.shortcodes_list.length ? _c("button", {
+  }) : _vm._e(), _vm._v(" "), _vm.shortcodes_list.length ? _c('button', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
-        return _vm.copyToClip("all-shortcodes");
+      "click": function click($event) {
+        return _vm.copyToClip('all-shortcodes');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.copyButtonLabel)
+      "innerHTML": _vm._s(_vm.copyButtonLabel)
     }
-  })]) : _vm._e(), _vm._v(" "), _c("button", {
+  })]) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: _vm.generateShortcode
+      "click": _vm.generateShortcode
     }
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.generateButtonLabel)
+      "innerHTML": _vm._s(_vm.generateButtonLabel)
     }
-  })])]), _vm._v(" "), _vm.dirty ? _c("div", [_vm.shortcodes_list.length ? _c("div", {
+  })])]), _vm._v(" "), _vm.dirty ? _c('div', [_vm.shortcodes_list.length ? _c('div', {
     staticClass: "cptm-shortcodes"
   }, _vm._l(_vm.shortcodes_list, function (shortcode, i) {
-    return _c("p", {
+    return _c('p', {
       key: i,
       ref: "shortcodes",
       refInFor: true,
       staticClass: "directorist-alert",
       domProps: {
-        innerHTML: _vm._s(shortcode)
+        "innerHTML": _vm._s(shortcode)
       }
     });
-  }), 0) : _c("div", [_c("p", {
+  }), 0) : _c('div', [_c('p', {
     staticClass: "directorist-alert"
   }, [_vm._v("Nothing to generate")])])]) : _vm._e()])])]);
 };
@@ -35551,25 +35531,25 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group tab-field"
-  }, [_vm.schema.length ? _c("div", {
+  }, [_vm.schema.length ? _c('div', {
     staticClass: "cptm-schema-tab-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-schema-tab-label"
-  }, [_vm._v("\n        " + _vm._s(_vm.schema) + "\n      ")]), _vm._v(" "), _c("div", {
+  }, [_vm._v("\n        " + _vm._s(_vm.schema) + "\n      ")]), _vm._v(" "), _c('div', {
     staticClass: "cptm-schema-tab-wrapper",
     class: {
-      "cptm-schema-multi-directory-disabled": !_vm.multi_directory_status
+      'cptm-schema-multi-directory-disabled': !_vm.multi_directory_status
     }
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-schema-tab-item",
       class: {
-        active: _vm.local_value === option.value
+        'active': _vm.local_value === option.value
       }
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -35578,47 +35558,47 @@ var render = function render() {
       }],
       staticClass: "cptm-schema-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       staticClass: "cptm-schema-label-wrapper",
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
-    }, [_c("div", {
+    }, [_c('div', {
       staticClass: "cptm-schema-label"
-    }, [_vm._v("\n              " + _vm._s(option.label) + "\n              "), !_vm.multi_directory_status.length ? _c("span", {
+    }, [_vm._v("\n              " + _vm._s(option.label) + "\n              "), !_vm.multi_directory_status.length ? _c('span', {
       staticClass: "cptm-schema-label-badge"
-    }, [_vm._v("Multi Directory Disabled")]) : _vm._e()]), _vm._v(" "), _c("div", {
+    }, [_vm._v("Multi Directory Disabled")]) : _vm._e()]), _vm._v(" "), _c('div', {
       staticClass: "cptm-schema-label-description"
     }, [_vm._v("\n                " + _vm._s(option.description) + "\n              ")])])]);
-  }), 0)]) : _c("div", {
+  }), 0)]) : _c('div', {
     staticClass: "cptm-preview-wrapper"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-tab-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-tab-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -35627,35 +35607,35 @@ var render = function render() {
       }],
       staticClass: "cptm-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
     }, [_vm._v("\n          " + _vm._s(option.label) + "\n        ")])]);
-  }), 0), _vm._v(" "), _c("form-field-validatior", {
+  }), 0), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35690,60 +35670,60 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, ["hidden" !== _vm.input_type && _vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, ['hidden' !== _vm.input_type && _vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) !== "object" ? true : false) ? _c("input", {
+  }, [(_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) !== 'object' ? true : false) ? _c('input', {
     staticClass: "cptm-form-control",
     class: _vm.formControlClass,
     attrs: {
-      id: _vm.fieldId,
-      type: _vm.input_type,
-      min: _vm.min,
-      max: _vm.max,
-      step: _vm.step,
-      placeholder: _vm.placeholder,
-      disabled: _vm.disable
+      "id": _vm.fieldId,
+      "type": _vm.input_type,
+      "min": _vm.min,
+      "max": _vm.max,
+      "step": _vm.step,
+      "placeholder": _vm.placeholder,
+      "disabled": _vm.disable
     },
     domProps: {
-      value: _vm.filteredValue === false ? "" : _vm.filteredValue
+      "value": _vm.filteredValue === false ? '' : _vm.filteredValue
     },
     on: {
-      input: function input($event) {
-        return _vm.$emit("update", $event.target.value);
+      "input": function input($event) {
+        return _vm.$emit('update', $event.target.value);
       }
     }
-  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) === "object" ? true : false) ? _c("input", {
+  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) === 'object' ? true : false) ? _c('input', {
     attrs: {
-      type: "hidden"
+      "type": "hidden"
     },
     domProps: {
-      value: JSON.stringify(_vm.filteredValue)
+      "value": JSON.stringify(_vm.filteredValue)
     }
-  }) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.filteredValue,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.filteredValue,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35775,23 +35755,23 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("textarea", {
+  }, [_c('textarea', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -35800,32 +35780,32 @@ var render = function render() {
     }],
     staticClass: "cptm-form-control",
     attrs: {
-      name: "",
-      id: "",
-      cols: _vm.cols,
-      rows: _vm.rows,
-      placeholder: _vm.placeholder
+      "name": "",
+      "id": "",
+      "cols": _vm.cols,
+      "rows": _vm.rows,
+      "placeholder": _vm.placeholder
     },
     domProps: {
-      value: _vm.local_value
+      "value": _vm.local_value
     },
     on: {
-      input: function input($event) {
+      "input": function input($event) {
         if ($event.target.composing) return;
         _vm.local_value = $event.target.value;
       }
     }
-  }), _vm._v(" "), _c("form-field-validatior", {
+  }), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.local_value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.local_value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35857,34 +35837,34 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_vertical-align-m"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_item"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-input-toggle",
     class: _vm.toggleClass,
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.toggleValue();
       }
     }
-  }), _vm._v(" "), _c("input", {
+  }), _vm._v(" "), _c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -35892,18 +35872,18 @@ var render = function render() {
       expression: "local_value"
     }],
     staticStyle: {
-      display: "none"
+      "display": "none"
     },
     attrs: {
-      type: "checkbox",
-      id: _vm.name,
-      name: _vm.name
+      "type": "checkbox",
+      "id": _vm.name,
+      "name": _vm.name
     },
     domProps: {
-      checked: Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, null) > -1 : _vm.local_value
+      "checked": Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, null) > -1 : _vm.local_value
     },
     on: {
-      change: function change($event) {
+      "change": function change($event) {
         var $$a = _vm.local_value,
           $$el = $event.target,
           $$c = $$el.checked ? true : false;
@@ -35920,26 +35900,26 @@ var render = function render() {
         }
       }
     }
-  })]), _vm._v(" "), _c("div", {
+  })]), _vm._v(" "), _c('div', {
     staticClass: "directorist_item"
-  }, [_vm.compLinkIsEnable ? _c("a", {
+  }, [_vm.compLinkIsEnable ? _c('a', {
     staticClass: "cptm-btn cptm-btn-outline directorist_btn-start",
     class: _vm.compLinkClass,
     attrs: {
-      href: _vm.link,
-      target: _vm.comp.link.target
+      "href": _vm.link,
+      "target": _vm.comp.link.target
     }
-  }, [_vm._v("\n                        " + _vm._s(_vm.comp.link.label) + "\n                    ")]) : _vm._e()])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v("\n                        " + _vm._s(_vm.comp.link.label) + "\n                    ")]) : _vm._e()])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -35949,13 +35929,13 @@ var render = function render() {
       },
       expression: "validationLog"
     }
-  })], 1)]), _vm._v(" "), _c("confirmation-modal", _vm._b({
+  })], 1)]), _vm._v(" "), _c('confirmation-modal', _vm._b({
     on: {
-      cancel: function cancel($event) {
+      "cancel": function cancel($event) {
         return _vm.confirmationOnCancel();
       }
     }
-  }, "confirmation-modal", _vm.confirmation, false))], 1);
+  }, 'confirmation-modal', _vm.confirmation, false))], 1);
 };
 var staticRenderFns = [];
 render._withStripped = true;
@@ -35977,66 +35957,66 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-thumbnail"
-  }, [_vm.thumbnailSrc.length ? _c("div", {
+  }, [_vm.thumbnailSrc.length ? _c('div', {
     staticClass: "cptm-thumbnail-img-wrap"
-  }, [_c("img", {
+  }, [_c('img', {
     staticClass: "cptm-thumbnail-img",
     attrs: {
-      src: _vm.thumbnailSrc,
-      width: "100%",
-      height: "auto"
+      "src": _vm.thumbnailSrc,
+      "width": "100%",
+      "height": "auto"
     }
-  }), _vm._v(" "), _vm.hasThumbnail ? _c("span", {
+  }), _vm._v(" "), _vm.hasThumbnail ? _c('span', {
     staticClass: "cptm-thumbnail-action action-trash",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.deleteThumbnail();
       }
     }
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-trash-alt"
-  })]) : _vm._e()]) : _vm._e(), _vm._v(" "), !_vm.thumbnailSrc.length ? _c("span", {
+  })]) : _vm._e()]) : _vm._e(), _vm._v(" "), !_vm.thumbnailSrc.length ? _c('span', {
     staticClass: "cptm-thumbnail-placeholder"
-  }, [_vm._m(0)]) : _vm._e()]), _vm._v(" "), _c("input", {
+  }, [_vm._m(0)]) : _vm._e()]), _vm._v(" "), _c('input', {
     staticClass: "cptm-btn cptm-btn-primary",
     attrs: {
-      type: "button",
-      value: _vm.theButtonLabel
+      "type": "button",
+      "value": _vm.theButtonLabel
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.openMediaPicker.apply(null, arguments);
       }
     }
-  }), _vm._v(" "), _c("form-field-validatior", {
+  }), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36051,9 +36031,9 @@ var render = function render() {
 var staticRenderFns = [function () {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("span", {
+  return _c('span', {
     staticClass: "cptm-thumbnail-placeholder-icon"
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-image"
   })]);
 }];
@@ -36076,35 +36056,35 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("button", {
+  }) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "settings-save-btn",
     attrs: {
-      type: "button",
-      disabled: _vm.button.is_disabled
+      "type": "button",
+      "disabled": _vm.button.is_disabled
     },
     domProps: {
-      innerHTML: _vm._s(_vm.button.label)
+      "innerHTML": _vm._s(_vm.button.label)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.submitAjaxRequest();
       }
     }
-  }), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback cptm-my-10"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n            " + _vm._s(_vm.validation_message.message) + "\n        ")])]) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -36127,22 +36107,22 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-checkbox-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-checkbox-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -36151,20 +36131,20 @@ var render = function render() {
       }],
       staticClass: "cptm-checkbox",
       attrs: {
-        type: "checkbox",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "type": "checkbox",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId)
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, typeof option.value !== "undefined" ? option.value : "") > -1 : _vm.local_value
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '') > -1 : _vm.local_value
       },
       on: {
-        change: function change($event) {
+        "change": function change($event) {
           var $$a = _vm.local_value,
             $$el = $event.target,
             $$c = $$el.checked ? true : false;
           if (Array.isArray($$a)) {
-            var $$v = typeof option.value !== "undefined" ? option.value : "",
+            var $$v = typeof option.value !== 'undefined' ? option.value : '',
               $$i = _vm._i($$a, $$v);
             if ($$el.checked) {
               $$i < 0 && (_vm.local_value = $$a.concat([$$v]));
@@ -36176,32 +36156,32 @@ var render = function render() {
           }
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       staticClass: "cptm-checkbox-ui",
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       },
       domProps: {
-        innerHTML: _vm._s(option.label + " " + option_index)
+        "innerHTML": _vm._s(option.label + ' ' + option_index)
       }
     })]);
-  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c("p", {
+  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36233,30 +36213,30 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-4"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-8"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-color-picker-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-color-picker"
-  }, [_c("v-input-colorpicker", {
+  }, [_c('v-input-colorpicker', {
     attrs: {
-      value: _vm.local_value,
-      picker: "sketch"
+      "value": _vm.local_value,
+      "picker": "sketch"
     },
     model: {
       value: _vm.local_value,
@@ -36265,24 +36245,24 @@ var render = function render() {
       },
       expression: "local_value"
     }
-  })], 1), _vm._v(" "), _c("div", {
+  })], 1), _vm._v(" "), _c('div', {
     staticClass: "cptm-color-picker-label"
-  }, [_vm._v(_vm._s(_vm.local_value))])]), _vm._v(" "), _vm.validationMessages ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.local_value))])]), _vm._v(" "), _vm.validationMessages ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validationMessages.type
-  }, [_vm._v("\n                    " + _vm._s(_vm.validationMessages.message) + "\n                ")])]) : _vm._e()])]), _vm._v(" "), _c("form-field-validatior", {
+    class: 'cptm-' + _vm.validationMessages.type
+  }, [_vm._v("\n                    " + _vm._s(_vm.validationMessages.message) + "\n                ")])]) : _vm._e()])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36314,26 +36294,26 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("a", {
+  }) : _vm._e(), _vm._v(" "), _c('a', {
     staticClass: "settings-save-btn",
     attrs: {
-      href: "#",
-      target: "_blank"
+      "href": "#",
+      "target": "_blank"
     },
     domProps: {
-      innerHTML: _vm._s(_vm.button_label)
+      "innerHTML": _vm._s(_vm.button_label)
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.exportData.apply(null, arguments);
       }
@@ -36360,32 +36340,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("button", {
+  }) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.exportJSON();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-download"
-  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n            " + _vm._s(_vm.validation_message.message) + "\n        ")])]) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -36408,37 +36388,37 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("input", {
+  }) : _vm._e(), _vm._v(" "), _c('input', {
     staticClass: "cptm-d-none",
     attrs: {
-      type: "file",
-      accept: ".json",
-      id: _vm.fieldId
+      "type": "file",
+      "accept": ".json",
+      "id": _vm.fieldId
     },
     on: {
-      input: _vm.importJSON
+      "input": _vm.importJSON
     }
-  }), _vm._v(" "), _c("label", {
+  }), _vm._v(" "), _c('label', {
     staticClass: "cptm-btn cptm-label-btn cptm-btn-secondery",
     attrs: {
-      for: _vm.fieldId
+      "for": _vm.fieldId
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-upload"
-  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n            " + _vm._s(_vm.validation_message.message) + "\n        ")])]) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -36461,19 +36441,19 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-note"
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "fa fa-info-circle"
-  }), _vm._v(" "), _c("div", [_c("h2", {
+  }), _vm._v(" "), _c('div', [_c('h2', {
     staticClass: "cptm-form-note-title",
     domProps: {
-      innerHTML: _vm._s(_vm.title)
+      "innerHTML": _vm._s(_vm.title)
     }
-  }), _vm._v(" "), _vm.description.length ? _c("div", {
+  }), _vm._v(" "), _vm.description.length ? _c('div', {
     staticClass: "cptm-form-note-content",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
   }) : _vm._e()])]);
 };
@@ -36497,24 +36477,24 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-preview-wrapper"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-preview-radio-area"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-info-text",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-radio-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-radio-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -36523,37 +36503,37 @@ var render = function render() {
       }],
       staticClass: "cptm-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
     }, [_vm._v("\n                    " + _vm._s(option.label) + "\n                ")])]);
-  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c("p", {
+  }), 0), _vm._v(" "), !_vm.theOptions.length ? _c('p', {
     staticClass: "cptm-info-text"
-  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.infoTextForNoOption))]) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36563,12 +36543,12 @@ var render = function render() {
       },
       expression: "validationLog"
     }
-  })], 1), _vm._v(" "), _vm.preview ? _c("div", {
+  })], 1), _vm._v(" "), _vm.preview ? _c('div', {
     staticClass: "cptm-preview-area-archive"
   }, _vm._l(Object.keys(_vm.preview), function (previewKey) {
-    return _vm.local_value === previewKey ? _c("img", {
+    return _vm.local_value === previewKey ? _c('img', {
       attrs: {
-        src: _vm.preview[previewKey]
+        "src": _vm.preview[previewKey]
       }
     }) : _vm._e();
   }), 0) : _vm._e()]);
@@ -36593,27 +36573,27 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-form-range-wrap"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-range-bar"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_slider-range"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_range-bar"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_range-fill",
     style: _vm.rangeFillStyle
-  })]), _vm._v(" "), _c("input", {
+  })]), _vm._v(" "), _c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -36622,36 +36602,36 @@ var render = function render() {
     }],
     staticClass: "directorist_slider-input",
     attrs: {
-      type: "range",
-      id: _vm.fieldId,
-      step: _vm.theStep,
-      min: _vm.theMin,
-      max: _vm.theMax,
-      name: _vm.name
+      "type": "range",
+      "id": _vm.fieldId,
+      "step": _vm.theStep,
+      "min": _vm.theMin,
+      "max": _vm.theMax,
+      "name": _vm.name
     },
     domProps: {
-      value: _vm.range_value
+      "value": _vm.range_value
     },
     on: {
-      __r: function __r($event) {
+      "__r": function __r($event) {
         _vm.range_value = $event.target.value;
       }
     }
-  })])]), _vm._v(" "), _c("div", {
+  })])]), _vm._v(" "), _c('div', {
     staticClass: "cptm-form-range-output"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-form-range-output-text"
-  }, [_vm._v(_vm._s(_vm.range_value))])])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v(_vm._s(_vm.range_value))])])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36683,32 +36663,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("button", {
+  }) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-btn-secondery",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.restore();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "fas fa-sync-alt"
-  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c("div", {
+  }), _vm._v("\n        " + _vm._s(_vm.buttonLabel) + "\n    ")]), _vm._v(" "), _vm.validation_message ? _c('div', {
     staticClass: "cptm-form-group-feedback"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-form-alert",
-    class: "cptm-" + _vm.validation_message.type
+    class: 'cptm-' + _vm.validation_message.type
   }, [_vm._v("\n            " + _vm._s(_vm.validation_message.message) + "\n        ")])]) : _vm._e()]);
 };
 var staticRenderFns = [];
@@ -36734,87 +36714,87 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "directorist_dropdown",
-    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "--open", _vm.show_option_modal)
-  }, [_c("a", {
+    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, '--open', _vm.show_option_modal)
+  }, [_c('a', {
     staticClass: "directorist_dropdown-toggle",
     attrs: {
-      href: "#"
+      "href": "#"
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.toggleTheOptionModal();
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "directorist_dropdown-toggle__text"
-  }, [_vm._v(_vm._s(_vm.theCurrentOptionLabel))])]), _vm._v(" "), _vm.theOptions ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.theCurrentOptionLabel))])]), _vm._v(" "), _vm.theOptions ? _c('div', {
     staticClass: "directorist_dropdown-option",
-    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, "--show", _vm.show_option_modal)
-  }, [_c("ul", _vm._l(_vm.theOptions, function (option, option_key) {
-    return _c("li", {
+    class: _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()({}, '--show', _vm.show_option_modal)
+  }, [_c('ul', _vm._l(_vm.theOptions, function (option, option_key) {
+    return _c('li', {
       key: option_key
-    }, [_c("a", {
+    }, [_c('a', {
       class: {
         active: option.value == _vm.value ? true : false
       },
       attrs: {
-        href: "#"
+        "href": "#"
       },
       domProps: {
-        innerHTML: _vm._s(option.label ? option.label : "")
+        "innerHTML": _vm._s(option.label ? option.label : '')
       },
       on: {
-        click: function click($event) {
+        "click": function click($event) {
           $event.preventDefault();
           return _vm.updateOption(option.value);
         }
       }
     })]);
-  }), 0)]) : _vm._e()]), _vm._v(" "), _c("select", {
+  }), 0)]) : _vm._e()]), _vm._v(" "), _c('select', {
     staticClass: "cptm-d-none",
     domProps: {
-      value: _vm.local_value
+      "value": _vm.local_value
     },
     on: {
-      change: function change($event) {
+      "change": function change($event) {
         return _vm.update_value($event.target.value);
       }
     }
-  }, [_vm.showDefaultOption && _vm.default_option ? _c("option", {
+  }, [_vm.showDefaultOption && _vm.default_option ? _c('option', {
     domProps: {
-      value: _vm.default_option.value
+      "value": _vm.default_option.value
     }
   }, [_vm._v(_vm._s(_vm.default_option.label))]) : _vm._e(), _vm._v(" "), _vm._l(_vm.theOptions, function (option, option_key) {
-    return [_c("option", {
+    return [_c('option', {
       key: option_key,
       domProps: {
-        value: option.value
+        "value": option.value
       }
     }, [_vm._v(_vm._s(option.label))])];
-  })], 2), _vm._v(" "), _c("form-field-validatior", {
+  })], 2), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -36846,32 +36826,32 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), !_vm.generateShortcode ? _c("input", {
+  }) : _vm._e(), _vm._v(" "), !_vm.generateShortcode ? _c('input', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button",
-      value: "Generate Shortcode"
+      "type": "button",
+      "value": "Generate Shortcode"
     },
     on: {
-      click: _vm.generate
+      "click": _vm.generate
     }
-  }) : _vm._e(), _vm._v(" "), _vm.generateShortcode ? _c("div", {
+  }) : _vm._e(), _vm._v(" "), _vm.generateShortcode ? _c('div', {
     ref: "shortcode",
     staticClass: "cptm-shortcode",
     on: {
-      click: _vm.copyToClip
+      "click": _vm.copyToClip
     }
-  }, [_vm._v(_vm._s(_vm.shortcode))]) : _vm._e(), _vm._v(" "), _vm.successMsg.length ? _c("div", {
+  }, [_vm._v(_vm._s(_vm.shortcode))]) : _vm._e(), _vm._v(" "), _vm.successMsg.length ? _c('div', {
     staticClass: "cptm-info-text cptm-info-success"
   }, [_vm._v(_vm._s(_vm.successMsg))]) : _vm._e()]);
 };
@@ -36895,67 +36875,67 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-row"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "atbdp-col atbdp-col-6"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("div", {
+  }) : _vm._e()]), _vm._v(" "), _c('div', {
     staticClass: "atbdp-col atbdp-col-6 directorist-text-right directorist-mb-n20"
-  }, [_vm.successMsg.length ? _c("span", {
+  }, [_vm.successMsg.length ? _c('span', {
     staticClass: "cptm-info-text cptm-info-success directorist-center-content-inline",
     domProps: {
-      innerHTML: _vm._s(_vm.successMsg)
+      "innerHTML": _vm._s(_vm.successMsg)
     }
-  }) : _vm._e(), _vm._v(" "), _vm.shortcodes_list.length ? _c("button", {
+  }) : _vm._e(), _vm._v(" "), _vm.shortcodes_list.length ? _c('button', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: function click($event) {
-        return _vm.copyToClip("all-shortcodes");
+      "click": function click($event) {
+        return _vm.copyToClip('all-shortcodes');
       }
     }
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.copyButtonLabel)
+      "innerHTML": _vm._s(_vm.copyButtonLabel)
     }
-  })]) : _vm._e(), _vm._v(" "), _c("button", {
+  })]) : _vm._e(), _vm._v(" "), _c('button', {
     staticClass: "cptm-btn cptm-generate-shortcode-button",
     attrs: {
-      type: "button"
+      "type": "button"
     },
     on: {
-      click: _vm.generateShortcode
+      "click": _vm.generateShortcode
     }
-  }, [_c("span", {
+  }, [_c('span', {
     domProps: {
-      innerHTML: _vm._s(_vm.generateButtonLabel)
+      "innerHTML": _vm._s(_vm.generateButtonLabel)
     }
-  })])])]), _vm._v(" "), _vm.dirty ? _c("div", [_vm.shortcodes_list.length ? _c("div", {
+  })])])]), _vm._v(" "), _vm.dirty ? _c('div', [_vm.shortcodes_list.length ? _c('div', {
     ref: "all-shortcodes",
     staticClass: "cptm-shortcodes"
   }, _vm._l(_vm.shortcodes_list, function (shortcode, i) {
-    return _c("p", {
+    return _c('p', {
       key: i,
       ref: "shortcodes",
       refInFor: true,
       staticClass: "directorist-alert",
       domProps: {
-        innerHTML: _vm._s(shortcode)
+        "innerHTML": _vm._s(shortcode)
       }
     });
-  }), 0) : _c("div", [_c("p", {
+  }), 0) : _c('div', [_c('p', {
     staticClass: "directorist-alert"
   }, [_vm._v("Nothing to generate")])])]) : _vm._e()]);
 };
@@ -36979,24 +36959,24 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-preview-wrapper tab-field"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-preview-tab-area"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-tab-area"
   }, _vm._l(_vm.theOptions, function (option, option_index) {
-    return _c("div", {
+    return _c('div', {
       key: option_index,
       staticClass: "cptm-tab-item"
-    }, [_c("input", {
+    }, [_c('input', {
       directives: [{
         name: "model",
         rawName: "v-model",
@@ -37005,35 +36985,35 @@ var render = function render() {
       }],
       staticClass: "cptm-radio",
       attrs: {
-        type: "radio",
-        id: _vm.getOptionID(option, option_index, _vm.sectionId),
-        name: _vm.name
+        "type": "radio",
+        "id": _vm.getOptionID(option, option_index, _vm.sectionId),
+        "name": _vm.name
       },
       domProps: {
-        value: typeof option.value !== "undefined" ? option.value : "",
-        checked: _vm._q(_vm.local_value, typeof option.value !== "undefined" ? option.value : "")
+        "value": typeof option.value !== 'undefined' ? option.value : '',
+        "checked": _vm._q(_vm.local_value, typeof option.value !== 'undefined' ? option.value : '')
       },
       on: {
-        change: function change($event) {
-          _vm.local_value = typeof option.value !== "undefined" ? option.value : "";
+        "change": function change($event) {
+          _vm.local_value = typeof option.value !== 'undefined' ? option.value : '';
         }
       }
-    }), _vm._v(" "), _c("label", {
+    }), _vm._v(" "), _c('label', {
       attrs: {
-        for: _vm.getOptionID(option, option_index, _vm.sectionId)
+        "for": _vm.getOptionID(option, option_index, _vm.sectionId)
       }
     }, [_vm._v("\n          " + _vm._s(option.label) + "\n        ")])]);
-  }), 0), _vm._v(" "), _c("form-field-validatior", {
+  }), 0), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37068,57 +37048,57 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, ["hidden" !== _vm.input_type && _vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, ['hidden' !== _vm.input_type && _vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) !== "object" ? true : false) ? _c("input", {
+  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) !== 'object' ? true : false) ? _c('input', {
     staticClass: "cptm-form-control",
     class: _vm.formControlClass,
     attrs: {
-      type: _vm.input_type,
-      placeholder: _vm.placeholder,
-      disabled: _vm.disable
+      "type": _vm.input_type,
+      "placeholder": _vm.placeholder,
+      "disabled": _vm.disable
     },
     domProps: {
-      value: _vm.filteredValue
+      "value": _vm.filteredValue
     },
     on: {
-      keyup: function keyup($event) {
-        if (!$event.type.indexOf("key") && _vm._k($event.keyCode, "enter", 13, $event.key, "Enter")) return null;
-        return _vm.$emit("enter", $event.target.value);
+      "keyup": function keyup($event) {
+        if (!$event.type.indexOf('key') && _vm._k($event.keyCode, "enter", 13, $event.key, "Enter")) return null;
+        return _vm.$emit('enter', $event.target.value);
       },
-      blur: function blur($event) {
-        return _vm.$emit("blur", $event.target.value);
+      "blur": function blur($event) {
+        return _vm.$emit('blur', $event.target.value);
       },
-      input: function input($event) {
-        return _vm.$emit("update", $event.target.value);
+      "input": function input($event) {
+        return _vm.$emit('update', $event.target.value);
       }
     }
-  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) === "object" ? true : false) ? _c("input", {
+  }) : _vm._e(), _vm._v(" "), (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(_vm.filteredValue) === 'object' ? true : false) ? _c('input', {
     attrs: {
-      type: "hidden"
+      "type": "hidden"
     },
     domProps: {
-      value: JSON.stringify(_vm.filteredValue)
+      "value": JSON.stringify(_vm.filteredValue)
     }
-  }) : _vm._e(), _vm._v(" "), _c("form-field-validatior", {
+  }) : _vm._e(), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.filteredValue,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.filteredValue,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37150,22 +37130,22 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group",
     class: _vm.formGroupClass
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _vm.editor ? _c("div", {
+  }) : _vm._e(), _vm._v(" "), _vm.editor ? _c('div', {
     staticClass: "cptm-form-control",
     attrs: {
-      id: _vm.editorID
+      "id": _vm.editorID
     }
-  }) : _c("textarea", {
+  }) : _c('textarea', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -37174,31 +37154,31 @@ var render = function render() {
     }],
     staticClass: "cptm-form-control",
     attrs: {
-      name: "",
-      cols: _vm.cols,
-      rows: _vm.rows,
-      placeholder: _vm.placeholder
+      "name": "",
+      "cols": _vm.cols,
+      "rows": _vm.rows,
+      "placeholder": _vm.placeholder
     },
     domProps: {
-      value: _vm.local_value
+      "value": _vm.local_value
     },
     on: {
-      input: function input($event) {
+      "input": function input($event) {
         if ($event.target.composing) return;
         _vm.local_value = $event.target.value;
       }
     }
-  }), _vm._v(" "), _c("form-field-validatior", {
+  }), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.local_value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.local_value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37230,25 +37210,25 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "cptm-input-toggle-wrap"
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _c("div", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "directorist_vertical-align-m"
-  }, [_c("div", {
+  }, [_c('div', {
     staticClass: "directorist_item"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-input-toggle",
     class: _vm.toggleClass,
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.toggleValue();
       }
     }
-  }), _vm._v(" "), _c("input", {
+  }), _vm._v(" "), _c('input', {
     directives: [{
       name: "model",
       rawName: "v-model",
@@ -37256,18 +37236,18 @@ var render = function render() {
       expression: "local_value"
     }],
     staticStyle: {
-      display: "none"
+      "display": "none"
     },
     attrs: {
-      type: "checkbox",
-      id: _vm.name,
-      name: _vm.name
+      "type": "checkbox",
+      "id": _vm.name,
+      "name": _vm.name
     },
     domProps: {
-      checked: Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, null) > -1 : _vm.local_value
+      "checked": Array.isArray(_vm.local_value) ? _vm._i(_vm.local_value, null) > -1 : _vm.local_value
     },
     on: {
-      change: function change($event) {
+      "change": function change($event) {
         var $$a = _vm.local_value,
           $$el = $event.target,
           $$c = $$el.checked ? true : false;
@@ -37284,40 +37264,40 @@ var render = function render() {
         }
       }
     }
-  })]), _vm._v(" "), _c("div", {
+  })]), _vm._v(" "), _c('div', {
     staticClass: "directorist_item"
-  }, [_vm.compLinkIsEnable ? _c("a", {
+  }, [_vm.compLinkIsEnable ? _c('a', {
     staticClass: "cptm-btn cptm-btn-outline directorist_btn-start",
     class: _vm.compLinkClass,
     attrs: {
-      href: _vm.comp.link.url,
-      target: _vm.comp.link.target
+      "href": _vm.comp.link.url,
+      "target": _vm.comp.link.target
     },
     domProps: {
-      innerHTML: _vm._s(_vm.comp.link.label)
+      "innerHTML": _vm._s(_vm.comp.link.label)
     }
-  }) : _vm._e()])]), _vm._v(" "), _vm.description.length ? _c("p", {
+  }) : _vm._e()])]), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e()]), _vm._v(" "), _c("confirmation-modal", _vm._b({
+  }) : _vm._e()]), _vm._v(" "), _c('confirmation-modal', _vm._b({
     on: {
-      cancel: function cancel($event) {
+      "cancel": function cancel($event) {
         return _vm.confirmationOnCancel();
       }
     }
-  }, "confirmation-modal", _vm.confirmation, false)), _vm._v(" "), _c("form-field-validatior", {
+  }, 'confirmation-modal', _vm.confirmation, false)), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -37349,104 +37329,104 @@ __webpack_require__.r(__webpack_exports__);
 var render = function render() {
   var _vm = this,
     _c = _vm._self._c;
-  return _c("div", {
+  return _c('div', {
     staticClass: "cptm-form-group cptm-preview-image-upload",
-    class: _vm.thumbnailSrc.length ? "cptm-preview-image-upload--show" : ""
-  }, [_vm.label.length ? _c("label", [_c(_vm.labelType, {
+    class: _vm.thumbnailSrc.length ? 'cptm-preview-image-upload--show' : ''
+  }, [_vm.label.length ? _c('label', [_c(_vm.labelType, {
     tag: "component"
-  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c("p", {
+  }, [_vm._v(_vm._s(_vm.label))])], 1) : _vm._e(), _vm._v(" "), _vm.description.length ? _c('p', {
     staticClass: "cptm-form-group-info",
     domProps: {
-      innerHTML: _vm._s(_vm.description)
+      "innerHTML": _vm._s(_vm.description)
     }
-  }) : _vm._e(), _vm._v(" "), _c("div", {
+  }) : _vm._e(), _vm._v(" "), _c('div', {
     staticClass: "cptm-thumbnail"
-  }, [_vm.hasThumbnail ? _c("span", {
+  }, [_vm.hasThumbnail ? _c('span', {
     staticClass: "cptm-thumbnail-action action-trash",
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         return _vm.deleteThumbnail();
       }
     }
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-trash-alt"
-  })]) : _vm._e(), _vm._v(" "), _vm.thumbnailSrc.length ? _c("div", {
+  })]) : _vm._e(), _vm._v(" "), _vm.thumbnailSrc.length ? _c('div', {
     staticClass: "cptm-thumbnail-img-wrap"
-  }, [_c("img", {
+  }, [_c('img', {
     staticClass: "cptm-thumbnail-img",
     attrs: {
-      src: _vm.thumbnailSrc,
-      width: "100%",
-      height: "auto"
+      "src": _vm.thumbnailSrc,
+      "width": "100%",
+      "height": "auto"
     }
-  })]) : _vm._e(), _vm._v(" "), !_vm.thumbnailSrc.length ? _c("span", {
+  })]) : _vm._e(), _vm._v(" "), !_vm.thumbnailSrc.length ? _c('span', {
     staticClass: "cptm-thumbnail-placeholder"
-  }, [_c("span", {
+  }, [_c('span', {
     staticClass: "cptm-thumbnail-placeholder-icon"
-  }, [_c("svg", {
+  }, [_c('svg', {
     attrs: {
-      xmlns: "http://www.w3.org/2000/svg",
-      width: "40",
-      height: "40",
-      viewBox: "0 0 40 40",
-      fill: "none"
+      "xmlns": "http://www.w3.org/2000/svg",
+      "width": "40",
+      "height": "40",
+      "viewBox": "0 0 40 40",
+      "fill": "none"
     }
-  }, [_c("g", {
+  }, [_c('g', {
     attrs: {
       "clip-path": "url(#clip0_5019_6906)"
     }
-  }, [_c("path", {
+  }, [_c('path', {
     attrs: {
-      d: "M33.6766 39.7132H6.31999C4.71995 39.7107 3.18616 39.0739 2.05497 37.9423C0.923782 36.8107 0.287519 35.2766 0.285706 33.6766V6.32231C0.28752 4.72248 0.923857 3.18869 2.05511 2.05743C3.18637 0.926176 4.72016 0.28984 6.31999 0.288025H33.6766C35.2764 0.28984 36.8102 0.926176 37.9414 2.05743C39.0727 3.18869 39.709 4.72248 39.7108 6.32231V33.6766C39.709 35.2766 39.0728 36.8107 37.9416 37.9423C36.8104 39.0739 35.2766 39.7107 33.6766 39.7132ZM6.31999 3.14517C5.47764 3.14608 4.67005 3.4811 4.07441 4.07673C3.47878 4.67237 3.14376 5.47996 3.14285 6.32231V33.6766C3.14345 34.5192 3.47831 35.3273 4.07394 35.9233C4.66957 36.5194 5.47734 36.8548 6.31999 36.856H33.6766C34.5192 36.8548 35.327 36.5194 35.9226 35.9233C36.5182 35.3273 36.8531 34.5192 36.8537 33.6766V6.32231C36.8528 5.47996 36.5178 4.67237 35.9221 4.07673C35.3265 3.4811 34.5189 3.14608 33.6766 3.14517H6.31999Z",
-      fill: "#D2D6DB"
+      "d": "M33.6766 39.7132H6.31999C4.71995 39.7107 3.18616 39.0739 2.05497 37.9423C0.923782 36.8107 0.287519 35.2766 0.285706 33.6766V6.32231C0.28752 4.72248 0.923857 3.18869 2.05511 2.05743C3.18637 0.926176 4.72016 0.28984 6.31999 0.288025H33.6766C35.2764 0.28984 36.8102 0.926176 37.9414 2.05743C39.0727 3.18869 39.709 4.72248 39.7108 6.32231V33.6766C39.709 35.2766 39.0728 36.8107 37.9416 37.9423C36.8104 39.0739 35.2766 39.7107 33.6766 39.7132ZM6.31999 3.14517C5.47764 3.14608 4.67005 3.4811 4.07441 4.07673C3.47878 4.67237 3.14376 5.47996 3.14285 6.32231V33.6766C3.14345 34.5192 3.47831 35.3273 4.07394 35.9233C4.66957 36.5194 5.47734 36.8548 6.31999 36.856H33.6766C34.5192 36.8548 35.327 36.5194 35.9226 35.9233C36.5182 35.3273 36.8531 34.5192 36.8537 33.6766V6.32231C36.8528 5.47996 36.5178 4.67237 35.9221 4.07673C35.3265 3.4811 34.5189 3.14608 33.6766 3.14517H6.31999Z",
+      "fill": "#D2D6DB"
     }
-  }), _vm._v(" "), _c("path", {
+  }), _vm._v(" "), _c('path', {
     attrs: {
-      d: "M13.5543 19.6869C12.5444 19.6869 11.5571 19.3874 10.7174 18.8263C9.87766 18.2652 9.22317 17.4677 8.83669 16.5347C8.45021 15.6016 8.34909 14.5749 8.54611 13.5844C8.74314 12.5939 9.22947 11.684 9.94359 10.9699C10.6577 10.2558 11.5676 9.76945 12.5581 9.57242C13.5486 9.3754 14.5753 9.47652 15.5084 9.863C16.4414 10.2495 17.2389 10.904 17.8 11.7437C18.3611 12.5834 18.6606 13.5707 18.6606 14.5806C18.6591 15.9344 18.1206 17.2323 17.1633 18.1896C16.206 19.1469 14.9081 19.6854 13.5543 19.6869ZM13.5543 12.3326C13.1094 12.3326 12.6745 12.4645 12.3046 12.7117C11.9347 12.9589 11.6464 13.3102 11.4762 13.7213C11.306 14.1323 11.2616 14.5846 11.3484 15.0209C11.4353 15.4573 11.6496 15.858 11.9643 16.1725C12.279 16.487 12.6798 16.7011 13.1162 16.7878C13.5526 16.8745 14.0048 16.8298 14.4158 16.6593C14.8267 16.4889 15.1779 16.2005 15.4249 15.8305C15.6719 15.4604 15.8037 15.0255 15.8034 14.5806C15.8025 13.9845 15.5652 13.413 15.1436 12.9916C14.722 12.5702 14.1504 12.3332 13.5543 12.3326ZM3.04457 36.48C2.76869 36.4798 2.4988 36.3996 2.26748 36.2493C2.03616 36.099 1.85332 35.8849 1.74104 35.6329C1.62876 35.3809 1.59185 35.1018 1.63476 34.8292C1.67767 34.5567 1.79857 34.3025 1.98286 34.0972L8.69828 26.6149C9.3463 25.8887 10.2508 25.4423 11.2213 25.3696C12.1919 25.2969 13.1528 25.6036 13.9017 26.2252L16.7874 28.6069C16.8811 28.6869 16.9906 28.7464 17.1087 28.7814C17.2268 28.8164 17.351 28.8263 17.4731 28.8103C17.5943 28.7977 17.7117 28.7609 17.8183 28.702C17.9249 28.6431 18.0186 28.5633 18.0937 28.4674L25.6869 18.6572C26.0369 18.202 26.487 17.8335 27.0022 17.58C27.5175 17.3266 28.0841 17.195 28.6583 17.1954H28.672C29.2409 17.1947 29.8025 17.3233 30.3143 17.5716C30.8261 17.8199 31.2748 18.1813 31.6263 18.6286L38.9086 27.8937C39.1427 28.1917 39.2489 28.5704 39.2038 28.9467C39.1587 29.323 38.966 29.6659 38.668 29.9C38.37 30.1342 37.9913 30.2404 37.615 30.1952C37.2388 30.1501 36.8959 29.9574 36.6617 29.6594L29.3794 20.3943C29.2943 20.286 29.1854 20.1987 29.0612 20.1392C28.9369 20.0798 28.8006 20.0497 28.6629 20.0514C28.5246 20.0565 28.389 20.0906 28.2648 20.1514C28.1405 20.2122 28.0305 20.2985 27.9417 20.4046L20.3429 30.2103C20.0336 30.6093 19.6475 30.9421 19.2072 31.1891C18.767 31.436 18.2817 31.5921 17.78 31.6481C17.2784 31.704 16.7706 31.6587 16.2868 31.5148C15.803 31.3709 15.353 31.1313 14.9634 30.8103L12.0777 28.4286C11.8967 28.2784 11.6645 28.2044 11.43 28.2221C11.1955 28.2398 10.977 28.3478 10.8206 28.5234L4.11428 36C3.98032 36.1514 3.81562 36.2726 3.63117 36.3553C3.44671 36.4381 3.24674 36.4806 3.04457 36.48Z",
-      fill: "#D2D6DB"
+      "d": "M13.5543 19.6869C12.5444 19.6869 11.5571 19.3874 10.7174 18.8263C9.87766 18.2652 9.22317 17.4677 8.83669 16.5347C8.45021 15.6016 8.34909 14.5749 8.54611 13.5844C8.74314 12.5939 9.22947 11.684 9.94359 10.9699C10.6577 10.2558 11.5676 9.76945 12.5581 9.57242C13.5486 9.3754 14.5753 9.47652 15.5084 9.863C16.4414 10.2495 17.2389 10.904 17.8 11.7437C18.3611 12.5834 18.6606 13.5707 18.6606 14.5806C18.6591 15.9344 18.1206 17.2323 17.1633 18.1896C16.206 19.1469 14.9081 19.6854 13.5543 19.6869ZM13.5543 12.3326C13.1094 12.3326 12.6745 12.4645 12.3046 12.7117C11.9347 12.9589 11.6464 13.3102 11.4762 13.7213C11.306 14.1323 11.2616 14.5846 11.3484 15.0209C11.4353 15.4573 11.6496 15.858 11.9643 16.1725C12.279 16.487 12.6798 16.7011 13.1162 16.7878C13.5526 16.8745 14.0048 16.8298 14.4158 16.6593C14.8267 16.4889 15.1779 16.2005 15.4249 15.8305C15.6719 15.4604 15.8037 15.0255 15.8034 14.5806C15.8025 13.9845 15.5652 13.413 15.1436 12.9916C14.722 12.5702 14.1504 12.3332 13.5543 12.3326ZM3.04457 36.48C2.76869 36.4798 2.4988 36.3996 2.26748 36.2493C2.03616 36.099 1.85332 35.8849 1.74104 35.6329C1.62876 35.3809 1.59185 35.1018 1.63476 34.8292C1.67767 34.5567 1.79857 34.3025 1.98286 34.0972L8.69828 26.6149C9.3463 25.8887 10.2508 25.4423 11.2213 25.3696C12.1919 25.2969 13.1528 25.6036 13.9017 26.2252L16.7874 28.6069C16.8811 28.6869 16.9906 28.7464 17.1087 28.7814C17.2268 28.8164 17.351 28.8263 17.4731 28.8103C17.5943 28.7977 17.7117 28.7609 17.8183 28.702C17.9249 28.6431 18.0186 28.5633 18.0937 28.4674L25.6869 18.6572C26.0369 18.202 26.487 17.8335 27.0022 17.58C27.5175 17.3266 28.0841 17.195 28.6583 17.1954H28.672C29.2409 17.1947 29.8025 17.3233 30.3143 17.5716C30.8261 17.8199 31.2748 18.1813 31.6263 18.6286L38.9086 27.8937C39.1427 28.1917 39.2489 28.5704 39.2038 28.9467C39.1587 29.323 38.966 29.6659 38.668 29.9C38.37 30.1342 37.9913 30.2404 37.615 30.1952C37.2388 30.1501 36.8959 29.9574 36.6617 29.6594L29.3794 20.3943C29.2943 20.286 29.1854 20.1987 29.0612 20.1392C28.9369 20.0798 28.8006 20.0497 28.6629 20.0514C28.5246 20.0565 28.389 20.0906 28.2648 20.1514C28.1405 20.2122 28.0305 20.2985 27.9417 20.4046L20.3429 30.2103C20.0336 30.6093 19.6475 30.9421 19.2072 31.1891C18.767 31.436 18.2817 31.5921 17.78 31.6481C17.2784 31.704 16.7706 31.6587 16.2868 31.5148C15.803 31.3709 15.353 31.1313 14.9634 30.8103L12.0777 28.4286C11.8967 28.2784 11.6645 28.2044 11.43 28.2221C11.1955 28.2398 10.977 28.3478 10.8206 28.5234L4.11428 36C3.98032 36.1514 3.81562 36.2726 3.63117 36.3553C3.44671 36.4381 3.24674 36.4806 3.04457 36.48Z",
+      "fill": "#D2D6DB"
     }
-  })]), _vm._v(" "), _c("defs", [_c("clipPath", {
+  })]), _vm._v(" "), _c('defs', [_c('clipPath', {
     attrs: {
-      id: "clip0_5019_6906"
+      "id": "clip0_5019_6906"
     }
-  }, [_c("rect", {
+  }, [_c('rect', {
     attrs: {
-      width: "40",
-      height: "40",
-      fill: "white"
+      "width": "40",
+      "height": "40",
+      "fill": "white"
     }
-  })])])])])]) : _vm._e(), _vm._v(" "), _c("label", {
+  })])])])])]) : _vm._e(), _vm._v(" "), _c('label', {
     staticClass: "cptm-upload-btn cptm-btn cptm-btn-dark directorist-row-tooltip",
     attrs: {
       "data-tooltip": "Change image",
       "data-flow": "bottom"
     }
-  }, [_c("i", {
+  }, [_c('i', {
     staticClass: "uil uil-top-arrow-to-top"
-  }), _vm._v(" "), _c("input", {
+  }), _vm._v(" "), _c('input', {
     attrs: {
-      type: "button",
-      value: _vm.theButtonLabel
+      "type": "button",
+      "value": _vm.theButtonLabel
     },
     on: {
-      click: function click($event) {
+      "click": function click($event) {
         $event.preventDefault();
         return _vm.openMediaPicker.apply(null, arguments);
       }
     }
-  })]), _vm._v(" "), _c("div", {
+  })]), _vm._v(" "), _c('div', {
     staticClass: "cptm-thumbnail-drag-text"
-  }, [_vm._v("upload image here")])]), _vm._v(" "), _c("form-field-validatior", {
+  }, [_vm._v("upload image here")])]), _vm._v(" "), _c('form-field-validatior', {
     attrs: {
       "section-id": _vm.sectionId,
       "field-id": _vm.fieldId,
-      root: _vm.root,
-      value: _vm.value,
-      rules: _vm.rules
+      "root": _vm.root,
+      "value": _vm.value,
+      "rules": _vm.rules
     },
     on: {
-      validate: function validate($event) {
-        return _vm.$emit("validate", $event);
+      "validate": function validate($event) {
+        return _vm.$emit('validate', $event);
       }
     },
     model: {
@@ -39139,8 +39119,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "vueDndrop", function() { return vueDndrop; });
 /**
  * Bundle of: vue-dndrop
- * Generated: 2023-02-10
- * Version: 1.3.0
+ * Generated: 2024-12-18
+ * Version: 1.3.2
  */
 
 var containerInstance = 'dndrop-container-instance';
@@ -40150,11 +40130,6 @@ function addGrabListeners () {
     window.document.addEventListener(e, onMouseDown, { passive: false });
   });
 }
-
-function removeGrabListeners () {
-  var touchstart = grabEvents[1];
-  window.document.removeEventListener(touchstart, onMouseDown, { passive: false });
-}
 function addMoveListeners () {
   moveEvents.forEach(function (e) {
     window.document.addEventListener(e, onMouseMove, { passive: false });
@@ -40388,6 +40363,9 @@ var handleDragStartConditions = (function handleDragStartConditions () {
     releaseEvents.forEach(function (e) { return window.document.addEventListener(e, onUp); }, {
       passive: false,
     });
+    grabEvents.forEach(function (e) { return window.document.addEventListener(e, onMove); }, {
+      passive: false,
+    });
     window.document.addEventListener('drag', onHTMLDrag, {
       passive: false,
     });
@@ -40398,6 +40376,9 @@ var handleDragStartConditions = (function handleDragStartConditions () {
       passive: false,
     });
     releaseEvents.forEach(function (e) { return window.document.removeEventListener(e, onUp); }, {
+      passive: false,
+    });
+    grabEvents.forEach(function (e) { return window.document.removeEventListener(e, onMove); }, {
       passive: false,
     });
     window.document.removeEventListener('drag', onHTMLDrag, {
@@ -40491,7 +40472,7 @@ function handleMouseMoveForContainer (ref, orientation) {
   }
 }
 function onMouseMove (event) {
-  event.preventDefault();
+  if (event.cancelable) { event.preventDefault(); }
   var e = getPointerEvent(event);
   if (!draggableInfo) {
     initiateDrag(e, getElementCursor(event.target));
@@ -40539,7 +40520,6 @@ function handleMissedDragFrame () {
 function onMouseUp () {
   removeMoveListeners();
   removeReleaseListeners();
-  removeGrabListeners();
   if (handleScroll && typeof handleScroll === 'function') { handleScroll({ reset: true }); }
   if (cursorStyleElement) {
     removeStyle(cursorStyleElement);
@@ -42198,7 +42178,7 @@ function normalizeComponent(
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-!function(t,e){ true?module.exports=e():undefined}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="/",e(e.s=89)}([function(t,e){t.exports=function(t){try{return!!t()}catch(t){return!0}}},function(t,e,n){var r=n(35),i=Function.prototype,o=i.call,s=r&&i.bind.bind(o,o);t.exports=r?s:function(t){return function(){return o.apply(t,arguments)}}},function(t,e,n){var r=n(59),i=r.all;t.exports=r.IS_HTMLDDA?function(t){return"function"==typeof t||t===i}:function(t){return"function"==typeof t}},function(t,e,n){var r=n(4),i=n(43).f,o=n(30),s=n(11),u=n(33),a=n(95),l=n(66);t.exports=function(t,e){var n,c,f,p,h,d=t.target,v=t.global,g=t.stat;if(n=v?r:g?r[d]||u(d,{}):(r[d]||{}).prototype)for(c in e){if(p=e[c],t.dontCallGetSet?(h=i(n,c),f=h&&h.value):f=n[c],!l(v?c:d+(g?".":"#")+c,t.forced)&&void 0!==f){if(typeof p==typeof f)continue;a(p,f)}(t.sham||f&&f.sham)&&o(p,"sham",!0),s(n,c,p,t)}}},function(t,e,n){(function(e){var n=function(t){return t&&t.Math==Math&&t};t.exports=n("object"==typeof globalThis&&globalThis)||n("object"==typeof window&&window)||n("object"==typeof self&&self)||n("object"==typeof e&&e)||function(){return this}()||Function("return this")()}).call(e,n(139))},function(t,e,n){var r=n(0);t.exports=!r(function(){return 7!=Object.defineProperty({},1,{get:function(){return 7}})[1]})},function(t,e,n){var r=n(8),i=String,o=TypeError;t.exports=function(t){if(r(t))return t;throw o(i(t)+" is not an object")}},function(t,e,n){var r=n(1),i=n(14),o=r({}.hasOwnProperty);t.exports=Object.hasOwn||function(t,e){return o(i(t),e)}},function(t,e,n){var r=n(2),i=n(59),o=i.all;t.exports=i.IS_HTMLDDA?function(t){return"object"==typeof t?null!==t:r(t)||t===o}:function(t){return"object"==typeof t?null!==t:r(t)}},function(t,e,n){var r=n(4),i=n(47),o=n(7),s=n(75),u=n(72),a=n(76),l=i("wks"),c=r.Symbol,f=c&&c.for,p=a?c:c&&c.withoutSetter||s;t.exports=function(t){if(!o(l,t)||!u&&"string"!=typeof l[t]){var e="Symbol."+t;u&&o(c,t)?l[t]=c[t]:l[t]=a&&f?f(e):p(e)}return l[t]}},function(t,e,n){var r=n(123);t.exports=function(t){return r(t.length)}},function(t,e,n){var r=n(2),i=n(13),o=n(104),s=n(33);t.exports=function(t,e,n,u){u||(u={});var a=u.enumerable,l=void 0!==u.name?u.name:e;if(r(n)&&o(n,l,u),u.global)a?t[e]=n:s(e,n);else{try{u.unsafe?t[e]&&(a=!0):delete t[e]}catch(t){}a?t[e]=n:i.f(t,e,{value:n,enumerable:!1,configurable:!u.nonConfigurable,writable:!u.nonWritable})}return t}},function(t,e,n){var r=n(35),i=Function.prototype.call;t.exports=r?i.bind(i):function(){return i.apply(i,arguments)}},function(t,e,n){var r=n(5),i=n(62),o=n(77),s=n(6),u=n(50),a=TypeError,l=Object.defineProperty,c=Object.getOwnPropertyDescriptor;e.f=r?o?function(t,e,n){if(s(t),e=u(e),s(n),"function"==typeof t&&"prototype"===e&&"value"in n&&"writable"in n&&!n.writable){var r=c(t,e);r&&r.writable&&(t[e]=n.value,n={configurable:"configurable"in n?n.configurable:r.configurable,enumerable:"enumerable"in n?n.enumerable:r.enumerable,writable:!1})}return l(t,e,n)}:l:function(t,e,n){if(s(t),e=u(e),s(n),i)try{return l(t,e,n)}catch(t){}if("get"in n||"set"in n)throw a("Accessors not supported");return"value"in n&&(t[e]=n.value),t}},function(t,e,n){var r=n(24),i=Object;t.exports=function(t){return i(r(t))}},function(t,e,n){var r=n(1),i=r({}.toString),o=r("".slice);t.exports=function(t){return o(i(t),8,-1)}},function(t,e,n){var r=n(0),i=n(9),o=n(23),s=i("species");t.exports=function(t){return o>=51||!r(function(){var e=[],n=e.constructor={};return n[s]=function(){return{foo:1}},1!==e[t](Boolean).foo})}},function(t,e,n){var r=n(4),i=n(2),o=function(t){return i(t)?t:void 0};t.exports=function(t,e){return arguments.length<2?o(r[t]):r[t]&&r[t][e]}},function(t,e,n){var r=n(15);t.exports=Array.isArray||function(t){return"Array"==r(t)}},function(t,e,n){var r=n(39),i=n(24);t.exports=function(t){return r(i(t))}},function(t,e,n){var r=n(29),i=String;t.exports=function(t){if("Symbol"===r(t))throw TypeError("Cannot convert a Symbol value to a string");return i(t)}},function(t,e,n){var r=n(100),i=n(1),o=n(39),s=n(14),u=n(10),a=n(28),l=i([].push),c=function(t){var e=1==t,n=2==t,i=3==t,c=4==t,f=6==t,p=7==t,h=5==t||f;return function(d,v,g,y){for(var b,m,x=s(d),_=o(x),O=r(v,g),w=u(_),S=0,E=y||a,L=e?E(d,w):n||p?E(d,0):void 0;w>S;S++)if((h||S in _)&&(b=_[S],m=O(b,S,x),t))if(e)L[S]=m;else if(m)switch(t){case 3:return!0;case 5:return b;case 6:return S;case 2:l(L,b)}else switch(t){case 4:return!1;case 7:l(L,b)}return f?-1:i||c?c:L}};t.exports={forEach:c(0),map:c(1),filter:c(2),some:c(3),every:c(4),find:c(5),findIndex:c(6),filterReject:c(7)}},function(t,e){var n=TypeError;t.exports=function(t){if(t>9007199254740991)throw n("Maximum allowed index exceeded");return t}},function(t,e,n){var r,i,o=n(4),s=n(97),u=o.process,a=o.Deno,l=u&&u.versions||a&&a.version,c=l&&l.v8;c&&(r=c.split("."),i=r[0]>0&&r[0]<4?1:+(r[0]+r[1])),!i&&s&&(!(r=s.match(/Edge\/(\d+)/))||r[1]>=74)&&(r=s.match(/Chrome\/(\d+)/))&&(i=+r[1]),t.exports=i},function(t,e,n){var r=n(40),i=TypeError;t.exports=function(t){if(r(t))throw i("Can't call method on "+t);return t}},function(t,e,n){var r=n(2),i=n(74),o=TypeError;t.exports=function(t){if(r(t))return t;throw o(i(t)+" is not a function")}},function(t,e,n){"use strict";var r=n(0);t.exports=function(t,e){var n=[][t];return!!n&&r(function(){n.call(null,e||function(){return 1},1)})}},function(t,e,n){"use strict";var r=n(5),i=n(18),o=TypeError,s=Object.getOwnPropertyDescriptor,u=r&&!function(){if(void 0!==this)return!0;try{Object.defineProperty([],"length",{writable:!1}).length=1}catch(t){return t instanceof TypeError}}();t.exports=u?function(t,e){if(i(t)&&!s(t,"length").writable)throw o("Cannot set read only .length");return t.length=e}:function(t,e){return t.length=e}},function(t,e,n){var r=n(94);t.exports=function(t,e){return new(r(t))(0===e?0:e)}},function(t,e,n){var r=n(51),i=n(2),o=n(15),s=n(9),u=s("toStringTag"),a=Object,l="Arguments"==o(function(){return arguments}()),c=function(t,e){try{return t[e]}catch(t){}};t.exports=r?o:function(t){var e,n,r;return void 0===t?"Undefined":null===t?"Null":"string"==typeof(n=c(e=a(t),u))?n:l?o(e):"Object"==(r=o(e))&&i(e.callee)?"Arguments":r}},function(t,e,n){var r=n(5),i=n(13),o=n(31);t.exports=r?function(t,e,n){return i.f(t,e,o(1,n))}:function(t,e,n){return t[e]=n,t}},function(t,e){t.exports=function(t,e){return{enumerable:!(1&t),configurable:!(2&t),writable:!(4&t),value:e}}},function(t,e,n){"use strict";var r=n(50),i=n(13),o=n(31);t.exports=function(t,e,n){var s=r(e);s in t?i.f(t,s,o(0,n)):t[s]=n}},function(t,e,n){var r=n(4),i=Object.defineProperty;t.exports=function(t,e){try{i(r,t,{value:e,configurable:!0,writable:!0})}catch(n){r[t]=e}return e}},function(t,e){t.exports=["constructor","hasOwnProperty","isPrototypeOf","propertyIsEnumerable","toLocaleString","toString","valueOf"]},function(t,e,n){var r=n(0);t.exports=!r(function(){var t=function(){}.bind();return"function"!=typeof t||t.hasOwnProperty("prototype")})},function(t,e,n){var r=n(5),i=n(7),o=Function.prototype,s=r&&Object.getOwnPropertyDescriptor,u=i(o,"name"),a=u&&"something"===function(){}.name,l=u&&(!r||r&&s(o,"name").configurable);t.exports={EXISTS:u,PROPER:a,CONFIGURABLE:l}},function(t,e,n){var r=n(15),i=n(1);t.exports=function(t){if("Function"===r(t))return i(t)}},function(t,e){t.exports={}},function(t,e,n){var r=n(1),i=n(0),o=n(15),s=Object,u=r("".split);t.exports=i(function(){return!s("z").propertyIsEnumerable(0)})?function(t){return"String"==o(t)?u(t,""):s(t)}:s},function(t,e){t.exports=function(t){return null===t||void 0===t}},function(t,e,n){var r=n(17),i=n(2),o=n(44),s=n(76),u=Object;t.exports=s?function(t){return"symbol"==typeof t}:function(t){var e=r("Symbol");return i(e)&&o(e.prototype,u(t))}},function(t,e,n){var r,i=n(6),o=n(107),s=n(34),u=n(38),a=n(101),l=n(60),c=n(70),f=c("IE_PROTO"),p=function(){},h=function(t){return"<script>"+t+"<\/script>"},d=function(t){t.write(h("")),t.close();var e=t.parentWindow.Object;return t=null,e},v=function(){var t,e=l("iframe");return e.style.display="none",a.appendChild(e),e.src=String("javascript:"),t=e.contentWindow.document,t.open(),t.write(h("document.F=Object")),t.close(),t.F},g=function(){try{r=new ActiveXObject("htmlfile")}catch(t){}g="undefined"!=typeof document?document.domain&&r?d(r):v():d(r);for(var t=s.length;t--;)delete g.prototype[s[t]];return g()};u[f]=!0,t.exports=Object.create||function(t,e){var n;return null!==t?(p.prototype=i(t),n=new p,p.prototype=null,n[f]=t):n=g(),void 0===e?n:o.f(n,e)}},function(t,e,n){var r=n(5),i=n(12),o=n(110),s=n(31),u=n(19),a=n(50),l=n(7),c=n(62),f=Object.getOwnPropertyDescriptor;e.f=r?f:function(t,e){if(t=u(t),e=a(e),c)try{return f(t,e)}catch(t){}if(l(t,e))return s(!i(o.f,t,e),t[e])}},function(t,e,n){var r=n(1);t.exports=r({}.isPrototypeOf)},function(t,e,n){"use strict";var r=n(12),i=n(1),o=n(20),s=n(69),u=n(117),a=n(47),l=n(42),c=n(64).get,f=n(118),p=n(119),h=a("native-string-replace",String.prototype.replace),d=RegExp.prototype.exec,v=d,g=i("".charAt),y=i("".indexOf),b=i("".replace),m=i("".slice),x=function(){var t=/a/,e=/b*/g;return r(d,t,"a"),r(d,e,"a"),0!==t.lastIndex||0!==e.lastIndex}(),_=u.BROKEN_CARET,O=void 0!==/()??/.exec("")[1];(x||O||_||f||p)&&(v=function(t){var e,n,i,u,a,f,p,w=this,S=c(w),E=o(t),L=S.raw;if(L)return L.lastIndex=w.lastIndex,e=r(v,L,E),w.lastIndex=L.lastIndex,e;var k=S.groups,P=_&&w.sticky,j=r(s,w),T=w.source,A=0,V=E;if(P&&(j=b(j,"y",""),-1===y(j,"g")&&(j+="g"),V=m(E,w.lastIndex),w.lastIndex>0&&(!w.multiline||w.multiline&&"\n"!==g(E,w.lastIndex-1))&&(T="(?: "+T+")",V=" "+V,A++),n=new RegExp("^(?:"+T+")",j)),O&&(n=new RegExp("^"+T+"$(?!\\s)",j)),x&&(i=w.lastIndex),u=r(d,P?n:w,V),P?u?(u.input=m(u.input,A),u[0]=m(u[0],A),u.index=w.lastIndex,w.lastIndex+=u[0].length):w.lastIndex=0:x&&u&&(w.lastIndex=w.global?u.index+u[0].length:i),O&&u&&u.length>1&&r(h,u[0],n,function(){for(a=1;a<arguments.length-2;a++)void 0===arguments[a]&&(u[a]=void 0)}),u&&k)for(u.groups=f=l(null),a=0;a<k.length;a++)p=k[a],f[p[0]]=u[p[1]];return u}),t.exports=v},function(t,e,n){var r=n(4),i=n(33),o=r["__core-js_shared__"]||i("__core-js_shared__",{});t.exports=o},function(t,e,n){var r=n(103),i=n(46);(t.exports=function(t,e){return i[t]||(i[t]=void 0!==e?e:{})})("versions",[]).push({version:"3.26.1",mode:r?"pure":"global",copyright:"© 2014-2022 Denis Pushkarev (zloirock.ru)",license:"https://github.com/zloirock/core-js/blob/v3.26.1/LICENSE",source:"https://github.com/zloirock/core-js"})},function(t,e,n){var r=n(49),i=Math.max,o=Math.min;t.exports=function(t,e){var n=r(t);return n<0?i(n+e,0):o(n,e)}},function(t,e,n){var r=n(105);t.exports=function(t){var e=+t;return e!==e||0===e?0:r(e)}},function(t,e,n){var r=n(73),i=n(41);t.exports=function(t){var e=r(t,"string");return i(e)?e:e+""}},function(t,e,n){var r=n(9),i=r("toStringTag"),o={};o[i]="z",t.exports="[object z]"===String(o)},function(t,e,n){"use strict";var r=n(5),i=n(4),o=n(1),s=n(66),u=n(11),a=n(7),l=n(102),c=n(44),f=n(41),p=n(73),h=n(0),d=n(67).f,v=n(43).f,g=n(13).f,y=n(122),b=n(71).trim,m=i.Number,x=m.prototype,_=i.TypeError,O=o("".slice),w=o("".charCodeAt),S=function(t){var e=p(t,"number");return"bigint"==typeof e?e:E(e)},E=function(t){var e,n,r,i,o,s,u,a,l=p(t,"number");if(f(l))throw _("Cannot convert a Symbol value to a number");if("string"==typeof l&&l.length>2)if(l=b(l),43===(e=w(l,0))||45===e){if(88===(n=w(l,2))||120===n)return NaN}else if(48===e){switch(w(l,1)){case 66:case 98:r=2,i=49;break;case 79:case 111:r=8,i=55;break;default:return+l}for(o=O(l,2),s=o.length,u=0;u<s;u++)if((a=w(o,u))<48||a>i)return NaN;return parseInt(o,r)}return+l};if(s("Number",!m(" 0o1")||!m("0b1")||m("+0x1"))){for(var L,k=function(t){var e=arguments.length<1?0:m(S(t)),n=this;return c(x,n)&&h(function(){y(n)})?l(Object(e),n,k):e},P=r?d(m):"MAX_VALUE,MIN_VALUE,NaN,NEGATIVE_INFINITY,POSITIVE_INFINITY,EPSILON,MAX_SAFE_INTEGER,MIN_SAFE_INTEGER,isFinite,isInteger,isNaN,isSafeInteger,parseFloat,parseInt,fromString,range".split(","),j=0;P.length>j;j++)a(m,L=P[j])&&!a(k,L)&&g(k,L,v(m,L));k.prototype=x,x.constructor=k,u(i,"Number",k,{constructor:!0})}},function(t,e,n){"use strict";var r=n(3),i=n(45);r({target:"RegExp",proto:!0,forced:/./.exec!==i},{exec:i})},function(t,e,n){"use strict";function r(t){return 0!==t&&(!(!Array.isArray(t)||0!==t.length)||!t)}function i(t){return function(){return!t.apply(void 0,arguments)}}function o(t,e){return void 0===t&&(t="undefined"),null===t&&(t="null"),!1===t&&(t="false"),-1!==t.toString().toLowerCase().indexOf(e.trim())}function s(t,e,n,r){return t.filter(function(t){return o(r(t,n),e)})}function u(t){return t.filter(function(t){return!t.$isLabel})}function a(t,e){return function(n){return n.reduce(function(n,r){return r[t]&&r[t].length?(n.push({$groupLabel:r[e],$isLabel:!0}),n.concat(r[t])):n},[])}}function l(t,e,r,i,o){return function(u){return u.map(function(u){var a;if(!u[r])return console.warn("Options passed to vue-multiselect do not contain groups, despite the config."),[];var l=s(u[r],t,e,o);return l.length?(a={},n.i(f.a)(a,i,u[i]),n.i(f.a)(a,r,l),a):[]})}}var c=n(88),f=n(87),p=n(129),h=(n.n(p),n(82)),d=(n.n(h),n(81)),v=(n.n(d),n(83)),g=(n.n(v),n(84)),y=(n.n(g),n(128)),b=(n.n(y),n(135)),m=(n.n(b),n(127)),x=(n.n(m),n(132)),_=(n.n(x),n(131)),O=(n.n(_),n(125)),w=(n.n(O),n(130)),S=(n.n(w),n(52)),E=(n.n(S),n(53)),L=(n.n(E),n(85)),k=(n.n(L),n(134)),P=(n.n(k),n(80)),j=(n.n(P),n(79)),T=(n.n(j),n(133)),A=(n.n(T),n(126)),V=(n.n(A),function(){for(var t=arguments.length,e=new Array(t),n=0;n<t;n++)e[n]=arguments[n];return function(t){return e.reduce(function(t,e){return e(t)},t)}});e.a={data:function(){return{search:"",isOpen:!1,preferredOpenDirection:"below",optimizedHeight:this.maxHeight}},props:{internalSearch:{type:Boolean,default:!0},options:{type:Array,required:!0},multiple:{type:Boolean,default:!1},value:{type:null,default:function(){return[]}},trackBy:{type:String},label:{type:String},searchable:{type:Boolean,default:!0},clearOnSelect:{type:Boolean,default:!0},hideSelected:{type:Boolean,default:!1},placeholder:{type:String,default:"Select option"},allowEmpty:{type:Boolean,default:!0},resetAfter:{type:Boolean,default:!1},closeOnSelect:{type:Boolean,default:!0},customLabel:{type:Function,default:function(t,e){return r(t)?"":e?t[e]:t}},taggable:{type:Boolean,default:!1},tagPlaceholder:{type:String,default:"Press enter to create a tag"},tagPosition:{type:String,default:"top"},max:{type:[Number,Boolean],default:!1},id:{default:null},optionsLimit:{type:Number,default:1e3},groupValues:{type:String},groupLabel:{type:String},groupSelect:{type:Boolean,default:!1},blockKeys:{type:Array,default:function(){return[]}},preserveSearch:{type:Boolean,default:!1},preselectFirst:{type:Boolean,default:!1},preventAutofocus:{type:Boolean,default:!1}},mounted:function(){!this.multiple&&this.max&&console.warn("[Vue-Multiselect warn]: Max prop should not be used when prop Multiple equals false."),this.preselectFirst&&!this.internalValue.length&&this.options.length&&this.select(this.filteredOptions[0])},computed:{internalValue:function(){return this.value||0===this.value?Array.isArray(this.value)?this.value:[this.value]:[]},filteredOptions:function(){var t=this.search||"",e=t.toLowerCase().trim(),n=this.options.concat();return n=this.internalSearch?this.groupValues?this.filterAndFlat(n,e,this.label):s(n,e,this.label,this.customLabel):this.groupValues?a(this.groupValues,this.groupLabel)(n):n,n=this.hideSelected?n.filter(i(this.isSelected)):n,this.taggable&&e.length&&!this.isExistingOption(e)&&("bottom"===this.tagPosition?n.push({isTag:!0,label:t}):n.unshift({isTag:!0,label:t})),n.slice(0,this.optionsLimit)},valueKeys:function(){var t=this;return this.trackBy?this.internalValue.map(function(e){return e[t.trackBy]}):this.internalValue},optionKeys:function(){var t=this;return(this.groupValues?this.flatAndStrip(this.options):this.options).map(function(e){return t.customLabel(e,t.label).toString().toLowerCase()})},currentOptionLabel:function(){return this.multiple?this.searchable?"":this.placeholder:this.internalValue.length?this.getOptionLabel(this.internalValue[0]):this.searchable?"":this.placeholder}},watch:{internalValue:function(){this.resetAfter&&this.internalValue.length&&(this.search="",this.$emit("input",this.multiple?[]:null))},search:function(){this.$emit("search-change",this.search,this.id)}},methods:{getValue:function(){return this.multiple?this.internalValue:0===this.internalValue.length?null:this.internalValue[0]},filterAndFlat:function(t,e,n){return V(l(e,n,this.groupValues,this.groupLabel,this.customLabel),a(this.groupValues,this.groupLabel))(t)},flatAndStrip:function(t){return V(a(this.groupValues,this.groupLabel),u)(t)},updateSearch:function(t){this.search=t},isExistingOption:function(t){return!!this.options&&this.optionKeys.indexOf(t)>-1},isSelected:function(t){var e=this.trackBy?t[this.trackBy]:t;return this.valueKeys.indexOf(e)>-1},isOptionDisabled:function(t){return!!t.$isDisabled},getOptionLabel:function(t){if(r(t))return"";if(t.isTag)return t.label;if(t.$isLabel)return t.$groupLabel;var e=this.customLabel(t,this.label);return r(e)?"":e},select:function(t,e){if(t.$isLabel&&this.groupSelect)return void this.selectGroup(t);if(!(-1!==this.blockKeys.indexOf(e)||this.disabled||t.$isDisabled||t.$isLabel)&&(!this.max||!this.multiple||this.internalValue.length!==this.max)&&("Tab"!==e||this.pointerDirty)){if(t.isTag)this.$emit("tag",t.label,this.id),this.search="",this.closeOnSelect&&!this.multiple&&this.deactivate();else{if(this.isSelected(t))return void("Tab"!==e&&this.removeElement(t));this.multiple?this.$emit("input",this.internalValue.concat([t]),this.id):this.$emit("input",t,this.id),this.$emit("select",t,this.id),this.clearOnSelect&&(this.search="")}this.closeOnSelect&&this.deactivate()}},selectGroup:function(t){var e=this,n=this.options.find(function(n){return n[e.groupLabel]===t.$groupLabel});if(n){if(this.wholeGroupSelected(n)){this.$emit("remove",n[this.groupValues],this.id);var r=this.internalValue.filter(function(t){return-1===n[e.groupValues].indexOf(t)});this.$emit("input",r,this.id)}else{var i=n[this.groupValues].filter(function(t){return!(e.isOptionDisabled(t)||e.isSelected(t))});this.max&&i.splice(this.max-this.internalValue.length),this.$emit("select",i,this.id),this.$emit("input",this.internalValue.concat(i),this.id)}this.closeOnSelect&&this.deactivate()}},wholeGroupSelected:function(t){var e=this;return t[this.groupValues].every(function(t){return e.isSelected(t)||e.isOptionDisabled(t)})},wholeGroupDisabled:function(t){return t[this.groupValues].every(this.isOptionDisabled)},removeElement:function(t){var e=!(arguments.length>1&&void 0!==arguments[1])||arguments[1];if(!this.disabled&&!t.$isDisabled){if(!this.allowEmpty&&this.internalValue.length<=1)return void this.deactivate();var r="object"===n.i(c.a)(t)?this.valueKeys.indexOf(t[this.trackBy]):this.valueKeys.indexOf(t);if(this.multiple){var i=this.internalValue.slice(0,r).concat(this.internalValue.slice(r+1));this.$emit("input",i,this.id)}else this.$emit("input",null,this.id);this.$emit("remove",t,this.id),this.closeOnSelect&&e&&this.deactivate()}},removeLastElement:function(){-1===this.blockKeys.indexOf("Delete")&&0===this.search.length&&Array.isArray(this.internalValue)&&this.internalValue.length&&this.removeElement(this.internalValue[this.internalValue.length-1],!1)},activate:function(){var t=this;this.isOpen||this.disabled||(this.adjustPosition(),this.groupValues&&0===this.pointer&&this.filteredOptions.length&&(this.pointer=1),this.isOpen=!0,this.searchable?(this.preserveSearch||(this.search=""),this.preventAutofocus||this.$nextTick(function(){return t.$refs.search&&t.$refs.search.focus()})):this.preventAutofocus||void 0!==this.$el&&this.$el.focus(),this.$emit("open",this.id))},deactivate:function(){this.isOpen&&(this.isOpen=!1,this.searchable?null!==this.$refs.search&&void 0!==this.$refs.search&&this.$refs.search.blur():void 0!==this.$el&&this.$el.blur(),this.preserveSearch||(this.search=""),this.$emit("close",this.getValue(),this.id))},toggle:function(){this.isOpen?this.deactivate():this.activate()},adjustPosition:function(){if("undefined"!=typeof window){var t=this.$el.getBoundingClientRect().top,e=window.innerHeight-this.$el.getBoundingClientRect().bottom;e>this.maxHeight||e>t||"below"===this.openDirection||"bottom"===this.openDirection?(this.preferredOpenDirection="below",this.optimizedHeight=Math.min(e-40,this.maxHeight)):(this.preferredOpenDirection="above",this.optimizedHeight=Math.min(t-40,this.maxHeight))}}}}},function(t,e,n){"use strict";var r=n(52),i=(n.n(r),n(53)),o=(n.n(i),n(85)),s=(n.n(o),n(82)),u=(n.n(s),n(81)),a=(n.n(u),n(83)),l=(n.n(a),n(84)),c=(n.n(l),n(79));n.n(c);e.a={data:function(){return{pointer:0,pointerDirty:!1}},props:{showPointer:{type:Boolean,default:!0},optionHeight:{type:Number,default:40}},computed:{pointerPosition:function(){return this.pointer*this.optionHeight},visibleElements:function(){return this.optimizedHeight/this.optionHeight}},watch:{filteredOptions:function(){this.pointerAdjust()},isOpen:function(){this.pointerDirty=!1},pointer:function(){this.$refs.search&&this.$refs.search.setAttribute("aria-activedescendant",this.id+"-"+this.pointer.toString())}},methods:{optionHighlight:function(t,e){return{"multiselect__option--highlight":t===this.pointer&&this.showPointer,"multiselect__option--selected":this.isSelected(e)}},groupHighlight:function(t,e){var n=this;if(!this.groupSelect)return["multiselect__option--disabled",{"multiselect__option--group":e.$isLabel}];var r=this.options.find(function(t){return t[n.groupLabel]===e.$groupLabel});return r&&!this.wholeGroupDisabled(r)?["multiselect__option--group",{"multiselect__option--highlight":t===this.pointer&&this.showPointer},{"multiselect__option--group-selected":this.wholeGroupSelected(r)}]:"multiselect__option--disabled"},addPointerElement:function(){var t=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"Enter",e=t.key;this.filteredOptions.length>0&&this.select(this.filteredOptions[this.pointer],e),this.pointerReset()},pointerForward:function(){this.pointer<this.filteredOptions.length-1&&(this.pointer++,this.$refs.list.scrollTop<=this.pointerPosition-(this.visibleElements-1)*this.optionHeight&&(this.$refs.list.scrollTop=this.pointerPosition-(this.visibleElements-1)*this.optionHeight),this.filteredOptions[this.pointer]&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerForward()),this.pointerDirty=!0},pointerBackward:function(){this.pointer>0?(this.pointer--,this.$refs.list.scrollTop>=this.pointerPosition&&(this.$refs.list.scrollTop=this.pointerPosition),this.filteredOptions[this.pointer]&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerBackward()):this.filteredOptions[this.pointer]&&this.filteredOptions[0].$isLabel&&!this.groupSelect&&this.pointerForward(),this.pointerDirty=!0},pointerReset:function(){this.closeOnSelect&&(this.pointer=0,this.$refs.list&&(this.$refs.list.scrollTop=0))},pointerAdjust:function(){this.pointer>=this.filteredOptions.length-1&&(this.pointer=this.filteredOptions.length?this.filteredOptions.length-1:0),this.filteredOptions.length>0&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerForward()},pointerSet:function(t){this.pointer=t,this.pointerDirty=!0}}}},function(t,e,n){"use strict";var r=n(52),i=(n.n(r),n(80)),o=(n.n(i),n(54)),s=n(55);e.a={name:"vue-multiselect",mixins:[o.a,s.a],props:{name:{type:String,default:""},selectLabel:{type:String,default:"Press enter to select"},selectGroupLabel:{type:String,default:"Press enter to select group"},selectedLabel:{type:String,default:"Selected"},deselectLabel:{type:String,default:"Press enter to remove"},deselectGroupLabel:{type:String,default:"Press enter to deselect group"},showLabels:{type:Boolean,default:!0},limit:{type:Number,default:99999},maxHeight:{type:Number,default:300},limitText:{type:Function,default:function(t){return"and ".concat(t," more")}},loading:{type:Boolean,default:!1},disabled:{type:Boolean,default:!1},openDirection:{type:String,default:""},showNoOptions:{type:Boolean,default:!0},showNoResults:{type:Boolean,default:!0},tabindex:{type:Number,default:0}},computed:{hasOptionGroup:function(){return this.groupValues&&this.groupLabel&&this.groupSelect},isSingleLabelVisible:function(){return(this.singleValue||0===this.singleValue)&&(!this.isOpen||!this.searchable)&&!this.visibleValues.length},isPlaceholderVisible:function(){return!(this.internalValue.length||this.searchable&&this.isOpen)},visibleValues:function(){return this.multiple?this.internalValue.slice(0,this.limit):[]},singleValue:function(){return this.internalValue[0]},deselectLabelText:function(){return this.showLabels?this.deselectLabel:""},deselectGroupLabelText:function(){return this.showLabels?this.deselectGroupLabel:""},selectLabelText:function(){return this.showLabels?this.selectLabel:""},selectGroupLabelText:function(){return this.showLabels?this.selectGroupLabel:""},selectedLabelText:function(){return this.showLabels?this.selectedLabel:""},inputStyle:function(){return this.searchable||this.multiple&&this.value&&this.value.length?this.isOpen?{width:"100%"}:{width:"0",position:"absolute",padding:"0"}:""},contentStyle:function(){return this.options.length?{display:"inline-block"}:{display:"block"}},isAbove:function(){return"above"===this.openDirection||"top"===this.openDirection||"below"!==this.openDirection&&"bottom"!==this.openDirection&&"above"===this.preferredOpenDirection},showSearchInput:function(){return this.searchable&&(!this.hasSingleSelectedSlot||!this.visibleSingleValue&&0!==this.visibleSingleValue||this.isOpen)}}}},function(t,e,n){var r=n(19),i=n(48),o=n(10),s=function(t){return function(e,n,s){var u,a=r(e),l=o(a),c=i(s,l);if(t&&n!=n){for(;l>c;)if((u=a[c++])!=u)return!0}else for(;l>c;c++)if((t||c in a)&&a[c]===n)return t||c||0;return!t&&-1}};t.exports={includes:s(!0),indexOf:s(!1)}},function(t,e,n){"use strict";var r=n(74),i=TypeError;t.exports=function(t,e){if(!delete t[e])throw i("Cannot delete property "+r(e)+" of "+r(t))}},function(t,e){var n="object"==typeof document&&document.all,r=void 0===n&&void 0!==n;t.exports={all:n,IS_HTMLDDA:r}},function(t,e,n){var r=n(4),i=n(8),o=r.document,s=i(o)&&i(o.createElement);t.exports=function(t){return s?o.createElement(t):{}}},function(t,e,n){var r=n(25),i=n(40);t.exports=function(t,e){var n=t[e];return i(n)?void 0:r(n)}},function(t,e,n){var r=n(5),i=n(0),o=n(60);t.exports=!r&&!i(function(){return 7!=Object.defineProperty(o("div"),"a",{get:function(){return 7}}).a})},function(t,e,n){var r=n(1),i=n(2),o=n(46),s=r(Function.toString);i(o.inspectSource)||(o.inspectSource=function(t){return s(t)}),t.exports=o.inspectSource},function(t,e,n){var r,i,o,s=n(124),u=n(4),a=n(8),l=n(30),c=n(7),f=n(46),p=n(70),h=n(38),d=u.TypeError,v=u.WeakMap,g=function(t){return o(t)?i(t):r(t,{})},y=function(t){return function(e){var n;if(!a(e)||(n=i(e)).type!==t)throw d("Incompatible receiver, "+t+" required");return n}};if(s||f.state){var b=f.state||(f.state=new v);b.get=b.get,b.has=b.has,b.set=b.set,r=function(t,e){if(b.has(t))throw d("Object already initialized");return e.facade=t,b.set(t,e),e},i=function(t){return b.get(t)||{}},o=function(t){return b.has(t)}}else{var m=p("state");h[m]=!0,r=function(t,e){if(c(t,m))throw d("Object already initialized");return e.facade=t,l(t,m,e),e},i=function(t){return c(t,m)?t[m]:{}},o=function(t){return c(t,m)}}t.exports={set:r,get:i,has:o,enforce:g,getterFor:y}},function(t,e,n){var r=n(1),i=n(0),o=n(2),s=n(29),u=n(17),a=n(63),l=function(){},c=[],f=u("Reflect","construct"),p=/^\s*(?:class|function)\b/,h=r(p.exec),d=!p.exec(l),v=function(t){if(!o(t))return!1;try{return f(l,c,t),!0}catch(t){return!1}},g=function(t){if(!o(t))return!1;switch(s(t)){case"AsyncFunction":case"GeneratorFunction":case"AsyncGeneratorFunction":return!1}try{return d||!!h(p,a(t))}catch(t){return!0}};g.sham=!0,t.exports=!f||i(function(){var t;return v(v.call)||!v(Object)||!v(function(){t=!0})||t})?g:v},function(t,e,n){var r=n(0),i=n(2),o=/#|\.prototype\./,s=function(t,e){var n=a[u(t)];return n==c||n!=l&&(i(e)?r(e):!!e)},u=s.normalize=function(t){return String(t).replace(o,".").toLowerCase()},a=s.data={},l=s.NATIVE="N",c=s.POLYFILL="P";t.exports=s},function(t,e,n){var r=n(68),i=n(34),o=i.concat("length","prototype");e.f=Object.getOwnPropertyNames||function(t){return r(t,o)}},function(t,e,n){var r=n(1),i=n(7),o=n(19),s=n(57).indexOf,u=n(38),a=r([].push);t.exports=function(t,e){var n,r=o(t),l=0,c=[];for(n in r)!i(u,n)&&i(r,n)&&a(c,n);for(;e.length>l;)i(r,n=e[l++])&&(~s(c,n)||a(c,n));return c}},function(t,e,n){"use strict";var r=n(6);t.exports=function(){var t=r(this),e="";return t.hasIndices&&(e+="d"),t.global&&(e+="g"),t.ignoreCase&&(e+="i"),t.multiline&&(e+="m"),t.dotAll&&(e+="s"),t.unicode&&(e+="u"),t.unicodeSets&&(e+="v"),t.sticky&&(e+="y"),e}},function(t,e,n){var r=n(47),i=n(75),o=r("keys");t.exports=function(t){return o[t]||(o[t]=i(t))}},function(t,e,n){var r=n(1),i=n(24),o=n(20),s=n(78),u=r("".replace),a="["+s+"]",l=RegExp("^"+a+a+"*"),c=RegExp(a+a+"*$"),f=function(t){return function(e){var n=o(i(e));return 1&t&&(n=u(n,l,"")),2&t&&(n=u(n,c,"")),n}};t.exports={start:f(1),end:f(2),trim:f(3)}},function(t,e,n){var r=n(23),i=n(0);t.exports=!!Object.getOwnPropertySymbols&&!i(function(){var t=Symbol();return!String(t)||!(Object(t)instanceof Symbol)||!Symbol.sham&&r&&r<41})},function(t,e,n){var r=n(12),i=n(8),o=n(41),s=n(61),u=n(113),a=n(9),l=TypeError,c=a("toPrimitive");t.exports=function(t,e){if(!i(t)||o(t))return t;var n,a=s(t,c);if(a){if(void 0===e&&(e="default"),n=r(a,t,e),!i(n)||o(n))return n;throw l("Can't convert object to primitive value")}return void 0===e&&(e="number"),u(t,e)}},function(t,e){var n=String;t.exports=function(t){try{return n(t)}catch(t){return"Object"}}},function(t,e,n){var r=n(1),i=0,o=Math.random(),s=r(1..toString);t.exports=function(t){return"Symbol("+(void 0===t?"":t)+")_"+s(++i+o,36)}},function(t,e,n){var r=n(72);t.exports=r&&!Symbol.sham&&"symbol"==typeof Symbol.iterator},function(t,e,n){var r=n(5),i=n(0);t.exports=r&&i(function(){return 42!=Object.defineProperty(function(){},"prototype",{value:42,writable:!1}).prototype})},function(t,e){t.exports="\t\n\v\f\r                　\u2028\u2029\ufeff"},function(t,e,n){"use strict";var r=n(3),i=n(21).find,o=n(91),s=!0;"find"in[]&&Array(1).find(function(){s=!1}),r({target:"Array",proto:!0,forced:s},{find:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}}),o("find")},function(t,e,n){"use strict";var r=n(3),i=n(18),o=n(65),s=n(8),u=n(48),a=n(10),l=n(19),c=n(32),f=n(9),p=n(16),h=n(93),d=p("slice"),v=f("species"),g=Array,y=Math.max;r({target:"Array",proto:!0,forced:!d},{slice:function(t,e){var n,r,f,p=l(this),d=a(p),b=u(t,d),m=u(void 0===e?d:e,d);if(i(p)&&(n=p.constructor,o(n)&&(n===g||i(n.prototype))?n=void 0:s(n)&&null===(n=n[v])&&(n=void 0),n===g||void 0===n))return h(p,b,m);for(r=new(void 0===n?g:n)(y(m-b,0)),f=0;b<m;b++,f++)b in p&&c(r,f,p[b]);return r.length=f,r}})},function(t,e,n){var r=n(1),i=n(11),o=Date.prototype,s=r(o.toString),u=r(o.getTime);"Invalid Date"!=String(new Date(NaN))&&i(o,"toString",function(){var t=u(this);return t===t?s(this):"Invalid Date"})},function(t,e,n){var r=n(11),i=n(98),o=Error.prototype;o.toString!==i&&r(o,"toString",i)},function(t,e,n){var r=n(51),i=n(11),o=n(112);r||i(Object.prototype,"toString",o,{unsafe:!0})},function(t,e,n){"use strict";var r=n(36).PROPER,i=n(11),o=n(6),s=n(20),u=n(0),a=n(116),l=RegExp.prototype,c=l.toString,f=u(function(){return"/a/b"!=c.call({source:"a",flags:"b"})}),p=r&&"toString"!=c.name;(f||p)&&i(RegExp.prototype,"toString",function(){var t=o(this);return"/"+s(t.source)+"/"+s(a(t))},{unsafe:!0})},function(t,e,n){"use strict";var r=n(12),i=n(99),o=n(6),s=n(40),u=n(24),a=n(120),l=n(20),c=n(61),f=n(115);i("search",function(t,e,n){return[function(e){var n=u(this),i=s(e)?void 0:c(e,t);return i?r(i,e,n):new RegExp(e)[t](l(n))},function(t){var r=o(this),i=l(t),s=n(e,r,i);if(s.done)return s.value;var u=r.lastIndex;a(u,0)||(r.lastIndex=0);var c=f(r,i);return a(r.lastIndex,u)||(r.lastIndex=u),null===c?-1:c.index}]})},function(t,e,n){"use strict";function r(t){n(136)}var i=n(56),o=n(138),s=n(137),u=r,a=s(i.a,o.a,!1,u,null,null);e.a=a.exports},function(t,e,n){"use strict";function r(t,e,n){return e in t?Object.defineProperty(t,e,{value:n,enumerable:!0,configurable:!0,writable:!0}):t[e]=n,t}e.a=r},function(t,e,n){"use strict";function r(t){"@babel/helpers - typeof";return(r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(t){return typeof t}:function(t){return t&&"function"==typeof Symbol&&t.constructor===Symbol&&t!==Symbol.prototype?"symbol":typeof t})(t)}e.a=r},function(t,e,n){"use strict";Object.defineProperty(e,"__esModule",{value:!0});var r=n(86),i=n(54),o=n(55);n.d(e,"Multiselect",function(){return r.a}),n.d(e,"multiselectMixin",function(){return i.a}),n.d(e,"pointerMixin",function(){return o.a}),e.default=r.a},function(t,e,n){var r=n(2),i=String,o=TypeError;t.exports=function(t){if("object"==typeof t||r(t))return t;throw o("Can't set "+i(t)+" as a prototype")}},function(t,e,n){var r=n(9),i=n(42),o=n(13).f,s=r("unscopables"),u=Array.prototype;void 0==u[s]&&o(u,s,{configurable:!0,value:i(null)}),t.exports=function(t){u[s][t]=!0}},function(t,e,n){var r=n(25),i=n(14),o=n(39),s=n(10),u=TypeError,a=function(t){return function(e,n,a,l){r(n);var c=i(e),f=o(c),p=s(c),h=t?p-1:0,d=t?-1:1;if(a<2)for(;;){if(h in f){l=f[h],h+=d;break}if(h+=d,t?h<0:p<=h)throw u("Reduce of empty array with no initial value")}for(;t?h>=0:p>h;h+=d)h in f&&(l=n(l,f[h],h,c));return l}};t.exports={left:a(!1),right:a(!0)}},function(t,e,n){var r=n(1);t.exports=r([].slice)},function(t,e,n){var r=n(18),i=n(65),o=n(8),s=n(9),u=s("species"),a=Array;t.exports=function(t){var e;return r(t)&&(e=t.constructor,i(e)&&(e===a||r(e.prototype))?e=void 0:o(e)&&null===(e=e[u])&&(e=void 0)),void 0===e?a:e}},function(t,e,n){var r=n(7),i=n(114),o=n(43),s=n(13);t.exports=function(t,e,n){for(var u=i(e),a=s.f,l=o.f,c=0;c<u.length;c++){var f=u[c];r(t,f)||n&&r(n,f)||a(t,f,l(e,f))}}},function(t,e,n){var r=n(15),i=n(4);t.exports="process"==r(i.process)},function(t,e,n){var r=n(17);t.exports=r("navigator","userAgent")||""},function(t,e,n){"use strict";var r=n(5),i=n(0),o=n(6),s=n(42),u=n(106),a=Error.prototype.toString,l=i(function(){if(r){var t=s(Object.defineProperty({},"name",{get:function(){return this===t}}));if("true"!==a.call(t))return!0}return"2: 1"!==a.call({message:1,name:2})||"Error"!==a.call({})});t.exports=l?function(){var t=o(this),e=u(t.name,"Error"),n=u(t.message);return e?n?e+": "+n:e:n}:a},function(t,e,n){"use strict";n(53);var r=n(37),i=n(11),o=n(45),s=n(0),u=n(9),a=n(30),l=u("species"),c=RegExp.prototype;t.exports=function(t,e,n,f){var p=u(t),h=!s(function(){var e={};return e[p]=function(){return 7},7!=""[t](e)}),d=h&&!s(function(){var e=!1,n=/a/;return"split"===t&&(n={},n.constructor={},n.constructor[l]=function(){return n},n.flags="",n[p]=/./[p]),n.exec=function(){return e=!0,null},n[p](""),!e});if(!h||!d||n){var v=r(/./[p]),g=e(p,""[t],function(t,e,n,i,s){var u=r(t),a=e.exec;return a===o||a===c.exec?h&&!s?{done:!0,value:v(e,n,i)}:{done:!0,value:u(n,e,i)}:{done:!1}});i(String.prototype,t,g[0]),i(c,p,g[1])}f&&a(c[p],"sham",!0)}},function(t,e,n){var r=n(37),i=n(25),o=n(35),s=r(r.bind);t.exports=function(t,e){return i(t),void 0===e?t:o?s(t,e):function(){return t.apply(e,arguments)}}},function(t,e,n){var r=n(17);t.exports=r("document","documentElement")},function(t,e,n){var r=n(2),i=n(8),o=n(111);t.exports=function(t,e,n){var s,u;return o&&r(s=e.constructor)&&s!==n&&i(u=s.prototype)&&u!==n.prototype&&o(t,u),t}},function(t,e){t.exports=!1},function(t,e,n){var r=n(0),i=n(2),o=n(7),s=n(5),u=n(36).CONFIGURABLE,a=n(63),l=n(64),c=l.enforce,f=l.get,p=Object.defineProperty,h=s&&!r(function(){return 8!==p(function(){},"length",{value:8}).length}),d=String(String).split("String"),v=t.exports=function(t,e,n){"Symbol("===String(e).slice(0,7)&&(e="["+String(e).replace(/^Symbol\(([^)]*)\)/,"$1")+"]"),n&&n.getter&&(e="get "+e),n&&n.setter&&(e="set "+e),(!o(t,"name")||u&&t.name!==e)&&(s?p(t,"name",{value:e,configurable:!0}):t.name=e),h&&n&&o(n,"arity")&&t.length!==n.arity&&p(t,"length",{value:n.arity});try{n&&o(n,"constructor")&&n.constructor?s&&p(t,"prototype",{writable:!1}):t.prototype&&(t.prototype=void 0)}catch(t){}var r=c(t);return o(r,"source")||(r.source=d.join("string"==typeof e?e:"")),t};Function.prototype.toString=v(function(){return i(this)&&f(this).source||a(this)},"toString")},function(t,e){var n=Math.ceil,r=Math.floor;t.exports=Math.trunc||function(t){var e=+t;return(e>0?r:n)(e)}},function(t,e,n){var r=n(20);t.exports=function(t,e){return void 0===t?arguments.length<2?"":e:r(t)}},function(t,e,n){var r=n(5),i=n(77),o=n(13),s=n(6),u=n(19),a=n(109);e.f=r&&!i?Object.defineProperties:function(t,e){s(t);for(var n,r=u(e),i=a(e),l=i.length,c=0;l>c;)o.f(t,n=i[c++],r[n]);return t}},function(t,e){e.f=Object.getOwnPropertySymbols},function(t,e,n){var r=n(68),i=n(34);t.exports=Object.keys||function(t){return r(t,i)}},function(t,e,n){"use strict";var r={}.propertyIsEnumerable,i=Object.getOwnPropertyDescriptor,o=i&&!r.call({1:2},1);e.f=o?function(t){var e=i(this,t);return!!e&&e.enumerable}:r},function(t,e,n){var r=n(1),i=n(6),o=n(90);t.exports=Object.setPrototypeOf||("__proto__"in{}?function(){var t,e=!1,n={};try{t=r(Object.getOwnPropertyDescriptor(Object.prototype,"__proto__").set),t(n,[]),e=n instanceof Array}catch(t){}return function(n,r){return i(n),o(r),e?t(n,r):n.__proto__=r,n}}():void 0)},function(t,e,n){"use strict";var r=n(51),i=n(29);t.exports=r?{}.toString:function(){return"[object "+i(this)+"]"}},function(t,e,n){var r=n(12),i=n(2),o=n(8),s=TypeError;t.exports=function(t,e){var n,u;if("string"===e&&i(n=t.toString)&&!o(u=r(n,t)))return u;if(i(n=t.valueOf)&&!o(u=r(n,t)))return u;if("string"!==e&&i(n=t.toString)&&!o(u=r(n,t)))return u;throw s("Can't convert object to primitive value")}},function(t,e,n){var r=n(17),i=n(1),o=n(67),s=n(108),u=n(6),a=i([].concat);t.exports=r("Reflect","ownKeys")||function(t){var e=o.f(u(t)),n=s.f;return n?a(e,n(t)):e}},function(t,e,n){var r=n(12),i=n(6),o=n(2),s=n(15),u=n(45),a=TypeError;t.exports=function(t,e){var n=t.exec;if(o(n)){var l=r(n,t,e);return null!==l&&i(l),l}if("RegExp"===s(t))return r(u,t,e);throw a("RegExp#exec called on incompatible receiver")}},function(t,e,n){var r=n(12),i=n(7),o=n(44),s=n(69),u=RegExp.prototype;t.exports=function(t){var e=t.flags;return void 0!==e||"flags"in u||i(t,"flags")||!o(u,t)?e:r(s,t)}},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp,s=r(function(){var t=o("a","y");return t.lastIndex=2,null!=t.exec("abcd")}),u=s||r(function(){return!o("a","y").sticky}),a=s||r(function(){var t=o("^r","gy");return t.lastIndex=2,null!=t.exec("str")});t.exports={BROKEN_CARET:a,MISSED_STICKY:u,UNSUPPORTED_Y:s}},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp;t.exports=r(function(){var t=o(".","s");return!(t.dotAll&&t.exec("\n")&&"s"===t.flags)})},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp;t.exports=r(function(){var t=o("(?<a>b)","g");return"b"!==t.exec("b").groups.a||"bc"!=="b".replace(t,"$<a>c")})},function(t,e){t.exports=Object.is||function(t,e){return t===e?0!==t||1/t==1/e:t!=t&&e!=e}},function(t,e,n){var r=n(36).PROPER,i=n(0),o=n(78),s="​᠎";t.exports=function(t){return i(function(){return!!o[t]()||s[t]()!==s||r&&o[t].name!==t})}},function(t,e,n){var r=n(1);t.exports=r(1..valueOf)},function(t,e,n){var r=n(49),i=Math.min;t.exports=function(t){return t>0?i(r(t),9007199254740991):0}},function(t,e,n){var r=n(4),i=n(2),o=r.WeakMap;t.exports=i(o)&&/native code/.test(String(o))},function(t,e,n){"use strict";var r=n(3),i=n(0),o=n(18),s=n(8),u=n(14),a=n(10),l=n(22),c=n(32),f=n(28),p=n(16),h=n(9),d=n(23),v=h("isConcatSpreadable"),g=d>=51||!i(function(){var t=[];return t[v]=!1,t.concat()[0]!==t}),y=p("concat"),b=function(t){if(!s(t))return!1;var e=t[v];return void 0!==e?!!e:o(t)};r({target:"Array",proto:!0,arity:1,forced:!g||!y},{concat:function(t){var e,n,r,i,o,s=u(this),p=f(s,0),h=0;for(e=-1,r=arguments.length;e<r;e++)if(o=-1===e?s:arguments[e],b(o))for(i=a(o),l(h+i),n=0;n<i;n++,h++)n in o&&c(p,h,o[n]);else l(h+1),c(p,h++,o);return p.length=h,p}})},function(t,e,n){"use strict";var r=n(3),i=n(21).every;r({target:"Array",proto:!0,forced:!n(26)("every")},{every:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(21).filter;r({target:"Array",proto:!0,forced:!n(16)("filter")},{filter:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(37),o=n(57).indexOf,s=n(26),u=i([].indexOf),a=!!u&&1/u([1],1,-0)<0,l=s("indexOf");r({target:"Array",proto:!0,forced:a||!l},{indexOf:function(t){var e=arguments.length>1?arguments[1]:void 0;return a?u(this,t,e)||0:o(this,t,e)}})},function(t,e,n){n(3)({target:"Array",stat:!0},{isArray:n(18)})},function(t,e,n){"use strict";var r=n(3),i=n(21).map;r({target:"Array",proto:!0,forced:!n(16)("map")},{map:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(10),s=n(27),u=n(22),a=n(0),l=a(function(){return 4294967297!==[].push.call({length:4294967296},1)}),c=!function(){try{Object.defineProperty([],"length",{writable:!1}).push()}catch(t){return t instanceof TypeError}}();r({target:"Array",proto:!0,arity:1,forced:l||c},{push:function(t){var e=i(this),n=o(e),r=arguments.length;u(n+r);for(var a=0;a<r;a++)e[n]=arguments[a],n++;return s(e,n),n}})},function(t,e,n){"use strict";var r=n(3),i=n(92).left,o=n(26),s=n(23),u=n(96),a=o("reduce"),l=!u&&s>79&&s<83;r({target:"Array",proto:!0,forced:!a||l},{reduce:function(t){var e=arguments.length;return i(this,t,e,e>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(48),s=n(49),u=n(10),a=n(27),l=n(22),c=n(28),f=n(32),p=n(58),h=n(16),d=h("splice"),v=Math.max,g=Math.min;r({target:"Array",proto:!0,forced:!d},{splice:function(t,e){var n,r,h,d,y,b,m=i(this),x=u(m),_=o(t,x),O=arguments.length;for(0===O?n=r=0:1===O?(n=0,r=x-_):(n=O-2,r=g(v(s(e),0),x-_)),l(x+n-r),h=c(m,r),d=0;d<r;d++)(y=_+d)in m&&f(h,d,m[y]);if(h.length=r,n<r){for(d=_;d<x-r;d++)y=d+r,b=d+n,y in m?m[b]=m[y]:p(m,b);for(d=x;d>x-r+n;d--)p(m,d-1)}else if(n>r)for(d=x-r;d>_;d--)y=d+r-1,b=d+n-1,y in m?m[b]=m[y]:p(m,b);for(d=0;d<n;d++)m[d+_]=arguments[d+2];return a(m,x-r+n),h}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(10),s=n(27),u=n(58),a=n(22),l=1!==[].unshift(0),c=!function(){try{Object.defineProperty([],"length",{writable:!1}).unshift()}catch(t){return t instanceof TypeError}}();r({target:"Array",proto:!0,arity:1,forced:l||c},{unshift:function(t){var e=i(this),n=o(e),r=arguments.length;if(r){a(n+r);for(var l=n;l--;){var c=l+r;l in e?e[c]=e[l]:u(e,c)}for(var f=0;f<r;f++)e[f]=arguments[f]}return s(e,n+r)}})},function(t,e,n){"use strict";var r=n(3),i=n(71).trim;r({target:"String",proto:!0,forced:n(121)("trim")},{trim:function(){return i(this)}})},function(t,e){},function(t,e){t.exports=function(t,e,n,r,i,o){var s,u=t=t||{},a=typeof t.default;"object"!==a&&"function"!==a||(s=t,u=t.default);var l="function"==typeof u?u.options:u;e&&(l.render=e.render,l.staticRenderFns=e.staticRenderFns,l._compiled=!0),n&&(l.functional=!0),i&&(l._scopeId=i);var c;if(o?(c=function(t){t=t||this.$vnode&&this.$vnode.ssrContext||this.parent&&this.parent.$vnode&&this.parent.$vnode.ssrContext,t||"undefined"==typeof __VUE_SSR_CONTEXT__||(t=__VUE_SSR_CONTEXT__),r&&r.call(this,t),t&&t._registeredComponents&&t._registeredComponents.add(o)},l._ssrRegister=c):r&&(c=r),c){var f=l.functional,p=f?l.render:l.beforeCreate;f?(l._injectStyles=c,l.render=function(t,e){return c.call(e),p(t,e)}):l.beforeCreate=p?[].concat(p,c):[c]}return{esModule:s,exports:u,options:l}}},function(t,e,n){"use strict";var r=function(){var t=this,e=t.$createElement,n=t._self._c||e;return n("div",{staticClass:"multiselect",class:{"multiselect--active":t.isOpen,"multiselect--disabled":t.disabled,"multiselect--above":t.isAbove,"multiselect--has-options-group":t.hasOptionGroup},attrs:{tabindex:t.searchable?-1:t.tabindex,role:"combobox","aria-owns":"listbox-"+t.id},on:{focus:function(e){return t.activate()},blur:function(e){!t.searchable&&t.deactivate()},keydown:[function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"down",40,e.key,["Down","ArrowDown"])?null:e.target!==e.currentTarget?null:(e.preventDefault(),t.pointerForward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"up",38,e.key,["Up","ArrowUp"])?null:e.target!==e.currentTarget?null:(e.preventDefault(),t.pointerBackward())}],keypress:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"enter",13,e.key,"Enter")&&t._k(e.keyCode,"tab",9,e.key,"Tab")?null:(e.stopPropagation(),e.target!==e.currentTarget?null:t.addPointerElement(e))},keyup:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"esc",27,e.key,["Esc","Escape"])?null:t.deactivate()}}},[t._t("caret",function(){return[n("div",{staticClass:"multiselect__select",on:{mousedown:function(e){return e.preventDefault(),e.stopPropagation(),t.toggle()}}})]},{toggle:t.toggle}),t._v(" "),t._t("clear",null,{search:t.search}),t._v(" "),n("div",{ref:"tags",staticClass:"multiselect__tags"},[t._t("selection",function(){return[n("div",{directives:[{name:"show",rawName:"v-show",value:t.visibleValues.length>0,expression:"visibleValues.length > 0"}],staticClass:"multiselect__tags-wrap"},[t._l(t.visibleValues,function(e,r){return[t._t("tag",function(){return[n("span",{key:r,staticClass:"multiselect__tag"},[n("span",{domProps:{textContent:t._s(t.getOptionLabel(e))}}),t._v(" "),n("i",{staticClass:"multiselect__tag-icon",attrs:{tabindex:"1"},on:{keypress:function(n){return!n.type.indexOf("key")&&t._k(n.keyCode,"enter",13,n.key,"Enter")?null:(n.preventDefault(),t.removeElement(e))},mousedown:function(n){return n.preventDefault(),t.removeElement(e)}}})])]},{option:e,search:t.search,remove:t.removeElement})]})],2),t._v(" "),t.internalValue&&t.internalValue.length>t.limit?[t._t("limit",function(){return[n("strong",{staticClass:"multiselect__strong",domProps:{textContent:t._s(t.limitText(t.internalValue.length-t.limit))}})]})]:t._e()]},{search:t.search,remove:t.removeElement,values:t.visibleValues,isOpen:t.isOpen}),t._v(" "),n("transition",{attrs:{name:"multiselect__loading"}},[t._t("loading",function(){return[n("div",{directives:[{name:"show",rawName:"v-show",value:t.loading,expression:"loading"}],staticClass:"multiselect__spinner"})]})],2),t._v(" "),t.searchable?n("input",{ref:"search",staticClass:"multiselect__input",style:t.inputStyle,attrs:{name:t.name,id:t.id,type:"text",autocomplete:"off",spellcheck:"false",placeholder:t.placeholder,disabled:t.disabled,tabindex:t.tabindex,"aria-controls":"listbox-"+t.id},domProps:{value:t.search},on:{input:function(e){return t.updateSearch(e.target.value)},focus:function(e){return e.preventDefault(),t.activate()},blur:function(e){return e.preventDefault(),t.deactivate()},keyup:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"esc",27,e.key,["Esc","Escape"])?null:t.deactivate()},keydown:[function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"down",40,e.key,["Down","ArrowDown"])?null:(e.preventDefault(),t.pointerForward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"up",38,e.key,["Up","ArrowUp"])?null:(e.preventDefault(),t.pointerBackward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"delete",[8,46],e.key,["Backspace","Delete","Del"])?null:(e.stopPropagation(),t.removeLastElement())}],keypress:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"enter",13,e.key,"Enter")?null:(e.preventDefault(),e.stopPropagation(),e.target!==e.currentTarget?null:t.addPointerElement(e))}}}):t._e(),t._v(" "),t.isSingleLabelVisible?n("span",{staticClass:"multiselect__single",on:{mousedown:function(e){return e.preventDefault(),t.toggle.apply(null,arguments)}}},[t._t("singleLabel",function(){return[[t._v(t._s(t.currentOptionLabel))]]},{option:t.singleValue})],2):t._e(),t._v(" "),t.isPlaceholderVisible?n("span",{staticClass:"multiselect__placeholder",on:{mousedown:function(e){return e.preventDefault(),t.toggle.apply(null,arguments)}}},[t._t("placeholder",function(){return[t._v("\n          "+t._s(t.placeholder)+"\n        ")]})],2):t._e()],2),t._v(" "),n("transition",{attrs:{name:"multiselect"}},[n("div",{directives:[{name:"show",rawName:"v-show",value:t.isOpen,expression:"isOpen"}],ref:"list",staticClass:"multiselect__content-wrapper",style:{maxHeight:t.optimizedHeight+"px"},attrs:{tabindex:"-1"},on:{focus:t.activate,mousedown:function(t){t.preventDefault()}}},[n("ul",{staticClass:"multiselect__content",style:t.contentStyle,attrs:{role:"listbox",id:"listbox-"+t.id}},[t._t("beforeList"),t._v(" "),t.multiple&&t.max===t.internalValue.length?n("li",[n("span",{staticClass:"multiselect__option"},[t._t("maxElements",function(){return[t._v("Maximum of "+t._s(t.max)+" options selected. First remove a selected option to select another.")]})],2)]):t._e(),t._v(" "),!t.max||t.internalValue.length<t.max?t._l(t.filteredOptions,function(e,r){return n("li",{key:r,staticClass:"multiselect__element",attrs:{id:t.id+"-"+r,role:e&&(e.$isLabel||e.$isDisabled)?null:"option"}},[e&&(e.$isLabel||e.$isDisabled)?t._e():n("span",{staticClass:"multiselect__option",class:t.optionHighlight(r,e),attrs:{"data-select":e&&e.isTag?t.tagPlaceholder:t.selectLabelText,"data-selected":t.selectedLabelText,"data-deselect":t.deselectLabelText},on:{click:function(n){return n.stopPropagation(),t.select(e)},mouseenter:function(e){return e.target!==e.currentTarget?null:t.pointerSet(r)}}},[t._t("option",function(){return[n("span",[t._v(t._s(t.getOptionLabel(e)))])]},{option:e,search:t.search,index:r})],2),t._v(" "),e&&(e.$isLabel||e.$isDisabled)?n("span",{staticClass:"multiselect__option",class:t.groupHighlight(r,e),attrs:{"data-select":t.groupSelect&&t.selectGroupLabelText,"data-deselect":t.groupSelect&&t.deselectGroupLabelText},on:{mouseenter:function(e){if(e.target!==e.currentTarget)return null;t.groupSelect&&t.pointerSet(r)},mousedown:function(n){return n.preventDefault(),t.selectGroup(e)}}},[t._t("option",function(){return[n("span",[t._v(t._s(t.getOptionLabel(e)))])]},{option:e,search:t.search,index:r})],2):t._e()])}):t._e(),t._v(" "),n("li",{directives:[{name:"show",rawName:"v-show",value:t.showNoResults&&0===t.filteredOptions.length&&t.search&&!t.loading,expression:"showNoResults && (filteredOptions.length === 0 && search && !loading)"}]},[n("span",{staticClass:"multiselect__option"},[t._t("noResult",function(){return[t._v("No elements found. Consider changing the search query.")]},{search:t.search})],2)]),t._v(" "),n("li",{directives:[{name:"show",rawName:"v-show",value:t.showNoOptions&&(0===t.options.length||!0===t.hasOptionGroup&&0===t.filteredOptions.length)&&!t.search&&!t.loading,expression:"showNoOptions && ((options.length === 0 || (hasOptionGroup === true && filteredOptions.length === 0)) && !search && !loading)"}]},[n("span",{staticClass:"multiselect__option"},[t._t("noOptions",function(){return[t._v("List is empty.")]})],2)]),t._v(" "),t._t("afterList")],2)])])],2)},i=[],o={render:r,staticRenderFns:i};e.a=o},function(t,e){var n;n=function(){return this}();try{n=n||Function("return this")()||(0,eval)("this")}catch(t){"object"==typeof window&&(n=window)}t.exports=n}])});
+!function(t,e){ true?module.exports=e():undefined}(this,function(){return function(t){function e(r){if(n[r])return n[r].exports;var i=n[r]={i:r,l:!1,exports:{}};return t[r].call(i.exports,i,i.exports,e),i.l=!0,i.exports}var n={};return e.m=t,e.c=n,e.i=function(t){return t},e.d=function(t,n,r){e.o(t,n)||Object.defineProperty(t,n,{configurable:!1,enumerable:!0,get:r})},e.n=function(t){var n=t&&t.__esModule?function(){return t.default}:function(){return t};return e.d(n,"a",n),n},e.o=function(t,e){return Object.prototype.hasOwnProperty.call(t,e)},e.p="/",e(e.s=89)}([function(t,e){t.exports=function(t){try{return!!t()}catch(t){return!0}}},function(t,e,n){var r=n(35),i=Function.prototype,o=i.call,s=r&&i.bind.bind(o,o);t.exports=r?s:function(t){return function(){return o.apply(t,arguments)}}},function(t,e,n){var r=n(59),i=r.all;t.exports=r.IS_HTMLDDA?function(t){return"function"==typeof t||t===i}:function(t){return"function"==typeof t}},function(t,e,n){var r=n(4),i=n(43).f,o=n(30),s=n(11),u=n(33),a=n(95),l=n(66);t.exports=function(t,e){var n,c,f,p,h,d=t.target,v=t.global,g=t.stat;if(n=v?r:g?r[d]||u(d,{}):(r[d]||{}).prototype)for(c in e){if(p=e[c],t.dontCallGetSet?(h=i(n,c),f=h&&h.value):f=n[c],!l(v?c:d+(g?".":"#")+c,t.forced)&&void 0!==f){if(typeof p==typeof f)continue;a(p,f)}(t.sham||f&&f.sham)&&o(p,"sham",!0),s(n,c,p,t)}}},function(t,e,n){(function(e){var n=function(t){return t&&t.Math==Math&&t};t.exports=n("object"==typeof globalThis&&globalThis)||n("object"==typeof window&&window)||n("object"==typeof self&&self)||n("object"==typeof e&&e)||function(){return this}()||Function("return this")()}).call(e,n(139))},function(t,e,n){var r=n(0);t.exports=!r(function(){return 7!=Object.defineProperty({},1,{get:function(){return 7}})[1]})},function(t,e,n){var r=n(8),i=String,o=TypeError;t.exports=function(t){if(r(t))return t;throw o(i(t)+" is not an object")}},function(t,e,n){var r=n(1),i=n(14),o=r({}.hasOwnProperty);t.exports=Object.hasOwn||function(t,e){return o(i(t),e)}},function(t,e,n){var r=n(2),i=n(59),o=i.all;t.exports=i.IS_HTMLDDA?function(t){return"object"==typeof t?null!==t:r(t)||t===o}:function(t){return"object"==typeof t?null!==t:r(t)}},function(t,e,n){var r=n(4),i=n(47),o=n(7),s=n(75),u=n(72),a=n(76),l=i("wks"),c=r.Symbol,f=c&&c.for,p=a?c:c&&c.withoutSetter||s;t.exports=function(t){if(!o(l,t)||!u&&"string"!=typeof l[t]){var e="Symbol."+t;u&&o(c,t)?l[t]=c[t]:l[t]=a&&f?f(e):p(e)}return l[t]}},function(t,e,n){var r=n(123);t.exports=function(t){return r(t.length)}},function(t,e,n){var r=n(2),i=n(13),o=n(104),s=n(33);t.exports=function(t,e,n,u){u||(u={});var a=u.enumerable,l=void 0!==u.name?u.name:e;if(r(n)&&o(n,l,u),u.global)a?t[e]=n:s(e,n);else{try{u.unsafe?t[e]&&(a=!0):delete t[e]}catch(t){}a?t[e]=n:i.f(t,e,{value:n,enumerable:!1,configurable:!u.nonConfigurable,writable:!u.nonWritable})}return t}},function(t,e,n){var r=n(35),i=Function.prototype.call;t.exports=r?i.bind(i):function(){return i.apply(i,arguments)}},function(t,e,n){var r=n(5),i=n(62),o=n(77),s=n(6),u=n(50),a=TypeError,l=Object.defineProperty,c=Object.getOwnPropertyDescriptor;e.f=r?o?function(t,e,n){if(s(t),e=u(e),s(n),"function"==typeof t&&"prototype"===e&&"value"in n&&"writable"in n&&!n.writable){var r=c(t,e);r&&r.writable&&(t[e]=n.value,n={configurable:"configurable"in n?n.configurable:r.configurable,enumerable:"enumerable"in n?n.enumerable:r.enumerable,writable:!1})}return l(t,e,n)}:l:function(t,e,n){if(s(t),e=u(e),s(n),i)try{return l(t,e,n)}catch(t){}if("get"in n||"set"in n)throw a("Accessors not supported");return"value"in n&&(t[e]=n.value),t}},function(t,e,n){var r=n(24),i=Object;t.exports=function(t){return i(r(t))}},function(t,e,n){var r=n(1),i=r({}.toString),o=r("".slice);t.exports=function(t){return o(i(t),8,-1)}},function(t,e,n){var r=n(0),i=n(9),o=n(23),s=i("species");t.exports=function(t){return o>=51||!r(function(){var e=[],n=e.constructor={};return n[s]=function(){return{foo:1}},1!==e[t](Boolean).foo})}},function(t,e,n){var r=n(4),i=n(2),o=function(t){return i(t)?t:void 0};t.exports=function(t,e){return arguments.length<2?o(r[t]):r[t]&&r[t][e]}},function(t,e,n){var r=n(15);t.exports=Array.isArray||function(t){return"Array"==r(t)}},function(t,e,n){var r=n(39),i=n(24);t.exports=function(t){return r(i(t))}},function(t,e,n){var r=n(29),i=String;t.exports=function(t){if("Symbol"===r(t))throw TypeError("Cannot convert a Symbol value to a string");return i(t)}},function(t,e,n){var r=n(100),i=n(1),o=n(39),s=n(14),u=n(10),a=n(28),l=i([].push),c=function(t){var e=1==t,n=2==t,i=3==t,c=4==t,f=6==t,p=7==t,h=5==t||f;return function(d,v,g,y){for(var b,m,x=s(d),_=o(x),O=r(v,g),w=u(_),S=0,E=y||a,k=e?E(d,w):n||p?E(d,0):void 0;w>S;S++)if((h||S in _)&&(b=_[S],m=O(b,S,x),t))if(e)k[S]=m;else if(m)switch(t){case 3:return!0;case 5:return b;case 6:return S;case 2:l(k,b)}else switch(t){case 4:return!1;case 7:l(k,b)}return f?-1:i||c?c:k}};t.exports={forEach:c(0),map:c(1),filter:c(2),some:c(3),every:c(4),find:c(5),findIndex:c(6),filterReject:c(7)}},function(t,e){var n=TypeError;t.exports=function(t){if(t>9007199254740991)throw n("Maximum allowed index exceeded");return t}},function(t,e,n){var r,i,o=n(4),s=n(97),u=o.process,a=o.Deno,l=u&&u.versions||a&&a.version,c=l&&l.v8;c&&(r=c.split("."),i=r[0]>0&&r[0]<4?1:+(r[0]+r[1])),!i&&s&&(!(r=s.match(/Edge\/(\d+)/))||r[1]>=74)&&(r=s.match(/Chrome\/(\d+)/))&&(i=+r[1]),t.exports=i},function(t,e,n){var r=n(40),i=TypeError;t.exports=function(t){if(r(t))throw i("Can't call method on "+t);return t}},function(t,e,n){var r=n(2),i=n(74),o=TypeError;t.exports=function(t){if(r(t))return t;throw o(i(t)+" is not a function")}},function(t,e,n){"use strict";var r=n(0);t.exports=function(t,e){var n=[][t];return!!n&&r(function(){n.call(null,e||function(){return 1},1)})}},function(t,e,n){"use strict";var r=n(5),i=n(18),o=TypeError,s=Object.getOwnPropertyDescriptor,u=r&&!function(){if(void 0!==this)return!0;try{Object.defineProperty([],"length",{writable:!1}).length=1}catch(t){return t instanceof TypeError}}();t.exports=u?function(t,e){if(i(t)&&!s(t,"length").writable)throw o("Cannot set read only .length");return t.length=e}:function(t,e){return t.length=e}},function(t,e,n){var r=n(94);t.exports=function(t,e){return new(r(t))(0===e?0:e)}},function(t,e,n){var r=n(51),i=n(2),o=n(15),s=n(9),u=s("toStringTag"),a=Object,l="Arguments"==o(function(){return arguments}()),c=function(t,e){try{return t[e]}catch(t){}};t.exports=r?o:function(t){var e,n,r;return void 0===t?"Undefined":null===t?"Null":"string"==typeof(n=c(e=a(t),u))?n:l?o(e):"Object"==(r=o(e))&&i(e.callee)?"Arguments":r}},function(t,e,n){var r=n(5),i=n(13),o=n(31);t.exports=r?function(t,e,n){return i.f(t,e,o(1,n))}:function(t,e,n){return t[e]=n,t}},function(t,e){t.exports=function(t,e){return{enumerable:!(1&t),configurable:!(2&t),writable:!(4&t),value:e}}},function(t,e,n){"use strict";var r=n(50),i=n(13),o=n(31);t.exports=function(t,e,n){var s=r(e);s in t?i.f(t,s,o(0,n)):t[s]=n}},function(t,e,n){var r=n(4),i=Object.defineProperty;t.exports=function(t,e){try{i(r,t,{value:e,configurable:!0,writable:!0})}catch(n){r[t]=e}return e}},function(t,e){t.exports=["constructor","hasOwnProperty","isPrototypeOf","propertyIsEnumerable","toLocaleString","toString","valueOf"]},function(t,e,n){var r=n(0);t.exports=!r(function(){var t=function(){}.bind();return"function"!=typeof t||t.hasOwnProperty("prototype")})},function(t,e,n){var r=n(5),i=n(7),o=Function.prototype,s=r&&Object.getOwnPropertyDescriptor,u=i(o,"name"),a=u&&"something"===function(){}.name,l=u&&(!r||r&&s(o,"name").configurable);t.exports={EXISTS:u,PROPER:a,CONFIGURABLE:l}},function(t,e,n){var r=n(15),i=n(1);t.exports=function(t){if("Function"===r(t))return i(t)}},function(t,e){t.exports={}},function(t,e,n){var r=n(1),i=n(0),o=n(15),s=Object,u=r("".split);t.exports=i(function(){return!s("z").propertyIsEnumerable(0)})?function(t){return"String"==o(t)?u(t,""):s(t)}:s},function(t,e){t.exports=function(t){return null===t||void 0===t}},function(t,e,n){var r=n(17),i=n(2),o=n(44),s=n(76),u=Object;t.exports=s?function(t){return"symbol"==typeof t}:function(t){var e=r("Symbol");return i(e)&&o(e.prototype,u(t))}},function(t,e,n){var r,i=n(6),o=n(107),s=n(34),u=n(38),a=n(101),l=n(60),c=n(70),f=c("IE_PROTO"),p=function(){},h=function(t){return"<script>"+t+"<\/script>"},d=function(t){t.write(h("")),t.close();var e=t.parentWindow.Object;return t=null,e},v=function(){var t,e=l("iframe");return e.style.display="none",a.appendChild(e),e.src=String("javascript:"),t=e.contentWindow.document,t.open(),t.write(h("document.F=Object")),t.close(),t.F},g=function(){try{r=new ActiveXObject("htmlfile")}catch(t){}g="undefined"!=typeof document?document.domain&&r?d(r):v():d(r);for(var t=s.length;t--;)delete g.prototype[s[t]];return g()};u[f]=!0,t.exports=Object.create||function(t,e){var n;return null!==t?(p.prototype=i(t),n=new p,p.prototype=null,n[f]=t):n=g(),void 0===e?n:o.f(n,e)}},function(t,e,n){var r=n(5),i=n(12),o=n(110),s=n(31),u=n(19),a=n(50),l=n(7),c=n(62),f=Object.getOwnPropertyDescriptor;e.f=r?f:function(t,e){if(t=u(t),e=a(e),c)try{return f(t,e)}catch(t){}if(l(t,e))return s(!i(o.f,t,e),t[e])}},function(t,e,n){var r=n(1);t.exports=r({}.isPrototypeOf)},function(t,e,n){"use strict";var r=n(12),i=n(1),o=n(20),s=n(69),u=n(117),a=n(47),l=n(42),c=n(64).get,f=n(118),p=n(119),h=a("native-string-replace",String.prototype.replace),d=RegExp.prototype.exec,v=d,g=i("".charAt),y=i("".indexOf),b=i("".replace),m=i("".slice),x=function(){var t=/a/,e=/b*/g;return r(d,t,"a"),r(d,e,"a"),0!==t.lastIndex||0!==e.lastIndex}(),_=u.BROKEN_CARET,O=void 0!==/()??/.exec("")[1];(x||O||_||f||p)&&(v=function(t){var e,n,i,u,a,f,p,w=this,S=c(w),E=o(t),k=S.raw;if(k)return k.lastIndex=w.lastIndex,e=r(v,k,E),w.lastIndex=k.lastIndex,e;var L=S.groups,P=_&&w.sticky,j=r(s,w),T=w.source,V=0,A=E;if(P&&(j=b(j,"y",""),-1===y(j,"g")&&(j+="g"),A=m(E,w.lastIndex),w.lastIndex>0&&(!w.multiline||w.multiline&&"\n"!==g(E,w.lastIndex-1))&&(T="(?: "+T+")",A=" "+A,V++),n=new RegExp("^(?:"+T+")",j)),O&&(n=new RegExp("^"+T+"$(?!\\s)",j)),x&&(i=w.lastIndex),u=r(d,P?n:w,A),P?u?(u.input=m(u.input,V),u[0]=m(u[0],V),u.index=w.lastIndex,w.lastIndex+=u[0].length):w.lastIndex=0:x&&u&&(w.lastIndex=w.global?u.index+u[0].length:i),O&&u&&u.length>1&&r(h,u[0],n,function(){for(a=1;a<arguments.length-2;a++)void 0===arguments[a]&&(u[a]=void 0)}),u&&L)for(u.groups=f=l(null),a=0;a<L.length;a++)p=L[a],f[p[0]]=u[p[1]];return u}),t.exports=v},function(t,e,n){var r=n(4),i=n(33),o=r["__core-js_shared__"]||i("__core-js_shared__",{});t.exports=o},function(t,e,n){var r=n(103),i=n(46);(t.exports=function(t,e){return i[t]||(i[t]=void 0!==e?e:{})})("versions",[]).push({version:"3.26.1",mode:r?"pure":"global",copyright:"© 2014-2022 Denis Pushkarev (zloirock.ru)",license:"https://github.com/zloirock/core-js/blob/v3.26.1/LICENSE",source:"https://github.com/zloirock/core-js"})},function(t,e,n){var r=n(49),i=Math.max,o=Math.min;t.exports=function(t,e){var n=r(t);return n<0?i(n+e,0):o(n,e)}},function(t,e,n){var r=n(105);t.exports=function(t){var e=+t;return e!==e||0===e?0:r(e)}},function(t,e,n){var r=n(73),i=n(41);t.exports=function(t){var e=r(t,"string");return i(e)?e:e+""}},function(t,e,n){var r=n(9),i=r("toStringTag"),o={};o[i]="z",t.exports="[object z]"===String(o)},function(t,e,n){"use strict";var r=n(5),i=n(4),o=n(1),s=n(66),u=n(11),a=n(7),l=n(102),c=n(44),f=n(41),p=n(73),h=n(0),d=n(67).f,v=n(43).f,g=n(13).f,y=n(122),b=n(71).trim,m=i.Number,x=m.prototype,_=i.TypeError,O=o("".slice),w=o("".charCodeAt),S=function(t){var e=p(t,"number");return"bigint"==typeof e?e:E(e)},E=function(t){var e,n,r,i,o,s,u,a,l=p(t,"number");if(f(l))throw _("Cannot convert a Symbol value to a number");if("string"==typeof l&&l.length>2)if(l=b(l),43===(e=w(l,0))||45===e){if(88===(n=w(l,2))||120===n)return NaN}else if(48===e){switch(w(l,1)){case 66:case 98:r=2,i=49;break;case 79:case 111:r=8,i=55;break;default:return+l}for(o=O(l,2),s=o.length,u=0;u<s;u++)if((a=w(o,u))<48||a>i)return NaN;return parseInt(o,r)}return+l};if(s("Number",!m(" 0o1")||!m("0b1")||m("+0x1"))){for(var k,L=function(t){var e=arguments.length<1?0:m(S(t)),n=this;return c(x,n)&&h(function(){y(n)})?l(Object(e),n,L):e},P=r?d(m):"MAX_VALUE,MIN_VALUE,NaN,NEGATIVE_INFINITY,POSITIVE_INFINITY,EPSILON,MAX_SAFE_INTEGER,MIN_SAFE_INTEGER,isFinite,isInteger,isNaN,isSafeInteger,parseFloat,parseInt,fromString,range".split(","),j=0;P.length>j;j++)a(m,k=P[j])&&!a(L,k)&&g(L,k,v(m,k));L.prototype=x,x.constructor=L,u(i,"Number",L,{constructor:!0})}},function(t,e,n){"use strict";var r=n(3),i=n(45);r({target:"RegExp",proto:!0,forced:/./.exec!==i},{exec:i})},function(t,e,n){"use strict";function r(t){return 0!==t&&(!(!Array.isArray(t)||0!==t.length)||!t)}function i(t){return function(){return!t.apply(void 0,arguments)}}function o(t,e){return void 0===t&&(t="undefined"),null===t&&(t="null"),!1===t&&(t="false"),-1!==t.toString().toLowerCase().indexOf(e.trim())}function s(t,e,n,r){return t.filter(function(t){return o(r(t,n),e)})}function u(t){return t.filter(function(t){return!t.$isLabel})}function a(t,e){return function(n){return n.reduce(function(n,r){return r[t]&&r[t].length?(n.push({$groupLabel:r[e],$isLabel:!0}),n.concat(r[t])):n},[])}}function l(t,e,r,i,o){return function(u){return u.map(function(u){var a;if(!u[r])return console.warn("Options passed to vue-multiselect do not contain groups, despite the config."),[];var l=s(u[r],t,e,o);return l.length?(a={},n.i(f.a)(a,i,u[i]),n.i(f.a)(a,r,l),a):[]})}}var c=n(88),f=n(87),p=n(129),h=(n.n(p),n(82)),d=(n.n(h),n(81)),v=(n.n(d),n(83)),g=(n.n(v),n(84)),y=(n.n(g),n(128)),b=(n.n(y),n(135)),m=(n.n(b),n(127)),x=(n.n(m),n(132)),_=(n.n(x),n(131)),O=(n.n(_),n(125)),w=(n.n(O),n(130)),S=(n.n(w),n(52)),E=(n.n(S),n(53)),k=(n.n(E),n(85)),L=(n.n(k),n(134)),P=(n.n(L),n(80)),j=(n.n(P),n(79)),T=(n.n(j),n(133)),V=(n.n(T),n(126)),A=(n.n(V),function(){for(var t=arguments.length,e=new Array(t),n=0;n<t;n++)e[n]=arguments[n];return function(t){return e.reduce(function(t,e){return e(t)},t)}});e.a={data:function(){return{search:"",isOpen:!1,preferredOpenDirection:"below",optimizedHeight:this.maxHeight}},props:{internalSearch:{type:Boolean,default:!0},options:{type:Array,required:!0},multiple:{type:Boolean,default:!1},value:{type:null,default:function(){return[]}},trackBy:{type:String},label:{type:String},searchable:{type:Boolean,default:!0},clearOnSelect:{type:Boolean,default:!0},hideSelected:{type:Boolean,default:!1},placeholder:{type:String,default:"Select option"},allowEmpty:{type:Boolean,default:!0},resetAfter:{type:Boolean,default:!1},closeOnSelect:{type:Boolean,default:!0},customLabel:{type:Function,default:function(t,e){return r(t)?"":e?t[e]:t}},taggable:{type:Boolean,default:!1},tagPlaceholder:{type:String,default:"Press enter to create a tag"},tagPosition:{type:String,default:"top"},max:{type:[Number,Boolean],default:!1},id:{default:null},optionsLimit:{type:Number,default:1e3},groupValues:{type:String},groupLabel:{type:String},groupSelect:{type:Boolean,default:!1},blockKeys:{type:Array,default:function(){return[]}},preserveSearch:{type:Boolean,default:!1},preselectFirst:{type:Boolean,default:!1},preventAutofocus:{type:Boolean,default:!1}},mounted:function(){!this.multiple&&this.max&&console.warn("[Vue-Multiselect warn]: Max prop should not be used when prop Multiple equals false."),this.preselectFirst&&!this.internalValue.length&&this.options.length&&this.select(this.filteredOptions[0])},computed:{internalValue:function(){return this.value||0===this.value?Array.isArray(this.value)?this.value:[this.value]:[]},filteredOptions:function(){var t=this.search||"",e=t.toLowerCase().trim(),n=this.options.concat();return n=this.internalSearch?this.groupValues?this.filterAndFlat(n,e,this.label):s(n,e,this.label,this.customLabel):this.groupValues?a(this.groupValues,this.groupLabel)(n):n,n=this.hideSelected?n.filter(i(this.isSelected)):n,this.taggable&&e.length&&!this.isExistingOption(e)&&("bottom"===this.tagPosition?n.push({isTag:!0,label:t}):n.unshift({isTag:!0,label:t})),n.slice(0,this.optionsLimit)},valueKeys:function(){var t=this;return this.trackBy?this.internalValue.map(function(e){return e[t.trackBy]}):this.internalValue},optionKeys:function(){var t=this;return(this.groupValues?this.flatAndStrip(this.options):this.options).map(function(e){return t.customLabel(e,t.label).toString().toLowerCase()})},currentOptionLabel:function(){return this.multiple?this.searchable?"":this.placeholder:this.internalValue.length?this.getOptionLabel(this.internalValue[0]):this.searchable?"":this.placeholder}},watch:{internalValue:function(){this.resetAfter&&this.internalValue.length&&(this.search="",this.$emit("input",this.multiple?[]:null))},search:function(){this.$emit("search-change",this.search,this.id)}},methods:{getValue:function(){return this.multiple?this.internalValue:0===this.internalValue.length?null:this.internalValue[0]},filterAndFlat:function(t,e,n){return A(l(e,n,this.groupValues,this.groupLabel,this.customLabel),a(this.groupValues,this.groupLabel))(t)},flatAndStrip:function(t){return A(a(this.groupValues,this.groupLabel),u)(t)},updateSearch:function(t){this.search=t},isExistingOption:function(t){return!!this.options&&this.optionKeys.indexOf(t)>-1},isSelected:function(t){var e=this.trackBy?t[this.trackBy]:t;return this.valueKeys.indexOf(e)>-1},isOptionDisabled:function(t){return!!t.$isDisabled},getOptionLabel:function(t){if(r(t))return"";if(t.isTag)return t.label;if(t.$isLabel)return t.$groupLabel;var e=this.customLabel(t,this.label);return r(e)?"":e},select:function(t,e){if(t.$isLabel&&this.groupSelect)return void this.selectGroup(t);if(!(-1!==this.blockKeys.indexOf(e)||this.disabled||t.$isDisabled||t.$isLabel)&&(!this.max||!this.multiple||this.internalValue.length!==this.max)&&("Tab"!==e||this.pointerDirty)){if(t.isTag)this.$emit("tag",t.label,this.id),this.search="",this.closeOnSelect&&!this.multiple&&this.deactivate();else{if(this.isSelected(t))return void("Tab"!==e&&this.removeElement(t));this.multiple?this.$emit("input",this.internalValue.concat([t]),this.id):this.$emit("input",t,this.id),this.$emit("select",t,this.id),this.clearOnSelect&&(this.search="")}this.closeOnSelect&&this.deactivate()}},selectGroup:function(t){var e=this,n=this.options.find(function(n){return n[e.groupLabel]===t.$groupLabel});if(n){if(this.wholeGroupSelected(n)){this.$emit("remove",n[this.groupValues],this.id);var r=this.trackBy?n[this.groupValues].map(function(t){return t[e.trackBy]}):n[this.groupValues],i=this.internalValue.filter(function(t){return-1===r.indexOf(e.trackBy?t[e.trackBy]:t)});this.$emit("input",i,this.id)}else{var o=n[this.groupValues].filter(function(t){return!(e.isOptionDisabled(t)||e.isSelected(t))});this.max&&o.splice(this.max-this.internalValue.length),this.$emit("select",o,this.id),this.$emit("input",this.internalValue.concat(o),this.id)}this.closeOnSelect&&this.deactivate()}},wholeGroupSelected:function(t){var e=this;return t[this.groupValues].every(function(t){return e.isSelected(t)||e.isOptionDisabled(t)})},wholeGroupDisabled:function(t){return t[this.groupValues].every(this.isOptionDisabled)},removeElement:function(t){var e=!(arguments.length>1&&void 0!==arguments[1])||arguments[1];if(!this.disabled&&!t.$isDisabled){if(!this.allowEmpty&&this.internalValue.length<=1)return void this.deactivate();var r="object"===n.i(c.a)(t)?this.valueKeys.indexOf(t[this.trackBy]):this.valueKeys.indexOf(t);if(this.multiple){var i=this.internalValue.slice(0,r).concat(this.internalValue.slice(r+1));this.$emit("input",i,this.id)}else this.$emit("input",null,this.id);this.$emit("remove",t,this.id),this.closeOnSelect&&e&&this.deactivate()}},removeLastElement:function(){-1===this.blockKeys.indexOf("Delete")&&0===this.search.length&&Array.isArray(this.internalValue)&&this.internalValue.length&&this.removeElement(this.internalValue[this.internalValue.length-1],!1)},activate:function(){var t=this;this.isOpen||this.disabled||(this.adjustPosition(),this.groupValues&&0===this.pointer&&this.filteredOptions.length&&(this.pointer=1),this.isOpen=!0,this.searchable?(this.preserveSearch||(this.search=""),this.preventAutofocus||this.$nextTick(function(){return t.$refs.search&&t.$refs.search.focus()})):this.preventAutofocus||void 0!==this.$el&&this.$el.focus(),this.$emit("open",this.id))},deactivate:function(){this.isOpen&&(this.isOpen=!1,this.searchable?null!==this.$refs.search&&void 0!==this.$refs.search&&this.$refs.search.blur():void 0!==this.$el&&this.$el.blur(),this.preserveSearch||(this.search=""),this.$emit("close",this.getValue(),this.id))},toggle:function(){this.isOpen?this.deactivate():this.activate()},adjustPosition:function(){if("undefined"!=typeof window){var t=this.$el.getBoundingClientRect().top,e=window.innerHeight-this.$el.getBoundingClientRect().bottom;e>this.maxHeight||e>t||"below"===this.openDirection||"bottom"===this.openDirection?(this.preferredOpenDirection="below",this.optimizedHeight=Math.min(e-40,this.maxHeight)):(this.preferredOpenDirection="above",this.optimizedHeight=Math.min(t-40,this.maxHeight))}}}}},function(t,e,n){"use strict";var r=n(52),i=(n.n(r),n(53)),o=(n.n(i),n(85)),s=(n.n(o),n(82)),u=(n.n(s),n(81)),a=(n.n(u),n(83)),l=(n.n(a),n(84)),c=(n.n(l),n(79));n.n(c);e.a={data:function(){return{pointer:0,pointerDirty:!1}},props:{showPointer:{type:Boolean,default:!0},optionHeight:{type:Number,default:40}},computed:{pointerPosition:function(){return this.pointer*this.optionHeight},visibleElements:function(){return this.optimizedHeight/this.optionHeight}},watch:{filteredOptions:function(){this.pointerAdjust()},isOpen:function(){this.pointerDirty=!1},pointer:function(){this.$refs.search&&this.$refs.search.setAttribute("aria-activedescendant",this.id+"-"+this.pointer.toString())}},methods:{optionHighlight:function(t,e){return{"multiselect__option--highlight":t===this.pointer&&this.showPointer,"multiselect__option--selected":this.isSelected(e)}},groupHighlight:function(t,e){var n=this;if(!this.groupSelect)return["multiselect__option--disabled",{"multiselect__option--group":e.$isLabel}];var r=this.options.find(function(t){return t[n.groupLabel]===e.$groupLabel});return r&&!this.wholeGroupDisabled(r)?["multiselect__option--group",{"multiselect__option--highlight":t===this.pointer&&this.showPointer},{"multiselect__option--group-selected":this.wholeGroupSelected(r)}]:"multiselect__option--disabled"},addPointerElement:function(){var t=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"Enter",e=t.key;this.filteredOptions.length>0&&this.select(this.filteredOptions[this.pointer],e),this.pointerReset()},pointerForward:function(){this.pointer<this.filteredOptions.length-1&&(this.pointer++,this.$refs.list.scrollTop<=this.pointerPosition-(this.visibleElements-1)*this.optionHeight&&(this.$refs.list.scrollTop=this.pointerPosition-(this.visibleElements-1)*this.optionHeight),this.filteredOptions[this.pointer]&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerForward()),this.pointerDirty=!0},pointerBackward:function(){this.pointer>0?(this.pointer--,this.$refs.list.scrollTop>=this.pointerPosition&&(this.$refs.list.scrollTop=this.pointerPosition),this.filteredOptions[this.pointer]&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerBackward()):this.filteredOptions[this.pointer]&&this.filteredOptions[0].$isLabel&&!this.groupSelect&&this.pointerForward(),this.pointerDirty=!0},pointerReset:function(){this.closeOnSelect&&(this.pointer=0,this.$refs.list&&(this.$refs.list.scrollTop=0))},pointerAdjust:function(){this.pointer>=this.filteredOptions.length-1&&(this.pointer=this.filteredOptions.length?this.filteredOptions.length-1:0),this.filteredOptions.length>0&&this.filteredOptions[this.pointer].$isLabel&&!this.groupSelect&&this.pointerForward()},pointerSet:function(t){this.pointer=t,this.pointerDirty=!0}}}},function(t,e,n){"use strict";var r=n(52),i=(n.n(r),n(80)),o=(n.n(i),n(54)),s=n(55);e.a={name:"vue-multiselect",mixins:[o.a,s.a],props:{name:{type:String,default:""},selectLabel:{type:String,default:"Press enter to select"},selectGroupLabel:{type:String,default:"Press enter to select group"},selectedLabel:{type:String,default:"Selected"},deselectLabel:{type:String,default:"Press enter to remove"},deselectGroupLabel:{type:String,default:"Press enter to deselect group"},showLabels:{type:Boolean,default:!0},limit:{type:Number,default:99999},maxHeight:{type:Number,default:300},limitText:{type:Function,default:function(t){return"and ".concat(t," more")}},loading:{type:Boolean,default:!1},disabled:{type:Boolean,default:!1},openDirection:{type:String,default:""},showNoOptions:{type:Boolean,default:!0},showNoResults:{type:Boolean,default:!0},tabindex:{type:Number,default:0}},computed:{hasOptionGroup:function(){return this.groupValues&&this.groupLabel&&this.groupSelect},isSingleLabelVisible:function(){return(this.singleValue||0===this.singleValue)&&(!this.isOpen||!this.searchable)&&!this.visibleValues.length},isPlaceholderVisible:function(){return!(this.internalValue.length||this.searchable&&this.isOpen)},visibleValues:function(){return this.multiple?this.internalValue.slice(0,this.limit):[]},singleValue:function(){return this.internalValue[0]},deselectLabelText:function(){return this.showLabels?this.deselectLabel:""},deselectGroupLabelText:function(){return this.showLabels?this.deselectGroupLabel:""},selectLabelText:function(){return this.showLabels?this.selectLabel:""},selectGroupLabelText:function(){return this.showLabels?this.selectGroupLabel:""},selectedLabelText:function(){return this.showLabels?this.selectedLabel:""},inputStyle:function(){return this.searchable||this.multiple&&this.value&&this.value.length?this.isOpen?{width:"100%"}:{width:"0",position:"absolute",padding:"0"}:""},contentStyle:function(){return this.options.length?{display:"inline-block"}:{display:"block"}},isAbove:function(){return"above"===this.openDirection||"top"===this.openDirection||"below"!==this.openDirection&&"bottom"!==this.openDirection&&"above"===this.preferredOpenDirection},showSearchInput:function(){return this.searchable&&(!this.hasSingleSelectedSlot||!this.visibleSingleValue&&0!==this.visibleSingleValue||this.isOpen)}}}},function(t,e,n){var r=n(19),i=n(48),o=n(10),s=function(t){return function(e,n,s){var u,a=r(e),l=o(a),c=i(s,l);if(t&&n!=n){for(;l>c;)if((u=a[c++])!=u)return!0}else for(;l>c;c++)if((t||c in a)&&a[c]===n)return t||c||0;return!t&&-1}};t.exports={includes:s(!0),indexOf:s(!1)}},function(t,e,n){"use strict";var r=n(74),i=TypeError;t.exports=function(t,e){if(!delete t[e])throw i("Cannot delete property "+r(e)+" of "+r(t))}},function(t,e){var n="object"==typeof document&&document.all,r=void 0===n&&void 0!==n;t.exports={all:n,IS_HTMLDDA:r}},function(t,e,n){var r=n(4),i=n(8),o=r.document,s=i(o)&&i(o.createElement);t.exports=function(t){return s?o.createElement(t):{}}},function(t,e,n){var r=n(25),i=n(40);t.exports=function(t,e){var n=t[e];return i(n)?void 0:r(n)}},function(t,e,n){var r=n(5),i=n(0),o=n(60);t.exports=!r&&!i(function(){return 7!=Object.defineProperty(o("div"),"a",{get:function(){return 7}}).a})},function(t,e,n){var r=n(1),i=n(2),o=n(46),s=r(Function.toString);i(o.inspectSource)||(o.inspectSource=function(t){return s(t)}),t.exports=o.inspectSource},function(t,e,n){var r,i,o,s=n(124),u=n(4),a=n(8),l=n(30),c=n(7),f=n(46),p=n(70),h=n(38),d=u.TypeError,v=u.WeakMap,g=function(t){return o(t)?i(t):r(t,{})},y=function(t){return function(e){var n;if(!a(e)||(n=i(e)).type!==t)throw d("Incompatible receiver, "+t+" required");return n}};if(s||f.state){var b=f.state||(f.state=new v);b.get=b.get,b.has=b.has,b.set=b.set,r=function(t,e){if(b.has(t))throw d("Object already initialized");return e.facade=t,b.set(t,e),e},i=function(t){return b.get(t)||{}},o=function(t){return b.has(t)}}else{var m=p("state");h[m]=!0,r=function(t,e){if(c(t,m))throw d("Object already initialized");return e.facade=t,l(t,m,e),e},i=function(t){return c(t,m)?t[m]:{}},o=function(t){return c(t,m)}}t.exports={set:r,get:i,has:o,enforce:g,getterFor:y}},function(t,e,n){var r=n(1),i=n(0),o=n(2),s=n(29),u=n(17),a=n(63),l=function(){},c=[],f=u("Reflect","construct"),p=/^\s*(?:class|function)\b/,h=r(p.exec),d=!p.exec(l),v=function(t){if(!o(t))return!1;try{return f(l,c,t),!0}catch(t){return!1}},g=function(t){if(!o(t))return!1;switch(s(t)){case"AsyncFunction":case"GeneratorFunction":case"AsyncGeneratorFunction":return!1}try{return d||!!h(p,a(t))}catch(t){return!0}};g.sham=!0,t.exports=!f||i(function(){var t;return v(v.call)||!v(Object)||!v(function(){t=!0})||t})?g:v},function(t,e,n){var r=n(0),i=n(2),o=/#|\.prototype\./,s=function(t,e){var n=a[u(t)];return n==c||n!=l&&(i(e)?r(e):!!e)},u=s.normalize=function(t){return String(t).replace(o,".").toLowerCase()},a=s.data={},l=s.NATIVE="N",c=s.POLYFILL="P";t.exports=s},function(t,e,n){var r=n(68),i=n(34),o=i.concat("length","prototype");e.f=Object.getOwnPropertyNames||function(t){return r(t,o)}},function(t,e,n){var r=n(1),i=n(7),o=n(19),s=n(57).indexOf,u=n(38),a=r([].push);t.exports=function(t,e){var n,r=o(t),l=0,c=[];for(n in r)!i(u,n)&&i(r,n)&&a(c,n);for(;e.length>l;)i(r,n=e[l++])&&(~s(c,n)||a(c,n));return c}},function(t,e,n){"use strict";var r=n(6);t.exports=function(){var t=r(this),e="";return t.hasIndices&&(e+="d"),t.global&&(e+="g"),t.ignoreCase&&(e+="i"),t.multiline&&(e+="m"),t.dotAll&&(e+="s"),t.unicode&&(e+="u"),t.unicodeSets&&(e+="v"),t.sticky&&(e+="y"),e}},function(t,e,n){var r=n(47),i=n(75),o=r("keys");t.exports=function(t){return o[t]||(o[t]=i(t))}},function(t,e,n){var r=n(1),i=n(24),o=n(20),s=n(78),u=r("".replace),a="["+s+"]",l=RegExp("^"+a+a+"*"),c=RegExp(a+a+"*$"),f=function(t){return function(e){var n=o(i(e));return 1&t&&(n=u(n,l,"")),2&t&&(n=u(n,c,"")),n}};t.exports={start:f(1),end:f(2),trim:f(3)}},function(t,e,n){var r=n(23),i=n(0);t.exports=!!Object.getOwnPropertySymbols&&!i(function(){var t=Symbol();return!String(t)||!(Object(t)instanceof Symbol)||!Symbol.sham&&r&&r<41})},function(t,e,n){var r=n(12),i=n(8),o=n(41),s=n(61),u=n(113),a=n(9),l=TypeError,c=a("toPrimitive");t.exports=function(t,e){if(!i(t)||o(t))return t;var n,a=s(t,c);if(a){if(void 0===e&&(e="default"),n=r(a,t,e),!i(n)||o(n))return n;throw l("Can't convert object to primitive value")}return void 0===e&&(e="number"),u(t,e)}},function(t,e){var n=String;t.exports=function(t){try{return n(t)}catch(t){return"Object"}}},function(t,e,n){var r=n(1),i=0,o=Math.random(),s=r(1..toString);t.exports=function(t){return"Symbol("+(void 0===t?"":t)+")_"+s(++i+o,36)}},function(t,e,n){var r=n(72);t.exports=r&&!Symbol.sham&&"symbol"==typeof Symbol.iterator},function(t,e,n){var r=n(5),i=n(0);t.exports=r&&i(function(){return 42!=Object.defineProperty(function(){},"prototype",{value:42,writable:!1}).prototype})},function(t,e){t.exports="\t\n\v\f\r                　\u2028\u2029\ufeff"},function(t,e,n){"use strict";var r=n(3),i=n(21).find,o=n(91),s=!0;"find"in[]&&Array(1).find(function(){s=!1}),r({target:"Array",proto:!0,forced:s},{find:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}}),o("find")},function(t,e,n){"use strict";var r=n(3),i=n(18),o=n(65),s=n(8),u=n(48),a=n(10),l=n(19),c=n(32),f=n(9),p=n(16),h=n(93),d=p("slice"),v=f("species"),g=Array,y=Math.max;r({target:"Array",proto:!0,forced:!d},{slice:function(t,e){var n,r,f,p=l(this),d=a(p),b=u(t,d),m=u(void 0===e?d:e,d);if(i(p)&&(n=p.constructor,o(n)&&(n===g||i(n.prototype))?n=void 0:s(n)&&null===(n=n[v])&&(n=void 0),n===g||void 0===n))return h(p,b,m);for(r=new(void 0===n?g:n)(y(m-b,0)),f=0;b<m;b++,f++)b in p&&c(r,f,p[b]);return r.length=f,r}})},function(t,e,n){var r=n(1),i=n(11),o=Date.prototype,s=r(o.toString),u=r(o.getTime);"Invalid Date"!=String(new Date(NaN))&&i(o,"toString",function(){var t=u(this);return t===t?s(this):"Invalid Date"})},function(t,e,n){var r=n(11),i=n(98),o=Error.prototype;o.toString!==i&&r(o,"toString",i)},function(t,e,n){var r=n(51),i=n(11),o=n(112);r||i(Object.prototype,"toString",o,{unsafe:!0})},function(t,e,n){"use strict";var r=n(36).PROPER,i=n(11),o=n(6),s=n(20),u=n(0),a=n(116),l=RegExp.prototype,c=l.toString,f=u(function(){return"/a/b"!=c.call({source:"a",flags:"b"})}),p=r&&"toString"!=c.name;(f||p)&&i(RegExp.prototype,"toString",function(){var t=o(this);return"/"+s(t.source)+"/"+s(a(t))},{unsafe:!0})},function(t,e,n){"use strict";var r=n(12),i=n(99),o=n(6),s=n(40),u=n(24),a=n(120),l=n(20),c=n(61),f=n(115);i("search",function(t,e,n){return[function(e){var n=u(this),i=s(e)?void 0:c(e,t);return i?r(i,e,n):new RegExp(e)[t](l(n))},function(t){var r=o(this),i=l(t),s=n(e,r,i);if(s.done)return s.value;var u=r.lastIndex;a(u,0)||(r.lastIndex=0);var c=f(r,i);return a(r.lastIndex,u)||(r.lastIndex=u),null===c?-1:c.index}]})},function(t,e,n){"use strict";function r(t){n(136)}var i=n(56),o=n(138),s=n(137),u=r,a=s(i.a,o.a,!1,u,null,null);e.a=a.exports},function(t,e,n){"use strict";function r(t,e,n){return e in t?Object.defineProperty(t,e,{value:n,enumerable:!0,configurable:!0,writable:!0}):t[e]=n,t}e.a=r},function(t,e,n){"use strict";function r(t){"@babel/helpers - typeof";return(r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(t){return typeof t}:function(t){return t&&"function"==typeof Symbol&&t.constructor===Symbol&&t!==Symbol.prototype?"symbol":typeof t})(t)}e.a=r},function(t,e,n){"use strict";Object.defineProperty(e,"__esModule",{value:!0});var r=n(86),i=n(54),o=n(55);n.d(e,"Multiselect",function(){return r.a}),n.d(e,"multiselectMixin",function(){return i.a}),n.d(e,"pointerMixin",function(){return o.a}),e.default=r.a},function(t,e,n){var r=n(2),i=String,o=TypeError;t.exports=function(t){if("object"==typeof t||r(t))return t;throw o("Can't set "+i(t)+" as a prototype")}},function(t,e,n){var r=n(9),i=n(42),o=n(13).f,s=r("unscopables"),u=Array.prototype;void 0==u[s]&&o(u,s,{configurable:!0,value:i(null)}),t.exports=function(t){u[s][t]=!0}},function(t,e,n){var r=n(25),i=n(14),o=n(39),s=n(10),u=TypeError,a=function(t){return function(e,n,a,l){r(n);var c=i(e),f=o(c),p=s(c),h=t?p-1:0,d=t?-1:1;if(a<2)for(;;){if(h in f){l=f[h],h+=d;break}if(h+=d,t?h<0:p<=h)throw u("Reduce of empty array with no initial value")}for(;t?h>=0:p>h;h+=d)h in f&&(l=n(l,f[h],h,c));return l}};t.exports={left:a(!1),right:a(!0)}},function(t,e,n){var r=n(1);t.exports=r([].slice)},function(t,e,n){var r=n(18),i=n(65),o=n(8),s=n(9),u=s("species"),a=Array;t.exports=function(t){var e;return r(t)&&(e=t.constructor,i(e)&&(e===a||r(e.prototype))?e=void 0:o(e)&&null===(e=e[u])&&(e=void 0)),void 0===e?a:e}},function(t,e,n){var r=n(7),i=n(114),o=n(43),s=n(13);t.exports=function(t,e,n){for(var u=i(e),a=s.f,l=o.f,c=0;c<u.length;c++){var f=u[c];r(t,f)||n&&r(n,f)||a(t,f,l(e,f))}}},function(t,e,n){var r=n(15),i=n(4);t.exports="process"==r(i.process)},function(t,e,n){var r=n(17);t.exports=r("navigator","userAgent")||""},function(t,e,n){"use strict";var r=n(5),i=n(0),o=n(6),s=n(42),u=n(106),a=Error.prototype.toString,l=i(function(){if(r){var t=s(Object.defineProperty({},"name",{get:function(){return this===t}}));if("true"!==a.call(t))return!0}return"2: 1"!==a.call({message:1,name:2})||"Error"!==a.call({})});t.exports=l?function(){var t=o(this),e=u(t.name,"Error"),n=u(t.message);return e?n?e+": "+n:e:n}:a},function(t,e,n){"use strict";n(53);var r=n(37),i=n(11),o=n(45),s=n(0),u=n(9),a=n(30),l=u("species"),c=RegExp.prototype;t.exports=function(t,e,n,f){var p=u(t),h=!s(function(){var e={};return e[p]=function(){return 7},7!=""[t](e)}),d=h&&!s(function(){var e=!1,n=/a/;return"split"===t&&(n={},n.constructor={},n.constructor[l]=function(){return n},n.flags="",n[p]=/./[p]),n.exec=function(){return e=!0,null},n[p](""),!e});if(!h||!d||n){var v=r(/./[p]),g=e(p,""[t],function(t,e,n,i,s){var u=r(t),a=e.exec;return a===o||a===c.exec?h&&!s?{done:!0,value:v(e,n,i)}:{done:!0,value:u(n,e,i)}:{done:!1}});i(String.prototype,t,g[0]),i(c,p,g[1])}f&&a(c[p],"sham",!0)}},function(t,e,n){var r=n(37),i=n(25),o=n(35),s=r(r.bind);t.exports=function(t,e){return i(t),void 0===e?t:o?s(t,e):function(){return t.apply(e,arguments)}}},function(t,e,n){var r=n(17);t.exports=r("document","documentElement")},function(t,e,n){var r=n(2),i=n(8),o=n(111);t.exports=function(t,e,n){var s,u;return o&&r(s=e.constructor)&&s!==n&&i(u=s.prototype)&&u!==n.prototype&&o(t,u),t}},function(t,e){t.exports=!1},function(t,e,n){var r=n(0),i=n(2),o=n(7),s=n(5),u=n(36).CONFIGURABLE,a=n(63),l=n(64),c=l.enforce,f=l.get,p=Object.defineProperty,h=s&&!r(function(){return 8!==p(function(){},"length",{value:8}).length}),d=String(String).split("String"),v=t.exports=function(t,e,n){"Symbol("===String(e).slice(0,7)&&(e="["+String(e).replace(/^Symbol\(([^)]*)\)/,"$1")+"]"),n&&n.getter&&(e="get "+e),n&&n.setter&&(e="set "+e),(!o(t,"name")||u&&t.name!==e)&&(s?p(t,"name",{value:e,configurable:!0}):t.name=e),h&&n&&o(n,"arity")&&t.length!==n.arity&&p(t,"length",{value:n.arity});try{n&&o(n,"constructor")&&n.constructor?s&&p(t,"prototype",{writable:!1}):t.prototype&&(t.prototype=void 0)}catch(t){}var r=c(t);return o(r,"source")||(r.source=d.join("string"==typeof e?e:"")),t};Function.prototype.toString=v(function(){return i(this)&&f(this).source||a(this)},"toString")},function(t,e){var n=Math.ceil,r=Math.floor;t.exports=Math.trunc||function(t){var e=+t;return(e>0?r:n)(e)}},function(t,e,n){var r=n(20);t.exports=function(t,e){return void 0===t?arguments.length<2?"":e:r(t)}},function(t,e,n){var r=n(5),i=n(77),o=n(13),s=n(6),u=n(19),a=n(109);e.f=r&&!i?Object.defineProperties:function(t,e){s(t);for(var n,r=u(e),i=a(e),l=i.length,c=0;l>c;)o.f(t,n=i[c++],r[n]);return t}},function(t,e){e.f=Object.getOwnPropertySymbols},function(t,e,n){var r=n(68),i=n(34);t.exports=Object.keys||function(t){return r(t,i)}},function(t,e,n){"use strict";var r={}.propertyIsEnumerable,i=Object.getOwnPropertyDescriptor,o=i&&!r.call({1:2},1);e.f=o?function(t){var e=i(this,t);return!!e&&e.enumerable}:r},function(t,e,n){var r=n(1),i=n(6),o=n(90);t.exports=Object.setPrototypeOf||("__proto__"in{}?function(){var t,e=!1,n={};try{t=r(Object.getOwnPropertyDescriptor(Object.prototype,"__proto__").set),t(n,[]),e=n instanceof Array}catch(t){}return function(n,r){return i(n),o(r),e?t(n,r):n.__proto__=r,n}}():void 0)},function(t,e,n){"use strict";var r=n(51),i=n(29);t.exports=r?{}.toString:function(){return"[object "+i(this)+"]"}},function(t,e,n){var r=n(12),i=n(2),o=n(8),s=TypeError;t.exports=function(t,e){var n,u;if("string"===e&&i(n=t.toString)&&!o(u=r(n,t)))return u;if(i(n=t.valueOf)&&!o(u=r(n,t)))return u;if("string"!==e&&i(n=t.toString)&&!o(u=r(n,t)))return u;throw s("Can't convert object to primitive value")}},function(t,e,n){var r=n(17),i=n(1),o=n(67),s=n(108),u=n(6),a=i([].concat);t.exports=r("Reflect","ownKeys")||function(t){var e=o.f(u(t)),n=s.f;return n?a(e,n(t)):e}},function(t,e,n){var r=n(12),i=n(6),o=n(2),s=n(15),u=n(45),a=TypeError;t.exports=function(t,e){var n=t.exec;if(o(n)){var l=r(n,t,e);return null!==l&&i(l),l}if("RegExp"===s(t))return r(u,t,e);throw a("RegExp#exec called on incompatible receiver")}},function(t,e,n){var r=n(12),i=n(7),o=n(44),s=n(69),u=RegExp.prototype;t.exports=function(t){var e=t.flags;return void 0!==e||"flags"in u||i(t,"flags")||!o(u,t)?e:r(s,t)}},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp,s=r(function(){var t=o("a","y");return t.lastIndex=2,null!=t.exec("abcd")}),u=s||r(function(){return!o("a","y").sticky}),a=s||r(function(){var t=o("^r","gy");return t.lastIndex=2,null!=t.exec("str")});t.exports={BROKEN_CARET:a,MISSED_STICKY:u,UNSUPPORTED_Y:s}},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp;t.exports=r(function(){var t=o(".","s");return!(t.dotAll&&t.exec("\n")&&"s"===t.flags)})},function(t,e,n){var r=n(0),i=n(4),o=i.RegExp;t.exports=r(function(){var t=o("(?<a>b)","g");return"b"!==t.exec("b").groups.a||"bc"!=="b".replace(t,"$<a>c")})},function(t,e){t.exports=Object.is||function(t,e){return t===e?0!==t||1/t==1/e:t!=t&&e!=e}},function(t,e,n){var r=n(36).PROPER,i=n(0),o=n(78),s="​᠎";t.exports=function(t){return i(function(){return!!o[t]()||s[t]()!==s||r&&o[t].name!==t})}},function(t,e,n){var r=n(1);t.exports=r(1..valueOf)},function(t,e,n){var r=n(49),i=Math.min;t.exports=function(t){return t>0?i(r(t),9007199254740991):0}},function(t,e,n){var r=n(4),i=n(2),o=r.WeakMap;t.exports=i(o)&&/native code/.test(String(o))},function(t,e,n){"use strict";var r=n(3),i=n(0),o=n(18),s=n(8),u=n(14),a=n(10),l=n(22),c=n(32),f=n(28),p=n(16),h=n(9),d=n(23),v=h("isConcatSpreadable"),g=d>=51||!i(function(){var t=[];return t[v]=!1,t.concat()[0]!==t}),y=p("concat"),b=function(t){if(!s(t))return!1;var e=t[v];return void 0!==e?!!e:o(t)};r({target:"Array",proto:!0,arity:1,forced:!g||!y},{concat:function(t){var e,n,r,i,o,s=u(this),p=f(s,0),h=0;for(e=-1,r=arguments.length;e<r;e++)if(o=-1===e?s:arguments[e],b(o))for(i=a(o),l(h+i),n=0;n<i;n++,h++)n in o&&c(p,h,o[n]);else l(h+1),c(p,h++,o);return p.length=h,p}})},function(t,e,n){"use strict";var r=n(3),i=n(21).every;r({target:"Array",proto:!0,forced:!n(26)("every")},{every:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(21).filter;r({target:"Array",proto:!0,forced:!n(16)("filter")},{filter:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(37),o=n(57).indexOf,s=n(26),u=i([].indexOf),a=!!u&&1/u([1],1,-0)<0,l=s("indexOf");r({target:"Array",proto:!0,forced:a||!l},{indexOf:function(t){var e=arguments.length>1?arguments[1]:void 0;return a?u(this,t,e)||0:o(this,t,e)}})},function(t,e,n){n(3)({target:"Array",stat:!0},{isArray:n(18)})},function(t,e,n){"use strict";var r=n(3),i=n(21).map;r({target:"Array",proto:!0,forced:!n(16)("map")},{map:function(t){return i(this,t,arguments.length>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(10),s=n(27),u=n(22),a=n(0),l=a(function(){return 4294967297!==[].push.call({length:4294967296},1)}),c=!function(){try{Object.defineProperty([],"length",{writable:!1}).push()}catch(t){return t instanceof TypeError}}();r({target:"Array",proto:!0,arity:1,forced:l||c},{push:function(t){var e=i(this),n=o(e),r=arguments.length;u(n+r);for(var a=0;a<r;a++)e[n]=arguments[a],n++;return s(e,n),n}})},function(t,e,n){"use strict";var r=n(3),i=n(92).left,o=n(26),s=n(23),u=n(96),a=o("reduce"),l=!u&&s>79&&s<83;r({target:"Array",proto:!0,forced:!a||l},{reduce:function(t){var e=arguments.length;return i(this,t,e,e>1?arguments[1]:void 0)}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(48),s=n(49),u=n(10),a=n(27),l=n(22),c=n(28),f=n(32),p=n(58),h=n(16),d=h("splice"),v=Math.max,g=Math.min;r({target:"Array",proto:!0,forced:!d},{splice:function(t,e){var n,r,h,d,y,b,m=i(this),x=u(m),_=o(t,x),O=arguments.length;for(0===O?n=r=0:1===O?(n=0,r=x-_):(n=O-2,r=g(v(s(e),0),x-_)),l(x+n-r),h=c(m,r),d=0;d<r;d++)(y=_+d)in m&&f(h,d,m[y]);if(h.length=r,n<r){for(d=_;d<x-r;d++)y=d+r,b=d+n,y in m?m[b]=m[y]:p(m,b);for(d=x;d>x-r+n;d--)p(m,d-1)}else if(n>r)for(d=x-r;d>_;d--)y=d+r-1,b=d+n-1,y in m?m[b]=m[y]:p(m,b);for(d=0;d<n;d++)m[d+_]=arguments[d+2];return a(m,x-r+n),h}})},function(t,e,n){"use strict";var r=n(3),i=n(14),o=n(10),s=n(27),u=n(58),a=n(22),l=1!==[].unshift(0),c=!function(){try{Object.defineProperty([],"length",{writable:!1}).unshift()}catch(t){return t instanceof TypeError}}();r({target:"Array",proto:!0,arity:1,forced:l||c},{unshift:function(t){var e=i(this),n=o(e),r=arguments.length;if(r){a(n+r);for(var l=n;l--;){var c=l+r;l in e?e[c]=e[l]:u(e,c)}for(var f=0;f<r;f++)e[f]=arguments[f]}return s(e,n+r)}})},function(t,e,n){"use strict";var r=n(3),i=n(71).trim;r({target:"String",proto:!0,forced:n(121)("trim")},{trim:function(){return i(this)}})},function(t,e){},function(t,e){t.exports=function(t,e,n,r,i,o){var s,u=t=t||{},a=typeof t.default;"object"!==a&&"function"!==a||(s=t,u=t.default);var l="function"==typeof u?u.options:u;e&&(l.render=e.render,l.staticRenderFns=e.staticRenderFns,l._compiled=!0),n&&(l.functional=!0),i&&(l._scopeId=i);var c;if(o?(c=function(t){t=t||this.$vnode&&this.$vnode.ssrContext||this.parent&&this.parent.$vnode&&this.parent.$vnode.ssrContext,t||"undefined"==typeof __VUE_SSR_CONTEXT__||(t=__VUE_SSR_CONTEXT__),r&&r.call(this,t),t&&t._registeredComponents&&t._registeredComponents.add(o)},l._ssrRegister=c):r&&(c=r),c){var f=l.functional,p=f?l.render:l.beforeCreate;f?(l._injectStyles=c,l.render=function(t,e){return c.call(e),p(t,e)}):l.beforeCreate=p?[].concat(p,c):[c]}return{esModule:s,exports:u,options:l}}},function(t,e,n){"use strict";var r=function(){var t=this,e=t.$createElement,n=t._self._c||e;return n("div",{staticClass:"multiselect",class:{"multiselect--active":t.isOpen,"multiselect--disabled":t.disabled,"multiselect--above":t.isAbove,"multiselect--has-options-group":t.hasOptionGroup},attrs:{tabindex:t.searchable?-1:t.tabindex,role:"combobox","aria-owns":"listbox-"+t.id},on:{focus:function(e){return t.activate()},blur:function(e){!t.searchable&&t.deactivate()},keydown:[function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"down",40,e.key,["Down","ArrowDown"])?null:e.target!==e.currentTarget?null:(e.preventDefault(),t.pointerForward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"up",38,e.key,["Up","ArrowUp"])?null:e.target!==e.currentTarget?null:(e.preventDefault(),t.pointerBackward())}],keypress:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"enter",13,e.key,"Enter")&&t._k(e.keyCode,"tab",9,e.key,"Tab")?null:(e.stopPropagation(),e.target!==e.currentTarget?null:t.addPointerElement(e))},keyup:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"esc",27,e.key,["Esc","Escape"])?null:t.deactivate()}}},[t._t("caret",function(){return[n("div",{staticClass:"multiselect__select",on:{mousedown:function(e){return e.preventDefault(),e.stopPropagation(),t.toggle()}}})]},{toggle:t.toggle}),t._v(" "),t._t("clear",null,{search:t.search}),t._v(" "),n("div",{ref:"tags",staticClass:"multiselect__tags"},[t._t("selection",function(){return[n("div",{directives:[{name:"show",rawName:"v-show",value:t.visibleValues.length>0,expression:"visibleValues.length > 0"}],staticClass:"multiselect__tags-wrap"},[t._l(t.visibleValues,function(e,r){return[t._t("tag",function(){return[n("span",{key:r,staticClass:"multiselect__tag"},[n("span",{domProps:{textContent:t._s(t.getOptionLabel(e))}}),t._v(" "),n("i",{staticClass:"multiselect__tag-icon",attrs:{tabindex:"1"},on:{keypress:function(n){return!n.type.indexOf("key")&&t._k(n.keyCode,"enter",13,n.key,"Enter")?null:(n.preventDefault(),t.removeElement(e))},mousedown:function(n){return n.preventDefault(),t.removeElement(e)}}})])]},{option:e,search:t.search,remove:t.removeElement})]})],2),t._v(" "),t.internalValue&&t.internalValue.length>t.limit?[t._t("limit",function(){return[n("strong",{staticClass:"multiselect__strong",domProps:{textContent:t._s(t.limitText(t.internalValue.length-t.limit))}})]})]:t._e()]},{search:t.search,remove:t.removeElement,values:t.visibleValues,isOpen:t.isOpen}),t._v(" "),n("transition",{attrs:{name:"multiselect__loading"}},[t._t("loading",function(){return[n("div",{directives:[{name:"show",rawName:"v-show",value:t.loading,expression:"loading"}],staticClass:"multiselect__spinner"})]})],2),t._v(" "),t.searchable?n("input",{ref:"search",staticClass:"multiselect__input",style:t.inputStyle,attrs:{name:t.name,id:t.id,type:"text",autocomplete:"off",spellcheck:"false",placeholder:t.placeholder,disabled:t.disabled,tabindex:t.tabindex,"aria-controls":"listbox-"+t.id},domProps:{value:t.search},on:{input:function(e){return t.updateSearch(e.target.value)},focus:function(e){return e.preventDefault(),t.activate()},blur:function(e){return e.preventDefault(),t.deactivate()},keyup:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"esc",27,e.key,["Esc","Escape"])?null:t.deactivate()},keydown:[function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"down",40,e.key,["Down","ArrowDown"])?null:(e.preventDefault(),t.pointerForward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"up",38,e.key,["Up","ArrowUp"])?null:(e.preventDefault(),t.pointerBackward())},function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"delete",[8,46],e.key,["Backspace","Delete","Del"])?null:(e.stopPropagation(),t.removeLastElement())}],keypress:function(e){return!e.type.indexOf("key")&&t._k(e.keyCode,"enter",13,e.key,"Enter")?null:(e.preventDefault(),e.stopPropagation(),e.target!==e.currentTarget?null:t.addPointerElement(e))}}}):t._e(),t._v(" "),t.isSingleLabelVisible?n("span",{staticClass:"multiselect__single",on:{mousedown:function(e){return e.preventDefault(),t.toggle.apply(null,arguments)}}},[t._t("singleLabel",function(){return[[t._v(t._s(t.currentOptionLabel))]]},{option:t.singleValue})],2):t._e(),t._v(" "),t.isPlaceholderVisible?n("span",{staticClass:"multiselect__placeholder",on:{mousedown:function(e){return e.preventDefault(),t.toggle.apply(null,arguments)}}},[t._t("placeholder",function(){return[t._v("\n          "+t._s(t.placeholder)+"\n        ")]})],2):t._e()],2),t._v(" "),n("transition",{attrs:{name:"multiselect"}},[n("div",{directives:[{name:"show",rawName:"v-show",value:t.isOpen,expression:"isOpen"}],ref:"list",staticClass:"multiselect__content-wrapper",style:{maxHeight:t.optimizedHeight+"px"},attrs:{tabindex:"-1"},on:{focus:t.activate,mousedown:function(t){t.preventDefault()}}},[n("ul",{staticClass:"multiselect__content",style:t.contentStyle,attrs:{role:"listbox",id:"listbox-"+t.id}},[t._t("beforeList"),t._v(" "),t.multiple&&t.max===t.internalValue.length?n("li",[n("span",{staticClass:"multiselect__option"},[t._t("maxElements",function(){return[t._v("Maximum of "+t._s(t.max)+" options selected. First remove a selected option to select another.")]})],2)]):t._e(),t._v(" "),!t.max||t.internalValue.length<t.max?t._l(t.filteredOptions,function(e,r){return n("li",{key:r,staticClass:"multiselect__element",attrs:{id:t.id+"-"+r,role:e&&(e.$isLabel||e.$isDisabled)?null:"option"}},[e&&(e.$isLabel||e.$isDisabled)?t._e():n("span",{staticClass:"multiselect__option",class:t.optionHighlight(r,e),attrs:{"data-select":e&&e.isTag?t.tagPlaceholder:t.selectLabelText,"data-selected":t.selectedLabelText,"data-deselect":t.deselectLabelText},on:{click:function(n){return n.stopPropagation(),t.select(e)},mouseenter:function(e){return e.target!==e.currentTarget?null:t.pointerSet(r)}}},[t._t("option",function(){return[n("span",[t._v(t._s(t.getOptionLabel(e)))])]},{option:e,search:t.search,index:r})],2),t._v(" "),e&&(e.$isLabel||e.$isDisabled)?n("span",{staticClass:"multiselect__option",class:t.groupHighlight(r,e),attrs:{"data-select":t.groupSelect&&t.selectGroupLabelText,"data-deselect":t.groupSelect&&t.deselectGroupLabelText},on:{mouseenter:function(e){if(e.target!==e.currentTarget)return null;t.groupSelect&&t.pointerSet(r)},mousedown:function(n){return n.preventDefault(),t.selectGroup(e)}}},[t._t("option",function(){return[n("span",[t._v(t._s(t.getOptionLabel(e)))])]},{option:e,search:t.search,index:r})],2):t._e()])}):t._e(),t._v(" "),n("li",{directives:[{name:"show",rawName:"v-show",value:t.showNoResults&&0===t.filteredOptions.length&&t.search&&!t.loading,expression:"showNoResults && (filteredOptions.length === 0 && search && !loading)"}]},[n("span",{staticClass:"multiselect__option"},[t._t("noResult",function(){return[t._v("No elements found. Consider changing the search query.")]},{search:t.search})],2)]),t._v(" "),n("li",{directives:[{name:"show",rawName:"v-show",value:t.showNoOptions&&(0===t.options.length||!0===t.hasOptionGroup&&0===t.filteredOptions.length)&&!t.search&&!t.loading,expression:"showNoOptions && ((options.length === 0 || (hasOptionGroup === true && filteredOptions.length === 0)) && !search && !loading)"}]},[n("span",{staticClass:"multiselect__option"},[t._t("noOptions",function(){return[t._v("List is empty.")]})],2)]),t._v(" "),t._t("afterList")],2)])])],2)},i=[],o={render:r,staticRenderFns:i};e.a=o},function(t,e){var n;n=function(){return this}();try{n=n||Function("return this")()||(0,eval)("this")}catch(t){"object"==typeof window&&(n=window)}t.exports=n}])});
 
 /***/ }),
 
@@ -43145,7 +43125,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "watchPostEffect", function() { return watchPostEffect; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "watchSyncEffect", function() { return watchSyncEffect; });
 /*!
- * Vue.js v2.7.15
+ * Vue.js v2.7.16
  * (c) 2014-2023 Evan You
  * Released under the MIT License.
  */
@@ -43222,8 +43202,15 @@ function toString(val) {
     return val == null
         ? ''
         : Array.isArray(val) || (isPlainObject(val) && val.toString === _toString)
-            ? JSON.stringify(val, null, 2)
+            ? JSON.stringify(val, replacer, 2)
             : String(val);
+}
+function replacer(_key, val) {
+    // avoid circular deps from v3
+    if (val && val.__v_isRef) {
+        return val.value;
+    }
+    return val;
 }
 /**
  * Convert an input value to a number for persistence.
@@ -43889,6 +43876,11 @@ var __assign = function() {
     return __assign.apply(this, arguments);
 };
 
+typeof SuppressedError === "function" ? SuppressedError : function (error, suppressed, message) {
+    var e = new Error(message);
+    return e.name = "SuppressedError", e.error = error, e.suppressed = suppressed, e;
+};
+
 var uid$2 = 0;
 var pendingCleanupDeps = [];
 var cleanupDeps = function () {
@@ -44117,7 +44109,8 @@ function observe(value, shallow, ssrMockReactivity) {
 /**
  * Define a reactive property on an Object.
  */
-function defineReactive(obj, key, val, customSetter, shallow, mock) {
+function defineReactive(obj, key, val, customSetter, shallow, mock, observeEvenIfShallow) {
+    if (observeEvenIfShallow === void 0) { observeEvenIfShallow = false; }
     var dep = new Dep();
     var property = Object.getOwnPropertyDescriptor(obj, key);
     if (property && property.configurable === false) {
@@ -44130,7 +44123,7 @@ function defineReactive(obj, key, val, customSetter, shallow, mock) {
         (val === NO_INITIAL_VALUE || arguments.length === 2)) {
         val = obj[key];
     }
-    var childOb = !shallow && observe(val, false, mock);
+    var childOb = shallow ? val && val.__ob__ : observe(val, false, mock);
     Object.defineProperty(obj, key, {
         enumerable: true,
         configurable: true,
@@ -44176,7 +44169,7 @@ function defineReactive(obj, key, val, customSetter, shallow, mock) {
             else {
                 val = newVal;
             }
-            childOb = !shallow && observe(newVal, false, mock);
+            childOb = shallow ? newVal && newVal.__ob__ : observe(newVal, false, mock);
             if (true) {
                 dep.notify({
                     type: "set" /* TriggerOpTypes.SET */,
@@ -45655,11 +45648,10 @@ function renderMixin(Vue) {
         // to the data on the placeholder node.
         vm.$vnode = _parentVnode;
         // render self
+        var prevInst = currentInstance;
+        var prevRenderInst = currentRenderingInstance;
         var vnode;
         try {
-            // There's no need to maintain a stack because all render fns are called
-            // separately from one another. Nested component's render fns are called
-            // when parent component is patched.
             setCurrentInstance(vm);
             currentRenderingInstance = vm;
             vnode = render.call(vm._renderProxy, vm.$createElement);
@@ -45683,8 +45675,8 @@ function renderMixin(Vue) {
             }
         }
         finally {
-            currentRenderingInstance = null;
-            setCurrentInstance();
+            currentRenderingInstance = prevRenderInst;
+            setCurrentInstance(prevInst);
         }
         // if the returned array contains only a single node, allow it
         if (isArray(vnode) && vnode.length === 1) {
@@ -46594,7 +46586,10 @@ function doWatch(source, cb, _a) {
     var instance = currentInstance;
     var call = function (fn, type, args) {
         if (args === void 0) { args = null; }
-        return invokeWithErrorHandling(fn, null, args, instance, type);
+        var res = invokeWithErrorHandling(fn, null, args, instance, type);
+        if (deep && res && res.__ob__)
+            res.__ob__.dep.depend();
+        return res;
     };
     var getter;
     var forceTrigger = false;
@@ -46619,6 +46614,7 @@ function doWatch(source, cb, _a) {
                     return s.value;
                 }
                 else if (isReactive(s)) {
+                    s.__ob__.dep.depend();
                     return traverse(s);
                 }
                 else if (isFunction(s)) {
@@ -47170,7 +47166,7 @@ function onErrorCaptured(hook, target) {
 /**
  * Note: also update dist/vue.runtime.mjs when adding new exports to this file.
  */
-var version = '2.7.15';
+var version = '2.7.16';
 /**
  * @internal type is manually declared in <root>/types/v3-define-component.d.ts
  */
@@ -47488,7 +47484,7 @@ function initProps$1(vm, propsOptions) {
                         "Instead, use a data or computed property based on the prop's " +
                         "value. Prop being mutated: \"".concat(key, "\""), vm);
                 }
-            });
+            }, true /* shallow */);
         }
         else {}
         // static props are already proxied on the component's prototype
@@ -47808,6 +47804,9 @@ function initMixin$1(Vue) {
         vm.__v_skip = true;
         // effect scope
         vm._scope = new EffectScope(true /* detached */);
+        // #13134 edge case where a child component is manually created during the
+        // render of a parent component
+        vm._scope.parent = undefined;
         vm._scope._vm = true;
         // merge options
         if (options && options._isComponent) {
@@ -49056,7 +49055,7 @@ function matches(pattern, name) {
     return false;
 }
 function pruneCache(keepAliveInstance, filter) {
-    var cache = keepAliveInstance.cache, keys = keepAliveInstance.keys, _vnode = keepAliveInstance._vnode;
+    var cache = keepAliveInstance.cache, keys = keepAliveInstance.keys, _vnode = keepAliveInstance._vnode, $vnode = keepAliveInstance.$vnode;
     for (var key in cache) {
         var entry = cache[key];
         if (entry) {
@@ -49066,6 +49065,7 @@ function pruneCache(keepAliveInstance, filter) {
             }
         }
     }
+    $vnode.componentOptions.children = undefined;
 }
 function pruneCacheEntry(cache, key, keys, current) {
     var entry = cache[key];
@@ -51407,10 +51407,8 @@ function updateStyle(oldVnode, vnode) {
     }
     for (name in newStyle) {
         cur = newStyle[name];
-        if (cur !== oldStyle[name]) {
-            // ie9 setting to null has no effect, must use empty string
-            setProp(el, name, cur == null ? '' : cur);
-        }
+        // ie9 setting to null has no effect, must use empty string
+        setProp(el, name, cur == null ? '' : cur);
     }
 }
 var style$1 = {

--- a/assets/js/admin-setup-wizard.js
+++ b/assets/js/admin-setup-wizard.js
@@ -109,7 +109,7 @@ jQuery(document).ready(function ($) {
     $('.atbdp-mapping-step').removeClass('active').addClass('done');
     $('.atbdp-progress-step').addClass('active');
     var counter = 0;
-    var run_import = function run_import() {
+    var _run_import = function run_import() {
       var form_data = new FormData();
       // ajax action
       form_data.append('action', 'atbdp_dummy_data_import');
@@ -142,7 +142,7 @@ jQuery(document).ready(function ($) {
           $('.directorist-importer-progress').val(response.percentage);
           if (response.percentage != '100' && counter < 150) {
             position = response.next_position;
-            run_import();
+            _run_import();
             counter++;
           } else {
             window.location = response.url;
@@ -155,7 +155,7 @@ jQuery(document).ready(function ($) {
         }
       });
     };
-    run_import();
+    _run_import();
   });
   $('.directorist-submit-importing').on('click', function (e) {
     e.preventDefault();
@@ -165,7 +165,7 @@ jQuery(document).ready(function ($) {
     $('.directorist-setup-wizard__content').addClass('hidden');
     $('.middle-content-import').removeClass('hidden');
     var type_count = 0;
-    var import_dummy = function import_dummy() {
+    var _import_dummy = function import_dummy() {
       var data = {
         action: 'directorist_setup_wizard',
         directorist_nonce: import_export_data.directorist_nonce
@@ -199,11 +199,11 @@ jQuery(document).ready(function ($) {
           $('.directorist-import-progress-bar').css('width', progressPercentage + '%');
           $('.directorist-importer-progress').val(progressPercentage);
           $('.directorist-import-progress-info-precent').text(progressPercentage + '%');
-          import_dummy();
+          _import_dummy();
         }
       });
     };
-    import_dummy();
+    _import_dummy();
   });
 
   // Reusable function to check and toggle the class based on the input value

--- a/assets/js/all-listings.js
+++ b/assets/js/all-listings.js
@@ -122,9 +122,9 @@ function debounce(func, wait, immediate) {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 var $ = jQuery;
 window.addEventListener('load', waitAndInit);
 window.addEventListener('directorist-search-form-nav-tab-reloaded', waitAndInit);
@@ -360,7 +360,6 @@ function initSelect2() {
   // Not found in any template
   '.bdas-category-search' // Not found in any template
   ];
-
   selectors.forEach(function (selector) {
     return Object(_lib_helper__WEBPACK_IMPORTED_MODULE_1__["convertToSelect2"])(selector);
   });
@@ -487,7 +486,6 @@ function maybeLazyLoadTaxonomyTermsSelect2(args) {
       if (level > 1) {
         $state.addClass('item-level-' + level); // Add class for the level (e.g., level-1, level-2, etc.)
       }
-
       $state.html(combinedText); // Set the combined content (icon + text)
 
       return $state;
@@ -1379,9 +1377,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _global_components_debounce__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../global/components/debounce */ "./assets/src/js/global/components/debounce.js");
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0___default()(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
 
@@ -2122,7 +2120,6 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
         instant_search_element.find('.directorist-header-bar .directorist-advanced-filter').css('visibility', 'hidden');
         //$(document).scrollTop( $(this).closest(".directorist-instant-search").offset().top );
       },
-
       success: function success(html) {
         if (html.view_as) {
           instant_search_element.find('.directorist-header-found-title span').text(html.count);
@@ -2362,7 +2359,6 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
         page_no = pageMatch[1]; // Extracts only the numeric value
       }
     }
-
     console.log(page_no);
     var form_data = {
       action: 'directorist_instant_search',
@@ -2787,7 +2783,6 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
     if ($(e.target).closest('.directorist-custom-range-slider__value').length > 0) {
       return; // Skip calling `filterListing` for this element
     }
-
     e.preventDefault();
     var searchElm = $(this).closest('.listing-with-sidebar');
     filterListing(searchElm);
@@ -2979,9 +2974,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1__);
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 window.addEventListener('load', function () {
   ;
   (function ($) {
@@ -2996,7 +2991,7 @@ window.addEventListener('load', function () {
           return _this.init();
         });
       }
-      _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(ReplyFormObserver, [{
+      return _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(ReplyFormObserver, [{
         key: "init",
         value: function init() {
           var node = document.querySelector('.commentlist');
@@ -3099,14 +3094,13 @@ window.addEventListener('load', function () {
           }
         }
       }]);
-      return ReplyFormObserver;
     }();
     var CommentEditHandler = /*#__PURE__*/function () {
       function CommentEditHandler() {
         _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default()(this, CommentEditHandler);
         this.init();
       }
-      _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentEditHandler, [{
+      return _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentEditHandler, [{
         key: "init",
         value: function init() {
           $(document).on('submit', '#directorist-form-comment-edit', this.onSubmit);
@@ -3175,14 +3169,13 @@ window.addEventListener('load', function () {
           $form.prepend(msg);
         }
       }]);
-      return CommentEditHandler;
     }();
     var CommentAddReplyHandler = /*#__PURE__*/function () {
       function CommentAddReplyHandler() {
         _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default()(this, CommentAddReplyHandler);
         this.init();
       }
-      _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentAddReplyHandler, [{
+      return _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentAddReplyHandler, [{
         key: "init",
         value: function init() {
           var t = setTimeout(function () {
@@ -3299,7 +3292,6 @@ window.addEventListener('load', function () {
           form.prepend($error);
         }
       }]);
-      return CommentAddReplyHandler;
     }();
     var CommentsManager = /*#__PURE__*/function () {
       function CommentsManager() {
@@ -3308,7 +3300,7 @@ window.addEventListener('load', function () {
         this.setupComponents();
         this.addEventListeners();
       }
-      _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentsManager, [{
+      return _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentsManager, [{
         key: "initStarRating",
         value: function initStarRating() {
           $('.directorist-review-criteria-select').barrating({
@@ -3401,7 +3393,6 @@ window.addEventListener('load', function () {
           new CommentEditHandler();
         }
       }]);
-      return CommentsManager;
     }();
     var commentsManager = new CommentsManager();
   })(jQuery);
@@ -3609,10 +3600,10 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayLikeToArray(arr, len) {
-  if (len == null || len > arr.length) len = arr.length;
-  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
-  return arr2;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
 }
 module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3625,8 +3616,8 @@ module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exp
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayWithHoles(arr) {
-  if (Array.isArray(arr)) return arr;
+function _arrayWithHoles(r) {
+  if (Array.isArray(r)) return r;
 }
 module.exports = _arrayWithHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3639,10 +3630,8 @@ module.exports = _arrayWithHoles, module.exports.__esModule = true, module.expor
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _classCallCheck(instance, Constructor) {
-  if (!(instance instanceof Constructor)) {
-    throw new TypeError("Cannot call a class as a function");
-  }
+function _classCallCheck(a, n) {
+  if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
 }
 module.exports = _classCallCheck, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3656,22 +3645,16 @@ module.exports = _classCallCheck, module.exports.__esModule = true, module.expor
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperties(target, props) {
-  for (var i = 0; i < props.length; i++) {
-    var descriptor = props[i];
-    descriptor.enumerable = descriptor.enumerable || false;
-    descriptor.configurable = true;
-    if ("value" in descriptor) descriptor.writable = true;
-    Object.defineProperty(target, toPropertyKey(descriptor.key), descriptor);
+function _defineProperties(e, r) {
+  for (var t = 0; t < r.length; t++) {
+    var o = r[t];
+    o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, toPropertyKey(o.key), o);
   }
 }
-function _createClass(Constructor, protoProps, staticProps) {
-  if (protoProps) _defineProperties(Constructor.prototype, protoProps);
-  if (staticProps) _defineProperties(Constructor, staticProps);
-  Object.defineProperty(Constructor, "prototype", {
-    writable: false
-  });
-  return Constructor;
+function _createClass(e, r, t) {
+  return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
+    writable: !1
+  }), e;
 }
 module.exports = _createClass, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3685,19 +3668,13 @@ module.exports = _createClass, module.exports.__esModule = true, module.exports[
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3766,8 +3743,8 @@ var arrayWithHoles = __webpack_require__(/*! ./arrayWithHoles.js */ "./node_modu
 var iterableToArrayLimit = __webpack_require__(/*! ./iterableToArrayLimit.js */ "./node_modules/@babel/runtime/helpers/iterableToArrayLimit.js");
 var unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js");
 var nonIterableRest = __webpack_require__(/*! ./nonIterableRest.js */ "./node_modules/@babel/runtime/helpers/nonIterableRest.js");
-function _slicedToArray(arr, i) {
-  return arrayWithHoles(arr) || iterableToArrayLimit(arr, i) || unsupportedIterableToArray(arr, i) || nonIterableRest();
+function _slicedToArray(r, e) {
+  return arrayWithHoles(r) || iterableToArrayLimit(r, e) || unsupportedIterableToArray(r, e) || nonIterableRest();
 }
 module.exports = _slicedToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3781,17 +3758,17 @@ module.exports = _slicedToArray, module.exports.__esModule = true, module.export
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -3804,11 +3781,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -3822,11 +3799,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -3840,13 +3817,12 @@ module.exports = _typeof, module.exports.__esModule = true, module.exports["defa
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _unsupportedIterableToArray(o, minLen) {
-  if (!o) return;
-  if (typeof o === "string") return arrayLikeToArray(o, minLen);
-  var n = Object.prototype.toString.call(o).slice(8, -1);
-  if (n === "Object" && o.constructor) n = o.constructor.name;
-  if (n === "Map" || n === "Set") return Array.from(o);
-  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
 }
 module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/directorist-dashboard.js
+++ b/assets/js/directorist-dashboard.js
@@ -539,7 +539,6 @@ __webpack_require__.r(__webpack_exports__);
       $(".directorist-user-dashboard__nav").toggleClass("directorist-dashboard-nav-collapsed");
       // $(".directorist-shade").toggleClass("directorist-active");
     });
-
     if ($(window).innerWidth() < 767) {
       $(".directorist-user-dashboard__nav").addClass("directorist-dashboard-nav-collapsed");
       $(".directorist-user-dashboard__nav").addClass("directorist-dashboard-nav-collapsed--fixed");
@@ -1110,9 +1109,9 @@ window.addEventListener('load', function () {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 /*
     Plugin: Dash Tab
     Version: 1.0.0

--- a/assets/js/directorist-plupload.js
+++ b/assets/js/directorist-plupload.js
@@ -121,7 +121,6 @@ function init() {
     } else {
       post_id = jQuery("#post input[name='post_ID']").val(); // backend
     }
-
     $(".plupload-upload-uic").each(function (ind, el) {
       var $this = $(this);
       var imgId = $this.attr("id").replace("plupload-upload-ui", "");
@@ -432,7 +431,6 @@ function plu_show_thumbs(imgId) {
         });
       }
     });
-
     thumbsC.disableSelection();
   }
 

--- a/assets/js/global-main.js
+++ b/assets/js/global-main.js
@@ -139,9 +139,9 @@ function modalToggle() {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 var $ = jQuery;
 window.addEventListener('load', waitAndInit);
 window.addEventListener('directorist-search-form-nav-tab-reloaded', waitAndInit);
@@ -377,7 +377,6 @@ function initSelect2() {
   // Not found in any template
   '.bdas-category-search' // Not found in any template
   ];
-
   selectors.forEach(function (selector) {
     return Object(_lib_helper__WEBPACK_IMPORTED_MODULE_1__["convertToSelect2"])(selector);
   });
@@ -504,7 +503,6 @@ function maybeLazyLoadTaxonomyTermsSelect2(args) {
       if (level > 1) {
         $state.addClass('item-level-' + level); // Add class for the level (e.g., level-1, level-2, etc.)
       }
-
       $state.html(combinedText); // Set the combined content (icon + text)
 
       return $state;
@@ -813,10 +811,10 @@ function convertToSelect2(selector) {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayLikeToArray(arr, len) {
-  if (len == null || len > arr.length) len = arr.length;
-  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
-  return arr2;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
 }
 module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -830,8 +828,8 @@ module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exp
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _arrayWithoutHoles(arr) {
-  if (Array.isArray(arr)) return arrayLikeToArray(arr);
+function _arrayWithoutHoles(r) {
+  if (Array.isArray(r)) return arrayLikeToArray(r);
 }
 module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -845,19 +843,13 @@ module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -870,8 +862,8 @@ module.exports = _defineProperty, module.exports.__esModule = true, module.expor
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _iterableToArray(iter) {
-  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+function _iterableToArray(r) {
+  if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r);
 }
 module.exports = _iterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -902,8 +894,8 @@ var arrayWithoutHoles = __webpack_require__(/*! ./arrayWithoutHoles.js */ "./nod
 var iterableToArray = __webpack_require__(/*! ./iterableToArray.js */ "./node_modules/@babel/runtime/helpers/iterableToArray.js");
 var unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js");
 var nonIterableSpread = __webpack_require__(/*! ./nonIterableSpread.js */ "./node_modules/@babel/runtime/helpers/nonIterableSpread.js");
-function _toConsumableArray(arr) {
-  return arrayWithoutHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableSpread();
+function _toConsumableArray(r) {
+  return arrayWithoutHoles(r) || iterableToArray(r) || unsupportedIterableToArray(r) || nonIterableSpread();
 }
 module.exports = _toConsumableArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -917,17 +909,17 @@ module.exports = _toConsumableArray, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -940,11 +932,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -958,11 +950,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -976,13 +968,12 @@ module.exports = _typeof, module.exports.__esModule = true, module.exports["defa
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _unsupportedIterableToArray(o, minLen) {
-  if (!o) return;
-  if (typeof o === "string") return arrayLikeToArray(o, minLen);
-  var n = Object.prototype.toString.call(o).slice(8, -1);
-  if (n === "Object" && o.constructor) n = o.constructor.name;
-  if (n === "Map" || n === "Set") return Array.from(o);
-  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
 }
 module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/global-markerclusterer.js
+++ b/assets/js/global-markerclusterer.js
@@ -1277,11 +1277,11 @@ ClusterIcon.prototype['onRemove'] = ClusterIcon.prototype.onRemove;
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/google-map.js
+++ b/assets/js/google-map.js
@@ -593,7 +593,6 @@ __webpack_require__.r(__webpack_exports__);
           }
           // ${$marker.data('icon')}
         });
-
         document.querySelectorAll('div').forEach(function (el1, index) {
           if (el1.style.backgroundImage.split('/').pop() === 'm1.png")') {
             el1.addEventListener('click', function () {
@@ -786,7 +785,6 @@ function initSingleMapWidget() {
         maxWidth: 400 /*Add configuration for max width*/
       });
     }
-
     var marker = new google.maps.marker.AdvancedMarkerElement({
       map: map,
       position: saved_lat_lng,
@@ -824,7 +822,6 @@ function initSingleMapWidget() {
         });
       }
     }
-
     $(document).ready(function () {
       initMap();
       //Convert address tags to google map links -
@@ -990,7 +987,6 @@ function initSingleMap() {
           maxWidth: 400 /*Add configuration for max width*/
         });
       }
-
       var marker = new google.maps.marker.AdvancedMarkerElement({
         map: map,
         position: saved_lat_lng,
@@ -1028,7 +1024,6 @@ function initSingleMap() {
           });
         }
       }
-
       initMap();
       //Convert address tags to google map links -
       $('address').each(function () {

--- a/assets/js/listing-slider.js
+++ b/assets/js/listing-slider.js
@@ -98,9 +98,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/slicedToArray */ "./node_modules/@babel/runtime/helpers/slicedToArray.js");
 /* harmony import */ var _babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_slicedToArray__WEBPACK_IMPORTED_MODULE_0__);
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 /***
     All Listing Slider
 ***/
@@ -490,10 +490,10 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayLikeToArray(arr, len) {
-  if (len == null || len > arr.length) len = arr.length;
-  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
-  return arr2;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
 }
 module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -506,8 +506,8 @@ module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exp
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayWithHoles(arr) {
-  if (Array.isArray(arr)) return arr;
+function _arrayWithHoles(r) {
+  if (Array.isArray(r)) return r;
 }
 module.exports = _arrayWithHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -576,8 +576,8 @@ var arrayWithHoles = __webpack_require__(/*! ./arrayWithHoles.js */ "./node_modu
 var iterableToArrayLimit = __webpack_require__(/*! ./iterableToArrayLimit.js */ "./node_modules/@babel/runtime/helpers/iterableToArrayLimit.js");
 var unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js");
 var nonIterableRest = __webpack_require__(/*! ./nonIterableRest.js */ "./node_modules/@babel/runtime/helpers/nonIterableRest.js");
-function _slicedToArray(arr, i) {
-  return arrayWithHoles(arr) || iterableToArrayLimit(arr, i) || unsupportedIterableToArray(arr, i) || nonIterableRest();
+function _slicedToArray(r, e) {
+  return arrayWithHoles(r) || iterableToArrayLimit(r, e) || unsupportedIterableToArray(r, e) || nonIterableRest();
 }
 module.exports = _slicedToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -591,13 +591,12 @@ module.exports = _slicedToArray, module.exports.__esModule = true, module.export
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _unsupportedIterableToArray(o, minLen) {
-  if (!o) return;
-  if (typeof o === "string") return arrayLikeToArray(o, minLen);
-  var n = Object.prototype.toString.call(o).slice(8, -1);
-  if (n === "Object" && o.constructor) n = o.constructor.name;
-  if (n === "Map" || n === "Set") return Array.from(o);
-  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
 }
 module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/openstreet-map.js
+++ b/assets/js/openstreet-map.js
@@ -421,7 +421,6 @@ __webpack_require__.r(__webpack_exports__);
       loadJsCss.list(list, {
         delayScripts: 500 // Load scripts after stylesheets, delayed by this duration (in ms).
       });
-
       function toggleFullscreen() {
         var mapContainer = document.getElementById('map');
         var fullScreenEnable = document.querySelector('#gmap_full_screen_button .fullscreen-enable');

--- a/assets/js/public-main.js
+++ b/assets/js/public-main.js
@@ -139,9 +139,9 @@ function modalToggle() {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 var $ = jQuery;
 window.addEventListener('load', waitAndInit);
 window.addEventListener('directorist-search-form-nav-tab-reloaded', waitAndInit);
@@ -377,7 +377,6 @@ function initSelect2() {
   // Not found in any template
   '.bdas-category-search' // Not found in any template
   ];
-
   selectors.forEach(function (selector) {
     return Object(_lib_helper__WEBPACK_IMPORTED_MODULE_1__["convertToSelect2"])(selector);
   });
@@ -504,7 +503,6 @@ function maybeLazyLoadTaxonomyTermsSelect2(args) {
       if (level > 1) {
         $state.addClass('item-level-' + level); // Add class for the level (e.g., level-1, level-2, etc.)
       }
-
       $state.html(combinedText); // Set the combined content (icon + text)
 
       return $state;
@@ -874,10 +872,10 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _arrayLikeToArray(arr, len) {
-  if (len == null || len > arr.length) len = arr.length;
-  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
-  return arr2;
+function _arrayLikeToArray(r, a) {
+  (null == a || a > r.length) && (a = r.length);
+  for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e];
+  return n;
 }
 module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -891,8 +889,8 @@ module.exports = _arrayLikeToArray, module.exports.__esModule = true, module.exp
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _arrayWithoutHoles(arr) {
-  if (Array.isArray(arr)) return arrayLikeToArray(arr);
+function _arrayWithoutHoles(r) {
+  if (Array.isArray(r)) return arrayLikeToArray(r);
 }
 module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -906,19 +904,13 @@ module.exports = _arrayWithoutHoles, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -931,8 +923,8 @@ module.exports = _defineProperty, module.exports.__esModule = true, module.expor
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _iterableToArray(iter) {
-  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+function _iterableToArray(r) {
+  if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r);
 }
 module.exports = _iterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -963,8 +955,8 @@ var arrayWithoutHoles = __webpack_require__(/*! ./arrayWithoutHoles.js */ "./nod
 var iterableToArray = __webpack_require__(/*! ./iterableToArray.js */ "./node_modules/@babel/runtime/helpers/iterableToArray.js");
 var unsupportedIterableToArray = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/unsupportedIterableToArray.js");
 var nonIterableSpread = __webpack_require__(/*! ./nonIterableSpread.js */ "./node_modules/@babel/runtime/helpers/nonIterableSpread.js");
-function _toConsumableArray(arr) {
-  return arrayWithoutHoles(arr) || iterableToArray(arr) || unsupportedIterableToArray(arr) || nonIterableSpread();
+function _toConsumableArray(r) {
+  return arrayWithoutHoles(r) || iterableToArray(r) || unsupportedIterableToArray(r) || nonIterableSpread();
 }
 module.exports = _toConsumableArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -978,17 +970,17 @@ module.exports = _toConsumableArray, module.exports.__esModule = true, module.ex
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -1001,11 +993,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -1019,11 +1011,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -1037,13 +1029,12 @@ module.exports = _typeof, module.exports.__esModule = true, module.exports["defa
 /***/ (function(module, exports, __webpack_require__) {
 
 var arrayLikeToArray = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/arrayLikeToArray.js");
-function _unsupportedIterableToArray(o, minLen) {
-  if (!o) return;
-  if (typeof o === "string") return arrayLikeToArray(o, minLen);
-  var n = Object.prototype.toString.call(o).slice(8, -1);
-  if (n === "Object" && o.constructor) n = o.constructor.name;
-  if (n === "Map" || n === "Set") return Array.from(o);
-  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return arrayLikeToArray(o, minLen);
+function _unsupportedIterableToArray(r, a) {
+  if (r) {
+    if ("string" == typeof r) return arrayLikeToArray(r, a);
+    var t = {}.toString.call(r).slice(8, -1);
+    return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? arrayLikeToArray(r, a) : void 0;
+  }
 }
 module.exports = _unsupportedIterableToArray, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/range-slider.js
+++ b/assets/js/range-slider.js
@@ -562,7 +562,7 @@ __webpack_require__.r(__webpack_exports__);
           - The provided value for the option;
           - A reference to the options object;
           - The name for the option;
-       The testing function returns false when an error is detected,
+        The testing function returns false when an error is detected,
       or true when everything is OK. It can also modify the option
       object, to make sure all values can be correctly looped elsewhere. */
   //region Defaults
@@ -1285,7 +1285,6 @@ __webpack_require__.r(__webpack_exports__);
       }
       return []; // pips.mode = never
     }
-
     function mapToRange(values, stepped) {
       return values.map(function (value) {
         return scope_Spectrum.fromStepping(stepped ? scope_Spectrum.getStep(value) : value);
@@ -2362,7 +2361,6 @@ __webpack_require__.r(__webpack_exports__);
       },
       pips: pips // Issue #594
     };
-
     return scope_Self;
   }
   // Run the standard initializer
@@ -2403,11 +2401,11 @@ __webpack_require__.r(__webpack_exports__);
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -122,9 +122,9 @@ function debounce(func, wait, immediate) {
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 var $ = jQuery;
 window.addEventListener('load', waitAndInit);
 window.addEventListener('directorist-search-form-nav-tab-reloaded', waitAndInit);
@@ -360,7 +360,6 @@ function initSelect2() {
   // Not found in any template
   '.bdas-category-search' // Not found in any template
   ];
-
   selectors.forEach(function (selector) {
     return Object(_lib_helper__WEBPACK_IMPORTED_MODULE_1__["convertToSelect2"])(selector);
   });
@@ -487,7 +486,6 @@ function maybeLazyLoadTaxonomyTermsSelect2(args) {
       if (level > 1) {
         $state.addClass('item-level-' + level); // Add class for the level (e.g., level-1, level-2, etc.)
       }
-
       $state.html(combinedText); // Set the combined content (icon + text)
 
       return $state;
@@ -767,7 +765,6 @@ function initSearchCategoryCustomFields($) {
       //     }
       // });
     });
-
     $pageContainer.find('.directorist-category-select, .directorist-search-category select').trigger('change');
   }
 }
@@ -998,9 +995,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _components_directoristDropdown__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(_components_directoristDropdown__WEBPACK_IMPORTED_MODULE_5__);
 /* harmony import */ var _components_directoristSelect__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./components/directoristSelect */ "./assets/src/js/public/components/directoristSelect.js");
 /* harmony import */ var _components_directoristSelect__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(_components_directoristSelect__WEBPACK_IMPORTED_MODULE_6__);
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 
 
 
@@ -2116,19 +2113,13 @@ function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len 
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperty(obj, key, value) {
-  key = toPropertyKey(key);
-  if (key in obj) {
-    Object.defineProperty(obj, key, {
-      value: value,
-      enumerable: true,
-      configurable: true,
-      writable: true
-    });
-  } else {
-    obj[key] = value;
-  }
-  return obj;
+function _defineProperty(e, r, t) {
+  return (r = toPropertyKey(r)) in e ? Object.defineProperty(e, r, {
+    value: t,
+    enumerable: !0,
+    configurable: !0,
+    writable: !0
+  }) : e[r] = t, e;
 }
 module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -2142,17 +2133,17 @@ module.exports = _defineProperty, module.exports.__esModule = true, module.expor
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -2165,11 +2156,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -2183,11 +2174,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 

--- a/assets/js/single-listing-google-map-widget.js
+++ b/assets/js/single-listing-google-map-widget.js
@@ -219,7 +219,6 @@ function initSingleMapWidget() {
         maxWidth: 400 /*Add configuration for max width*/
       });
     }
-
     var marker = new google.maps.marker.AdvancedMarkerElement({
       map: map,
       position: saved_lat_lng,
@@ -257,7 +256,6 @@ function initSingleMapWidget() {
         });
       }
     }
-
     $(document).ready(function () {
       initMap();
       //Convert address tags to google map links -

--- a/assets/js/single-listing-google-map.js
+++ b/assets/js/single-listing-google-map.js
@@ -221,7 +221,6 @@ function initSingleMap() {
           maxWidth: 400 /*Add configuration for max width*/
         });
       }
-
       var marker = new google.maps.marker.AdvancedMarkerElement({
         map: map,
         position: saved_lat_lng,
@@ -259,7 +258,6 @@ function initSingleMap() {
           });
         }
       }
-
       initMap();
       //Convert address tags to google map links -
       $('address').each(function () {

--- a/assets/js/single-listing.js
+++ b/assets/js/single-listing.js
@@ -733,9 +733,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1__);
 
 
-function _createForOfIteratorHelper(o, allowArrayLike) { var it = typeof Symbol !== "undefined" && o[Symbol.iterator] || o["@@iterator"]; if (!it) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e) { throw _e; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = it.call(o); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e2) { didErr = true; err = _e2; }, f: function f() { try { if (!normalCompletion && it.return != null) it.return(); } finally { if (didErr) throw err; } } }; }
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i]; return arr2; }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 window.addEventListener('load', function () {
   ;
   (function ($) {
@@ -750,7 +750,7 @@ window.addEventListener('load', function () {
           return _this.init();
         });
       }
-      _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(ReplyFormObserver, [{
+      return _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(ReplyFormObserver, [{
         key: "init",
         value: function init() {
           var node = document.querySelector('.commentlist');
@@ -853,14 +853,13 @@ window.addEventListener('load', function () {
           }
         }
       }]);
-      return ReplyFormObserver;
     }();
     var CommentEditHandler = /*#__PURE__*/function () {
       function CommentEditHandler() {
         _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default()(this, CommentEditHandler);
         this.init();
       }
-      _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentEditHandler, [{
+      return _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentEditHandler, [{
         key: "init",
         value: function init() {
           $(document).on('submit', '#directorist-form-comment-edit', this.onSubmit);
@@ -929,14 +928,13 @@ window.addEventListener('load', function () {
           $form.prepend(msg);
         }
       }]);
-      return CommentEditHandler;
     }();
     var CommentAddReplyHandler = /*#__PURE__*/function () {
       function CommentAddReplyHandler() {
         _babel_runtime_helpers_classCallCheck__WEBPACK_IMPORTED_MODULE_0___default()(this, CommentAddReplyHandler);
         this.init();
       }
-      _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentAddReplyHandler, [{
+      return _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentAddReplyHandler, [{
         key: "init",
         value: function init() {
           var t = setTimeout(function () {
@@ -1053,7 +1051,6 @@ window.addEventListener('load', function () {
           form.prepend($error);
         }
       }]);
-      return CommentAddReplyHandler;
     }();
     var CommentsManager = /*#__PURE__*/function () {
       function CommentsManager() {
@@ -1062,7 +1059,7 @@ window.addEventListener('load', function () {
         this.setupComponents();
         this.addEventListeners();
       }
-      _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentsManager, [{
+      return _babel_runtime_helpers_createClass__WEBPACK_IMPORTED_MODULE_1___default()(CommentsManager, [{
         key: "initStarRating",
         value: function initStarRating() {
           $('.directorist-review-criteria-select').barrating({
@@ -1155,7 +1152,6 @@ window.addEventListener('load', function () {
           new CommentEditHandler();
         }
       }]);
-      return CommentsManager;
     }();
     var commentsManager = new CommentsManager();
   })(jQuery);
@@ -1233,10 +1229,8 @@ __webpack_require__.r(__webpack_exports__);
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-function _classCallCheck(instance, Constructor) {
-  if (!(instance instanceof Constructor)) {
-    throw new TypeError("Cannot call a class as a function");
-  }
+function _classCallCheck(a, n) {
+  if (!(a instanceof n)) throw new TypeError("Cannot call a class as a function");
 }
 module.exports = _classCallCheck, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -1250,22 +1244,16 @@ module.exports = _classCallCheck, module.exports.__esModule = true, module.expor
 /***/ (function(module, exports, __webpack_require__) {
 
 var toPropertyKey = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/toPropertyKey.js");
-function _defineProperties(target, props) {
-  for (var i = 0; i < props.length; i++) {
-    var descriptor = props[i];
-    descriptor.enumerable = descriptor.enumerable || false;
-    descriptor.configurable = true;
-    if ("value" in descriptor) descriptor.writable = true;
-    Object.defineProperty(target, toPropertyKey(descriptor.key), descriptor);
+function _defineProperties(e, r) {
+  for (var t = 0; t < r.length; t++) {
+    var o = r[t];
+    o.enumerable = o.enumerable || !1, o.configurable = !0, "value" in o && (o.writable = !0), Object.defineProperty(e, toPropertyKey(o.key), o);
   }
 }
-function _createClass(Constructor, protoProps, staticProps) {
-  if (protoProps) _defineProperties(Constructor.prototype, protoProps);
-  if (staticProps) _defineProperties(Constructor, staticProps);
-  Object.defineProperty(Constructor, "prototype", {
-    writable: false
-  });
-  return Constructor;
+function _createClass(e, r, t) {
+  return r && _defineProperties(e.prototype, r), t && _defineProperties(e, t), Object.defineProperty(e, "prototype", {
+    writable: !1
+  }), e;
 }
 module.exports = _createClass, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
@@ -1279,17 +1267,17 @@ module.exports = _createClass, module.exports.__esModule = true, module.exports[
 /***/ (function(module, exports, __webpack_require__) {
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
-function _toPrimitive(input, hint) {
-  if (_typeof(input) !== "object" || input === null) return input;
-  var prim = input[Symbol.toPrimitive];
-  if (prim !== undefined) {
-    var res = prim.call(input, hint || "default");
-    if (_typeof(res) !== "object") return res;
+function toPrimitive(t, r) {
+  if ("object" != _typeof(t) || !t) return t;
+  var e = t[Symbol.toPrimitive];
+  if (void 0 !== e) {
+    var i = e.call(t, r || "default");
+    if ("object" != _typeof(i)) return i;
     throw new TypeError("@@toPrimitive must return a primitive value.");
   }
-  return (hint === "string" ? String : Number)(input);
+  return ("string" === r ? String : Number)(t);
 }
-module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -1302,11 +1290,11 @@ module.exports = _toPrimitive, module.exports.__esModule = true, module.exports[
 
 var _typeof = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/typeof.js")["default"];
 var toPrimitive = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/toPrimitive.js");
-function _toPropertyKey(arg) {
-  var key = toPrimitive(arg, "string");
-  return _typeof(key) === "symbol" ? key : String(key);
+function toPropertyKey(t) {
+  var i = toPrimitive(t, "string");
+  return "symbol" == _typeof(i) ? i : i + "";
 }
-module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+module.exports = toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
 
 /***/ }),
 
@@ -1320,11 +1308,11 @@ module.exports = _toPropertyKey, module.exports.__esModule = true, module.export
 function _typeof(o) {
   "@babel/helpers - typeof";
 
-  return (module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
+  return module.exports = _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) {
     return typeof o;
   } : function (o) {
     return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o;
-  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(o);
+  }, module.exports.__esModule = true, module.exports["default"] = module.exports, _typeof(o);
 }
 module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
 


### PR DESCRIPTION
Fixed an issue where the form builder's condition system only worked for multiple conditions but not for single conditions. Refactored the checkShowIfCondition method to properly handle both single and multiple conditions in a unified way. The solution maintains backward compatibility while adding support for the new multiple condition format.

Key Changes:

> Combined single and multiple condition handling into one method
> Added proper type detection for input conditions
> Removed duplicate code and fixed inconsistent property names
> Improved code readability and maintainability
> 

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.This fix ensures that both old (single condition) and new (multiple condition) formats work correctly in the form builder. https://prnt.sc/HJgYjwip6sBY
2.
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
