### PR TITLE
Range slider improved after form reset

### DIFF
--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -1516,7 +1516,7 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
         }
       });
       searchForm.querySelectorAll("input[type='hidden']:not(.listing_type)").forEach(function (el) {
-        if (el.getAttribute('name') === 'directory_type') return;
+        if (el.getAttribute('name') === 'directory_type' || el.getAttribute('name') === 'radius-search-based-on') return;
         el.value = '';
       });
       searchForm.querySelectorAll("input[type='radio']").forEach(function (el) {
@@ -2318,17 +2318,17 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
       var slider = sliderItem.querySelector('.directorist-custom-range-slider__slide');
       var minInput = sliderItem.querySelector('.directorist-custom-range-slider__value__min');
       var maxInput = sliderItem.querySelector('.directorist-custom-range-slider__value__max');
-      var sliderParent = sliderItem.closest('.directorist-search-field-radius_search');
-      var maxValue = slider.getAttribute('value') || 'none';
-      if (sliderParent) {
+      var radiusSearch = sliderItem.closest('.directorist-search-field-radius_search');
+      var defaultValue = slider.getAttribute('default-value') || '0';
+      if (radiusSearch) {
         minInput.value = '0';
-        maxInput.value = maxValue;
-        slider.directoristCustomRangeSlider.set([0, maxValue]); // Set your initial values
+        maxInput.value = defaultValue;
+        slider.directoristCustomRangeSlider.set([0, defaultValue]); // Set your initial values
       } else {
         // Reset values to their initial state
         slider.directoristCustomRangeSlider.set([0, 0]); // Set your initial values
-        minInput.value = ''; // Set your initial min value
-        maxInput.value = ''; // Set your initial max value
+        minInput.value = '0'; // Set your initial min value
+        maxInput.value = '0'; // Set your initial max value
       }
     }
 

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -1339,7 +1339,7 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
       var value = false;
 
       // Check all input fields which are not checkbox, radio & hidden
-      searchForm.querySelectorAll("input:not([type='checkbox']):not([type='radio']):not([type='hidden']):not(.wp-picker-clear)").forEach(function (el) {
+      searchForm.querySelectorAll("input:not([type='checkbox']):not([type='radio']):not([type='hidden']):not(.wp-picker-clear):not(.directorist-custom-range-slider__value__min):not(.directorist-custom-range-slider__value__max)").forEach(function (el) {
         if (el.value !== '') {
           value = true;
         }
@@ -1387,13 +1387,22 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
             resetButtonWrapper.classList.add('reset-btn-disabled');
           }
         }
+      } else {
+        setTimeout(function () {
+          enableResetButton(searchForm);
+        }, 100);
       }
     }
 
     // Enable Reset Button
     function enableResetButton(searchForm) {
-      var resetButtonWrapper = searchForm.querySelector('.directorist-advanced-filter__action');
-      resetButtonWrapper && resetButtonWrapper.classList.remove('reset-btn-disabled');
+      var $resetButtonWrapper = $(searchForm).find('.directorist-advanced-filter__action');
+      if (!$resetButtonWrapper.length) {
+        $resetButtonWrapper = $(searchForm).closest('.directorist-instant-search').find('.directorist-advanced-filter__action');
+      }
+      if ($resetButtonWrapper.length) {
+        $resetButtonWrapper.removeClass('reset-btn-disabled');
+      }
     }
 
     // Initialize Form Reset Button
@@ -2244,6 +2253,8 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
         (_slider$directoristCu = slider.directoristCustomRangeSlider) === null || _slider$directoristCu === void 0 || _slider$directoristCu.on('start', function () {
           if (sliderActivated) return;
           sliderActivated = true;
+
+          // Range slider options update
           slider.directoristCustomRangeSlider.updateOptions({
             start: [sliderMinValue, sliderMinValue],
             step: sliderStep,
@@ -2252,6 +2263,9 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
               max: sliderMaxValue
             }
           });
+
+          // Trigger range slider observer
+          rangeSliderObserver();
         });
 
         // Update slider config
@@ -2336,7 +2350,6 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
 
       // Destroy Range Slider
       slider === null || slider === void 0 || (_slider$directoristCu5 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu5 === void 0 || _slider$directoristCu5.destroy();
-      rangeSliderObserver();
     }
 
     // DOM Mutation Observer on Location Field

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -1568,6 +1568,16 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
     if ($('.directorist-btn-reset-js') !== null) {
       $('body').on('click', '.directorist-btn-reset-js', function (e) {
         e.preventDefault();
+        // Clear URL params on modal form reset
+        if (this.closest('.directorist-search-modal')) {
+          // Clear only the query parameters 
+          var baseUrl = window.location.origin + window.location.pathname;
+
+          // Update the URL in the address bar 
+          window.history.replaceState(null, '', baseUrl);
+        }
+
+        // Reset search form values
         if (this.closest('.directorist-contents-wrap')) {
           var _searchForm = this.closest('.directorist-contents-wrap').querySelector('.directorist-search-form');
           if (_searchForm) {
@@ -2251,7 +2261,7 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
 
         // Handle first interaction
         (_slider$directoristCu = slider.directoristCustomRangeSlider) === null || _slider$directoristCu === void 0 || _slider$directoristCu.on('start', function () {
-          if (sliderActivated) return;
+          if (sliderActivated || sliderRadiusActive) return;
           sliderActivated = true;
 
           // Range slider options update
@@ -2271,7 +2281,7 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
         // Update slider config
         (_slider$directoristCu2 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu2 === void 0 || _slider$directoristCu2.on('update', function (values, handle) {
           var value = Math.round(values[handle]);
-          // Assign minmax value based on handler
+          // Assign min-max value based on handler
           if (handle === 0) {
             minInput.value = value;
           } else {

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -2271,6 +2271,7 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
         // Update slider config
         (_slider$directoristCu2 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu2 === void 0 || _slider$directoristCu2.on('update', function (values, handle) {
           var value = Math.round(values[handle]);
+          // Assign minmax value based on handler
           if (handle === 0) {
             minInput.value = value;
           } else {
@@ -2329,27 +2330,31 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
 
     // Reset Custom Range Slider
     function resetCustomRangeSlider(sliderItem) {
-      var _slider$directoristCu5;
       var slider = sliderItem.querySelector('.directorist-custom-range-slider__slide');
       var minInput = sliderItem.querySelector('.directorist-custom-range-slider__value__min');
       var maxInput = sliderItem.querySelector('.directorist-custom-range-slider__value__max');
+      var rangeValue = sliderItem.querySelector('.directorist-custom-range-slider__range');
       var radiusSearch = sliderItem.closest('.directorist-search-field-radius_search');
       var defaultValue = slider.getAttribute('default-value') || '0';
       if (radiusSearch) {
         var _slider$directoristCu3;
         minInput.value = '0';
         maxInput.value = defaultValue;
-        slider === null || slider === void 0 || (_slider$directoristCu3 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu3 === void 0 || _slider$directoristCu3.set([0, defaultValue]); // Set your initial values
+        slider === null || slider === void 0 || (_slider$directoristCu3 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu3 === void 0 || _slider$directoristCu3.set([0, defaultValue]); // Set initial values
       } else {
         var _slider$directoristCu4;
         // Reset values to their initial state
-        slider === null || slider === void 0 || (_slider$directoristCu4 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu4 === void 0 || _slider$directoristCu4.set([0, 0]); // Set your initial values
-        minInput.value = '0'; // Set your initial min value
-        maxInput.value = '0'; // Set your initial max value
+        slider === null || slider === void 0 || (_slider$directoristCu4 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu4 === void 0 || _slider$directoristCu4.set([0, 0]); // Set initial values
+        minInput.value = '0'; // Set initial min value
+        maxInput.value = '0'; // Set initial max value
+        rangeValue.value = '0-0';
       }
-
-      // Destroy Range Slider
-      slider === null || slider === void 0 || (_slider$directoristCu5 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu5 === void 0 || _slider$directoristCu5.destroy();
+      var sidebarRangeSlider = slider.closest('.listing-with-sidebar');
+      if (sidebarRangeSlider && slider !== null && slider !== void 0 && slider.directoristCustomRangeSlider) {
+        // Destroy the custom range slider instance
+        slider.directoristCustomRangeSlider.destroy();
+        delete slider.directoristCustomRangeSlider;
+      }
     }
 
     // DOM Mutation Observer on Location Field

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -2315,21 +2315,28 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
 
     // Reset Custom Range Slider
     function resetCustomRangeSlider(sliderItem) {
+      var _slider$directoristCu5;
       var slider = sliderItem.querySelector('.directorist-custom-range-slider__slide');
       var minInput = sliderItem.querySelector('.directorist-custom-range-slider__value__min');
       var maxInput = sliderItem.querySelector('.directorist-custom-range-slider__value__max');
       var radiusSearch = sliderItem.closest('.directorist-search-field-radius_search');
       var defaultValue = slider.getAttribute('default-value') || '0';
       if (radiusSearch) {
+        var _slider$directoristCu3;
         minInput.value = '0';
         maxInput.value = defaultValue;
-        slider.directoristCustomRangeSlider.set([0, defaultValue]); // Set your initial values
+        slider === null || slider === void 0 || (_slider$directoristCu3 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu3 === void 0 || _slider$directoristCu3.set([0, defaultValue]); // Set your initial values
       } else {
+        var _slider$directoristCu4;
         // Reset values to their initial state
-        slider.directoristCustomRangeSlider.set([0, 0]); // Set your initial values
+        slider === null || slider === void 0 || (_slider$directoristCu4 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu4 === void 0 || _slider$directoristCu4.set([0, 0]); // Set your initial values
         minInput.value = '0'; // Set your initial min value
         maxInput.value = '0'; // Set your initial max value
       }
+
+      // Destroy Range Slider
+      slider === null || slider === void 0 || (_slider$directoristCu5 = slider.directoristCustomRangeSlider) === null || _slider$directoristCu5 === void 0 || _slider$directoristCu5.destroy();
+      rangeSliderObserver();
     }
 
     // DOM Mutation Observer on Location Field
@@ -2430,14 +2437,15 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
     }
 
     // Custom Range Slider Value Check on Change
-    function sliderValueCheck(targetNode, value) {
-      var searchForm = targetNode.closest('form');
+    function sliderValueCheck(searchForm, targetNode, value) {
       if (value > 0) {
-        var customSliderMin = targetNode.closest('.directorist-custom-range-slider').querySelector('.directorist-custom-range-slider__value__min');
-        var customSliderRange = targetNode.closest('.directorist-custom-range-slider').querySelector('.directorist-custom-range-slider__range');
+        enableResetButton(searchForm);
+        var rangeSlider = targetNode.closest('.directorist-custom-range-slider');
+        if (!rangeSlider) return;
+        var customSliderMin = rangeSlider.querySelector('.directorist-custom-range-slider__value__min');
+        var customSliderRange = rangeSlider.querySelector('.directorist-custom-range-slider__range');
         customSliderMin.value = customSliderMin.value ? customSliderMin.value : 0;
         customSliderRange.value = customSliderMin.value + '-' + value;
-        enableResetButton(searchForm);
       } else {
         initForm(searchForm);
       }
@@ -2448,6 +2456,7 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
       var targetNodes = document.querySelectorAll('.directorist-search-field:not(.directorist-search-field-radius_search) .directorist-custom-range-slider-handle-upper');
       targetNodes.forEach(function (targetNode) {
         if (targetNode) {
+          var _searchForm2 = targetNode.closest('form');
           var observerCallback = function observerCallback(mutationList, observer) {
             var _iterator = _createForOfIteratorHelper(mutationList),
               _step;
@@ -2455,7 +2464,7 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
               for (_iterator.s(); !(_step = _iterator.n()).done;) {
                 var mutation = _step.value;
                 if (targetNode.classList.contains('directorist-custom-range-slider-handle-upper')) {
-                  sliderValueCheck(targetNode, parseInt(targetNode.ariaValueNow));
+                  sliderValueCheck(_searchForm2, targetNode, parseInt(targetNode.ariaValueNow));
                 }
               }
             } catch (err) {

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -1735,7 +1735,7 @@ import "./components/directoristSelect";
 				// Update slider config
 				slider.directoristCustomRangeSlider?.on('update', function (values, handle) {
 					const value = Math.round(values[handle]);
-
+					// Assign minmax value based on handler
 					if (handle === 0) {
 						minInput.value = value;
 					} else {
@@ -1809,6 +1809,9 @@ import "./components/directoristSelect";
 			let maxInput = sliderItem.querySelector(
 				'.directorist-custom-range-slider__value__max'
 			);
+			let rangeValue = sliderItem.querySelector(
+				'.directorist-custom-range-slider__range'
+			);
 			let radiusSearch = sliderItem.closest(
 				'.directorist-search-field-radius_search'
 			);
@@ -1817,16 +1820,23 @@ import "./components/directoristSelect";
 			if (radiusSearch) {
 				minInput.value = '0';
 				maxInput.value = defaultValue;
-				slider?.directoristCustomRangeSlider?.set([0, defaultValue]); // Set your initial values
+				slider?.directoristCustomRangeSlider?.set([0, defaultValue]); // Set initial values
 			} else {
 				// Reset values to their initial state
-				slider?.directoristCustomRangeSlider?.set([0, 0]); // Set your initial values
-				minInput.value = '0'; // Set your initial min value
-				maxInput.value = '0'; // Set your initial max value
+				slider?.directoristCustomRangeSlider?.set([0, 0]); // Set initial values
+				minInput.value = '0'; // Set initial min value
+				maxInput.value = '0'; // Set initial max value
+				rangeValue.value = '0-0';
 			}
 
-			// Destroy Range Slider
-			slider?.directoristCustomRangeSlider?.destroy();
+			const sidebarRangeSlider = slider.closest('.listing-with-sidebar');
+
+			if (sidebarRangeSlider && slider?.directoristCustomRangeSlider) {
+				// Destroy the custom range slider instance
+				slider.directoristCustomRangeSlider.destroy();
+				delete slider.directoristCustomRangeSlider;
+			}
+
 		}
 
 		// DOM Mutation Observer on Location Field

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -589,6 +589,16 @@ import "./components/directoristSelect";
 		if ($('.directorist-btn-reset-js') !== null) {
 			$('body').on('click', '.directorist-btn-reset-js', function (e) {
 				e.preventDefault();
+				// Clear URL params on modal form reset
+				if (this.closest('.directorist-search-modal')) {
+					// Clear only the query parameters 
+					const baseUrl = window.location.origin + window.location.pathname;
+
+					// Update the URL in the address bar 
+					window.history.replaceState(null, '', baseUrl);
+				}
+
+				// Reset search form values
 				if (this.closest('.directorist-contents-wrap')) {
 					let searchForm = this.closest(
 						'.directorist-contents-wrap'
@@ -596,12 +606,14 @@ import "./components/directoristSelect";
 					if (searchForm) {
 						adsFormReset(searchForm);
 					}
+					
 					let advanceSearchForm = this.closest(
 						'.directorist-contents-wrap'
 					).querySelector('.directorist-advanced-filter__form');
 					if (advanceSearchForm) {
 						adsFormReset(advanceSearchForm);
 					}
+
 					let advanceSearchFilter = this.closest(
 						'.directorist-contents-wrap'
 					).querySelector('.directorist-advanced-filter__advanced');
@@ -1715,7 +1727,7 @@ import "./components/directoristSelect";
 
 				// Handle first interaction
 				slider.directoristCustomRangeSlider?.on('start', function () {
-					if (sliderActivated) return;
+					if (sliderActivated || sliderRadiusActive) return;
 					sliderActivated = true;
 
 					// Range slider options update
@@ -1735,7 +1747,7 @@ import "./components/directoristSelect";
 				// Update slider config
 				slider.directoristCustomRangeSlider?.on('update', function (values, handle) {
 					const value = Math.round(values[handle]);
-					// Assign minmax value based on handler
+					// Assign min-max value based on handler
 					if (handle === 0) {
 						minInput.value = value;
 					} else {

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -1804,13 +1804,17 @@ import "./components/directoristSelect";
 			if (radiusSearch) {
 				minInput.value = '0';
 				maxInput.value = defaultValue;
-				slider.directoristCustomRangeSlider.set([0, defaultValue]); // Set your initial values
+				slider?.directoristCustomRangeSlider?.set([0, defaultValue]); // Set your initial values
 			} else {
 				// Reset values to their initial state
-				slider.directoristCustomRangeSlider.set([0, 0]); // Set your initial values
+				slider?.directoristCustomRangeSlider?.set([0, 0]); // Set your initial values
 				minInput.value = '0'; // Set your initial min value
 				maxInput.value = '0'; // Set your initial max value
 			}
+
+			// Destroy Range Slider
+			slider?.directoristCustomRangeSlider?.destroy();
+			rangeSliderObserver();
 		}
 
 		// DOM Mutation Observer on Location Field
@@ -1936,22 +1940,21 @@ import "./components/directoristSelect";
 		}
 
 		// Custom Range Slider Value Check on Change
-		function sliderValueCheck(targetNode, value) {
-			let searchForm = targetNode.closest('form');
+		function sliderValueCheck(searchForm, targetNode, value) {
 			if (value > 0) {
-				let customSliderMin = targetNode
-					.closest('.directorist-custom-range-slider')
-					.querySelector(
-						'.directorist-custom-range-slider__value__min'
-					);
-				let customSliderRange = targetNode
-					.closest('.directorist-custom-range-slider')
-					.querySelector('.directorist-custom-range-slider__range');
+				enableResetButton(searchForm);
+
+				const rangeSlider = targetNode.closest('.directorist-custom-range-slider');
+
+				if (!rangeSlider) return; 
+
+				let customSliderMin = rangeSlider.querySelector('.directorist-custom-range-slider__value__min');
+				let customSliderRange = rangeSlider.querySelector('.directorist-custom-range-slider__range');
+
 				customSliderMin.value = customSliderMin.value
 					? customSliderMin.value
 					: 0;
 				customSliderRange.value = customSliderMin.value + '-' + value;
-				enableResetButton(searchForm);
 			} else {
 				initForm(searchForm);
 			}
@@ -1964,6 +1967,7 @@ import "./components/directoristSelect";
 			);
 			targetNodes.forEach((targetNode) => {
 				if (targetNode) {
+					const searchForm = targetNode.closest('form');
 					let observerCallback = (mutationList, observer) => {
 						for (let mutation of mutationList) {
 							if (
@@ -1972,6 +1976,7 @@ import "./components/directoristSelect";
 								)
 							) {
 								sliderValueCheck(
+									searchForm,
 									targetNode,
 									parseInt(targetNode.ariaValueNow)
 								);

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -495,7 +495,7 @@ import "./components/directoristSelect";
 			searchForm
 				.querySelectorAll("input[type='hidden']:not(.listing_type)")
 				.forEach(function (el) {
-					if (el.getAttribute('name') === 'directory_type') return;
+					if (el.getAttribute('name') === 'directory_type' || el.getAttribute('name') === 'radius-search-based-on') return;
 					el.value = '';
 				});
 			searchForm
@@ -1796,20 +1796,20 @@ import "./components/directoristSelect";
 			let maxInput = sliderItem.querySelector(
 				'.directorist-custom-range-slider__value__max'
 			);
-			let sliderParent = sliderItem.closest(
+			let radiusSearch = sliderItem.closest(
 				'.directorist-search-field-radius_search'
 			);
-			let maxValue = slider.getAttribute('value') || 'none';
+			let defaultValue = slider.getAttribute('default-value') || '0';
 
-			if (sliderParent) {
+			if (radiusSearch) {
 				minInput.value = '0';
-				maxInput.value = maxValue;
-				slider.directoristCustomRangeSlider.set([0, maxValue]); // Set your initial values
+				maxInput.value = defaultValue;
+				slider.directoristCustomRangeSlider.set([0, defaultValue]); // Set your initial values
 			} else {
 				// Reset values to their initial state
 				slider.directoristCustomRangeSlider.set([0, 0]); // Set your initial values
-				minInput.value = ''; // Set your initial min value
-				maxInput.value = ''; // Set your initial max value
+				minInput.value = '0'; // Set your initial min value
+				maxInput.value = '0'; // Set your initial max value
 			}
 		}
 

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -229,7 +229,7 @@ import "./components/directoristSelect";
 			// Check all input fields which are not checkbox, radio & hidden
 			searchForm
 				.querySelectorAll(
-					"input:not([type='checkbox']):not([type='radio']):not([type='hidden']):not(.wp-picker-clear)"
+					"input:not([type='checkbox']):not([type='radio']):not([type='hidden']):not(.wp-picker-clear):not(.directorist-custom-range-slider__value__min):not(.directorist-custom-range-slider__value__max)"
 				)
 				.forEach(function (el) {
 					if (el.value !== '') {
@@ -285,17 +285,26 @@ import "./components/directoristSelect";
 					if (resetButtonWrapper) {
 						resetButtonWrapper.classList.add('reset-btn-disabled');
 					}
-				}
+				}			
+			} else {
+				setTimeout(function () {
+					enableResetButton(searchForm)
+				}, 100);
 			}
 		}
 
 		// Enable Reset Button
 		function enableResetButton(searchForm) {
-			let resetButtonWrapper = searchForm.querySelector(
-				'.directorist-advanced-filter__action'
-			);
-			resetButtonWrapper &&
-				resetButtonWrapper.classList.remove('reset-btn-disabled');
+			let $resetButtonWrapper = $(searchForm).find('.directorist-advanced-filter__action');
+
+			if (!$resetButtonWrapper.length) {
+				$resetButtonWrapper = $(searchForm).closest('.directorist-instant-search').find('.directorist-advanced-filter__action');
+			}
+
+			if ($resetButtonWrapper.length) {
+				$resetButtonWrapper.removeClass('reset-btn-disabled');
+			}
+
 		}
 
 		// Initialize Form Reset Button
@@ -1709,6 +1718,7 @@ import "./components/directoristSelect";
 					if (sliderActivated) return;
 					sliderActivated = true;
 
+					// Range slider options update
 					slider.directoristCustomRangeSlider.updateOptions({
 						start: [sliderMinValue, sliderMinValue],
 						step: sliderStep,
@@ -1717,6 +1727,9 @@ import "./components/directoristSelect";
 							max: sliderMaxValue,
 						},
 					});
+					
+					// Trigger range slider observer
+					rangeSliderObserver();
 				});
 
 				// Update slider config
@@ -1814,7 +1827,6 @@ import "./components/directoristSelect";
 
 			// Destroy Range Slider
 			slider?.directoristCustomRangeSlider?.destroy();
-			rangeSliderObserver();
 		}
 
 		// DOM Mutation Observer on Location Field

--- a/templates/search-form/fields/radius_search.php
+++ b/templates/search-form/fields/radius_search.php
@@ -34,7 +34,7 @@ if ( ! empty( $_REQUEST['miles'] ) ) {
         </div>
         <div class="directorist-custom-range-slider__slide" default-value="<?php echo esc_attr( $default_distance ); ?>" max-value="<?php echo esc_attr( $default_max_distance ); ?>" min-value="<?php echo esc_attr( $default_min_distance ); ?>"></div>
         <div class="directorist-custom-range-slider__wrap">
-            <input type="hidden" value="<?php echo esc_attr( $radius_search_based_on ); ?>" class="directorist-radius_search_based_on">
+            <input type="hidden" name="radius-search-based-on" value="<?php echo esc_attr( $radius_search_based_on ); ?>" class="directorist-radius_search_based_on">
             <input type="hidden" placeholder="Min" value="<?php echo esc_attr( $min_distance ); ?>" class="directorist-custom-range-slider__radius directorist-custom-range-slider__value__min">
             <input type="hidden" placeholder="Max" value="<?php echo esc_attr( $max_distance ); ?>" class="directorist-custom-range-slider__radius directorist-custom-range-slider__value__max">
             <input type="hidden" name="miles" class="directorist-custom-range-slider__range" value="<?php echo esc_attr( $value ); ?>">


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

- Reset button was not available on form value update after reseting
- Range slider value not properly showing  after reseting
- Radius search_based_on value cleared after reseting
- Range slider destroyed on search modal after reseting 
- Cleared url params on modal search form reseting

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
