### PR TITLE
New: Added Recover password option in guest login modal

### DIFF
--- a/templates/listing-form/quick-login.php
+++ b/templates/listing-form/quick-login.php
@@ -33,6 +33,12 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                         <input type="password" name="password" placeholder="Password" class="directorist-form-element">
                     </div>
 
+                    <div class="directorist-form-group directorist-mb-15 directorist-text-right">
+                        <a href="<?php echo esc_url( wp_lostpassword_url() ); ?>" class="directorist-recover-password-link">
+                            <?php esc_html_e( 'Forgot your password?', 'directorist' ); ?>
+                        </a>                                                                            
+                    </div>
+
                     <?php wp_nonce_field( 'directorist-quick-login-nonce', 'directorist-quick-login-security' ); ?>
                     <div class="directorist-form-feedback"></div>
 


### PR DESCRIPTION
**Now, when a user clicks on 'Forgot Password', they will be redirected to the recovery page, where they can recover their password.**

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [x] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.There is no password reset option available for guest users. See video: 
Users are not receiving the password reset email.
Video demo: https://www.loom.com/share/6b2c6df244a4401987d238ace8c9a36a?sid=d9e95f97-ac26-42df-9ec7-77194469014f

Before
https://prnt.sc/3qBzxKK8C2SK
After
https://prnt.sc/aGV1iqpd8Bt8

## Any linked issues
Fixes #
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/1257

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
