### PR TITLE
Improved basic-search-form & advance-search-form condition

### DIFF
--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -2262,10 +2262,17 @@ class Directorist_Listings {
 				return substr( $key, 0, 7 ) == 'filter_';
 			}, ARRAY_FILTER_USE_KEY );
 
+			$search_form = new Directorist_Listing_Search_Form( $this->type, $this->current_listing_type, $search_field_atts );
+
+			if ( ! isset( $searchform->form_data[1]['fields'] ) || empty( $searchform->form_data[0]['fields'] ) ) {
+				return;
+			}
+
 			$args = array(
 				'listings'   => $this,
-				'searchform' => new Directorist_Listing_Search_Form( 'search_result', $this->current_listing_type, $search_field_atts ),
+				'searchform' => $search_form,
 			);
+
 			Helper::get_template( 'archive/basic-search-form', $args );
 		}
 
@@ -2275,10 +2282,17 @@ class Directorist_Listings {
 				return substr( $key, 0, 7 ) == 'filter_';
 			}, ARRAY_FILTER_USE_KEY );
 
+			$search_form = new Directorist_Listing_Search_Form( $this->type, $this->current_listing_type, $search_field_atts );
+
+			if ( ! isset( $searchform->form_data[1]['fields'] ) || empty( $searchform->form_data[1]['fields'] ) ) {
+				return;
+			}
+
 			$args = array(
 				'listings'   => $this,
-				'searchform' => new Directorist_Listing_Search_Form( 'search_result', $this->current_listing_type, $search_field_atts ),
+				'searchform' => $search_form,
 			);
+			
 			Helper::get_template( 'archive/advance-search-form', $args );
 		}
 

--- a/templates/sidebar-archive-contents.php
+++ b/templates/sidebar-archive-contents.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 					?>
 				</div>
 
-				<?php if( ! $listings->hide_top_search_bar_on_sidebar_layout() ) : ?>
+				<?php if( ! $listings->hide_top_search_bar_on_sidebar_layout() && $listings->basic_search_form_template() ) : ?>
 
 					<div class="listing-with-sidebar__searchform">
 						<?php
@@ -39,7 +39,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 				<?php endif; ?>
 
 				<div class="listing-with-sidebar__contents">
-					<?php if( isset( $searchform->form_data[1]['fields'] ) && ! empty( $searchform->form_data[1]['fields'] ) ) : ?>
+					<?php if( $listings->advance_search_form_template() ) : ?>
 						<aside class="listing-with-sidebar__sidebar <?php echo esc_attr( $listings->sidebar_class() ); ?>">
 							<?php
 								$listings->advance_search_form_template();


### PR DESCRIPTION
## PR Type
Conditional improvement. Checked empty value.
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. There is no fields on basic search-form still showing the area.
2. https://prnt.sc/oCTjd3UXBIGy 
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
