### PR TITLE
fixed paypal downlaod issue from setup wizard

### DIFF
--- a/includes/classes/class-setup-wizard.php
+++ b/includes/classes/class-setup-wizard.php
@@ -637,7 +637,7 @@ class Directorist_Setup_Wizard {
 
 
         if( ! empty( $_post_data['active_gateways'] ) && in_array( 'paypal_gateway',$_post_data['active_gateways'] ) ) {
-            directorist_download_plugin( [ 'url' => 'https://directorist.com/wp-content/uploads/2024/11/directorist-paypal.zip' ] );
+            directorist_download_plugin( [ 'url' => 'http://app.directorist.com/wp-content/uploads/2025/05/directorist-paypal.zip' ] );
 
             $path = WP_PLUGIN_DIR . '/directorist-paypal/directorist-paypal.php';
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. before : https://prnt.sc/bY_-kc4LBaUT PayPal was not installed through the setup wizard
2. After: works fine
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
