### PR TITLE
feat: Add Bricks Builder integration for custom single listing pages

### DIFF
--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -444,10 +444,39 @@ class Directorist_Single_Listing {
             return $content;
         }
 
+        // Check if page is built with Bricks and render content
+        $bricks_content = $this->get_bricks_content( $page_id );
+        if ( ! empty( $bricks_content ) ) {
+            return $bricks_content;
+        }
+
         $content = get_post_field( 'post_content', $page_id ); // Raw content
         $content = $this->filter_single_listing_content( $content ); // Actual content after running several filters
 
         return $content;
+    }
+
+    private function get_bricks_content( $page_id ) {
+        if ( ! class_exists( '\Bricks\Helpers' ) || ! class_exists( '\Bricks\Frontend' ) ) {
+            return false;
+        }
+
+        if ( ! \Bricks\Helpers::render_with_bricks( $page_id ) ) {
+            return false;
+        }
+
+        $bricks_meta_key = defined( 'BRICKS_DB_PAGE_CONTENT' ) ? BRICKS_DB_PAGE_CONTENT : '_bricks_page_content_2';
+        $bricks_data = get_post_meta( $page_id, $bricks_meta_key, true );
+        
+        if ( empty( $bricks_data ) || ! is_array( $bricks_data ) ) {
+            return false;
+        }
+
+        try {
+            return \Bricks\Frontend::render_data( $bricks_data );
+        } catch ( \Exception $e ) {
+            return false;
+        }
     }
 
     private function filter_single_listing_content( $content ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Adds native Bricks Builder support for Directorist custom single listing pages, allowing users to design beautiful single listing layouts using Bricks while maintaining full compatibility with Directorist shortcodes.

Before:
❌ Bricks content not displayed on custom single listing pages
❌ Only WordPress shortcodes worked
After:
✅ Full Bricks Builder support for custom single listing pages
✅ Seamless integration with Directorist shortcodes in Bricks layouts
✅ Automatic detection - no configuration needed
✅ Works alongside existing Elementor integration

🧪 Testing
[x] Tested with Bricks-designed single listing pages
[x] Tested with WordPress editor + shortcodes
[x] Tested fallback when Bricks not available
[x] Tested with existing Elementor integration
[x] Verified no performance impact

## Any linked issues
Fixes # https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/1792

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
