### PR TITLE
Fix default pricing type issue

### DIFF
--- a/includes/class-helper.php
+++ b/includes/class-helper.php
@@ -279,7 +279,21 @@ class Helper {
 
     public static function pricing_type( $listing_id ) {
         $pricing_type = get_post_meta( $listing_id, '_atbd_listing_pricing', true );
+        if ( ! $pricing_type ) return self::default_pricing_type( $listing_id ); 
         return $pricing_type;
+    }
+
+    public static function default_pricing_type( $listing_id ) {
+        $default_pricing_type = 'price';
+        $directory_type = directorist_get_listing_directory( $listing_id );
+        $directory_type = ( ! empty( $directory_type ) ) ? $directory_type : default_directory_type();
+        $form_fields = get_term_meta( $directory_type, 'submission_form_fields', true );
+        if ( isset( $form_fields['fields']['pricing']['pricing_type'] ) ) {
+            if ( $form_fields['fields']['pricing']['pricing_type'] == 'price_range' ) {
+                $default_pricing_type = 'range';
+            }
+        }
+        return apply_filters( 'directorist_default_pricing_type', $default_pricing_type, $listing_id );
     }
 
     public static function has_price( $listing_id ) {

--- a/templates/listing-form/fields/pricing.php
+++ b/templates/listing-form/fields/pricing.php
@@ -49,4 +49,12 @@ $currency_symbol         = atbdp_currency_symbol( directorist_get_currency() );
             <option value="bellow_economy" <?php selected( $price_range, 'bellow_economy' ); ?>><?php echo esc_html( sprintf( __( 'Cheap (%s)', 'directorist' ), str_repeat( $currency_symbol, 1 ) ) ); ?></option>
         </select>
     <?php } ?>
+
+    <?php if ( $data['pricing_type'] === 'price_unit' ) :?>
+        <input type="hidden" name="atbd_listing_pricing" value="price">
+    <?php endif; ?>
+
+    <?php if ( $data['pricing_type'] === 'price_range' ) :?>
+        <input type="hidden" name="atbd_listing_pricing" value="range">
+    <?php endif; ?>
 </div>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

<img width="1017" height="572" alt="image" src="https://github.com/user-attachments/assets/1f5a6151-e7a6-4815-91bb-0d06ae61c027" />

when select pricing range as an option here, on the all listing page and single listing page its not displaying correctly. Most of the case it is showing a 0$ price instead of the selected range.

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
