### PR TITLE
fixed paypal downlaod issue from setup wizard

### DIFF
--- a/includes/classes/class-setup-wizard.php
+++ b/includes/classes/class-setup-wizard.php
@@ -72,7 +72,7 @@ class Directorist_Setup_Wizard {
         if ( $is_completed ) {
             $has_general = get_term_by( 'slug', 'general', ATBDP_TYPE );
 
-            if ( ! is_wp_error( $has_general ) ) {
+            if ( $has_general && ! is_wp_error( $has_general ) ) {
                 wp_delete_term( $has_general->term_id, ATBDP_TYPE );
             }
 
@@ -650,9 +650,12 @@ class Directorist_Setup_Wizard {
 
 
         if ( ! empty( $_post_data['active_gateways'] ) && in_array( 'paypal_gateway',$_post_data['active_gateways'] ) ) {
-            directorist_download_plugin( [ 'url' => 'https://directorist.com/wp-content/uploads/2024/11/directorist-paypal.zip' ] );
 
-            $path = WP_PLUGIN_DIR . '/directorist-paypal/directorist-paypal.php';
+            include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+            
+            directorist_download_plugin( [ 'url' => 'https://app.directorist.com/wp-content/uploads/2025/05/directorist-paypal.zip' ] );
+
+            $path = 'directorist-paypal/directorist-paypal.php';
 
             if ( ! is_plugin_active( $path ) ) {
                 activate_plugin( $path );

--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -4515,7 +4515,7 @@ function directorist_download_plugin( array $args = [] ) {
     ];
     $args    = array_merge( $default, $args );
 
-    $allowed_host = [ 'directorist.com', 'wordpress.org', 'downloads.wordpress.org' ];
+    $allowed_host = [ 'app.directorist.com', 'directorist.com', 'wordpress.org', 'downloads.wordpress.org' ];
 
     if ( empty( $args['url'] ) || ! in_array( parse_url( $args['url'], PHP_URL_HOST ), $allowed_host, true ) ) {
         $status['success'] = false;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.before : https://prnt.sc/bY_-kc4LBaUT PayPal was not installed through the setup wizard
2. After: works fine
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
