### PR TITLE
Fix: Consistent taxonomy hierarchy indentation in add listing form

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -2333,7 +2333,7 @@ function add_listing_category_location_filter( $lisitng_type, $settings, $taxono
                 if ( ! empty( $settings['show_count'] ) ) {
                     $html .= ' (' . $count . ')';
                 }
-                $html .= add_listing_category_location_filter( $lisitng_type, $settings, $taxonomy_id, $term_id, $prefix . '&nbsp;&nbsp;&nbsp;' );
+                $html .= add_listing_category_location_filter( $lisitng_type, $settings, $taxonomy_id, $term_id, $prefix . '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;' );
                 $html .= '</option>';
             }
         }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

- Matched indentation spacing (`&nbsp;`) in add listing form with search form to ensure consistent hierarchy detection.
- This resolves an issue where Select2 failed to display proper category levels due to mismatched leading whitespace.
- Ensured both forms visually and functionally reflect category nesting in the same way.

before: https://prnt.sc/IjojUxUr4HBK
after: https://prnt.sc/dabxPhfF1EG-

## Any linked issues
Fixes #

https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/1384

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
