### PR TITLE
Fix: Relevant listings transition speed adjusted from 1s to 3s

### DIFF
--- a/templates/single/section-related_listings.php
+++ b/templates/single/section-related_listings.php
@@ -22,7 +22,7 @@ if ( ! $related->have_posts() ) {
 
     </div>
 
-    <div class='directorist-swiper directorist-swiper-related-listing' data-sw-items='3' data-sw-margin='30' data-sw-loop='true' data-sw-perslide='1' data-sw-speed='1000' data-sw-autoplay='true' data-sw-responsive='{
+    <div class='directorist-swiper directorist-swiper-related-listing' data-sw-items='3' data-sw-margin='30' data-sw-loop='true' data-sw-perslide='1' data-sw-speed='3000' data-sw-autoplay='true' data-sw-responsive='{
         "0": {"slidesPerView": "1"},
         "768": {"slidesPerView": "2"},
         "1200": {"slidesPerView": "<?php echo esc_attr( $section_data['similar_listings_number_of_columns'] ?? 3 ); ?>"}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

### Description
- Fixed the issue where relevant listings at the bottom of a single listing were spinning too fast due to a `0ms` transition in the portal (instead of the expected `300ms` from the root file).  
- Increased the transition duration from **1s** to **3s** for smoother animation.  
- Applied fix for both single listing view and larger screens with more than two listings in the block.  

## Any linked issues
Fixes #
Issue No 2
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/1841

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
