### PR TITLE
Fix: Hide featured option when Directorist Pricing Plans plugin is activated

### DIFF
--- a/views/admin-templates/listing-form/expiration-featured-fields.php
+++ b/views/admin-templates/listing-form/expiration-featured-fields.php
@@ -49,7 +49,7 @@ if ( ! is_fee_manager_active() || ! empty( $never_expire ) ) :
 endif;
 ?>
 <!--Show featured option if it is enabled by the user-->
-<?php if ( $f_active || is_fee_manager_active() ) { ?>
+<?php if ( ( $f_active || is_fee_manager_active() ) && ! class_exists( 'ATBDP_Pricing_Plans' ) ) { ?>
     <div class="misc-pub-section misc-pub-atbdp-featured">
         <label>
             <input type="checkbox" name="featured" value="1" <?php checked( 1, $featured, true ); ?>>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
When the pricing plans plugin is active, it should handle all monetization features including featured listings. Showing the featured checkbox in the admin area when pricing plans is active can cause confusion and conflicts.

This PR adds a condition to hide the featured listing checkbox in the admin listing form when the **Directorist Pricing Plans** plugin is active. This prevents conflicts where both the core plugin and the pricing plans extension try to manage featured listings.

## Changes Made
- Modified `views/admin-templates/listing-form/expiration-featured-fields.php`
- Added `! class_exists( 'ATBDP_Pricing_Plans' )` check to the existing featured option condition
- Follows the same pattern used in `is_fee_manager_active()` and other helper functions


## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
