### PR TITLE
Radius Search visibility issue fixed based on zipcode

### DIFF
--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -1898,17 +1898,29 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
 
     // Radius Search Field Hide on Empty Location Field
     function handleRadiusVisibility() {
+      // Add class to mark the radius search field
       $('.directorist-range-slider-wrap').closest('.directorist-search-field').addClass('directorist-search-field-radius_search');
-      $('.directorist-location-js').each(function (index, locationDOM) {
-        if ($(locationDOM).val() === '') {
-          $(locationDOM).closest('.directorist-contents-wrap').find('.directorist-search-field-radius_search, .directorist-radius-search').css({
-            display: 'none'
-          });
-        } else {
-          $(locationDOM).closest('.directorist-contents-wrap').find('.directorist-search-field-radius_search, .directorist-radius-search').css({
-            display: 'block'
-          });
-        }
+      var radius_search_item_selector = null;
+      var radius_search_based_on = $(".directorist-radius_search_based_on").val();
+
+      // Determine which search item selector to use
+      if (radius_search_based_on === "address") {
+        radius_search_item_selector = ".directorist-location-js";
+      } else if (radius_search_based_on === "zip") {
+        radius_search_item_selector = ".directorist-zipcode-search .zip-radius-search";
+      } else {
+        // Default fallback
+        radius_search_item_selector = ".directorist-location-js";
+      }
+
+      // Now, use jQuery to loop through the elements
+      $(radius_search_item_selector).each(function (index, locationDOM) {
+        var $location = $(locationDOM);
+        var isEmpty = $location.val() === '';
+        var $container = $location.closest('.directorist-contents-wrap').find('.directorist-search-field-radius_search, .directorist-radius-search');
+        $container.css({
+          display: isEmpty ? 'none' : 'block'
+        });
       });
     }
 

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -1135,25 +1135,34 @@ import "./components/directoristSelect";
 
 		// Radius Search Field Hide on Empty Location Field
 		function handleRadiusVisibility() {
+			// Add class to mark the radius search field
 			$('.directorist-range-slider-wrap')
-				.closest('.directorist-search-field')
-				.addClass('directorist-search-field-radius_search');
-			$('.directorist-location-js').each((index, locationDOM) => {
-				if ($(locationDOM).val() === '') {
-					$(locationDOM)
-						.closest('.directorist-contents-wrap')
-						.find(
-							'.directorist-search-field-radius_search, .directorist-radius-search'
-						)
-						.css({ display: 'none' });
-				} else {
-					$(locationDOM)
-						.closest('.directorist-contents-wrap')
-						.find(
-							'.directorist-search-field-radius_search, .directorist-radius-search'
-						)
-						.css({ display: 'block' });
-				}
+			.closest('.directorist-search-field')
+			.addClass('directorist-search-field-radius_search');
+
+			let radius_search_item_selector = null;
+			const radius_search_based_on = $(".directorist-radius_search_based_on").val();
+
+			// Determine which search item selector to use
+			if (radius_search_based_on === "address") {
+				radius_search_item_selector = ".directorist-location-js";
+			} else if (radius_search_based_on === "zip") {
+				radius_search_item_selector = ".directorist-zipcode-search .zip-radius-search";
+			} else {
+				// Default fallback
+				radius_search_item_selector = ".directorist-location-js";
+			}
+
+			// Now, use jQuery to loop through the elements
+			$(radius_search_item_selector).each((index, locationDOM) => {
+				const $location = $(locationDOM);
+				const isEmpty = $location.val() === '';
+
+				const $container = $location.closest('.directorist-contents-wrap').find(
+					'.directorist-search-field-radius_search, .directorist-radius-search'
+				);
+
+				$container.css({ display: isEmpty ? 'none' : 'block' });
 			});
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
When radius search based_on zipcode, it didn't work properly. Behaved as default based_on address. Fixed it by **radius_search_based_on**. 

**Before:** https://prnt.sc/5PhYSXW8HjUJ | https://prnt.sc/FrCL-QRIyLbv | https://prnt.sc/oFkt3obOLv9P 
**After:** https://prnt.sc/vR37rIjojG7R  

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
