### PR TITLE
Improve: Clean up Custom Single Listing Page copy and move toggle to the right

### DIFF
--- a/assets/css/admin-main.css
+++ b/assets/css/admin-main.css
@@ -18,21 +18,14 @@
   !*** css ./node_modules/css-loader/dist/cjs.js??clonedRuleSet-4.use[1]!./node_modules/resolve-url-loader/index.js!./node_modules/postcss-loader/src/index.js??clonedRuleSet-4.use[3]!./node_modules/sass-loader/dist/cjs.js??clonedRuleSet-4.use[4]!./assets/src/scss/layout/admin/admin-style.scss (4) ***!
   \**********************************************************************************************************************************************************************************************************************************************************************************************************/
 /* typography */
-#directiost-listing-fields_wrapper {
-	padding: 18px 20px;
-	/***********************************************************
-  ************************************************************
-  css for Custom Field
-  *************************************************************
-  **************************************************************/
-	/*
-   for shortable field*/
-}
 #directiost-listing-fields_wrapper .directorist-show {
 	display: block !important;
 }
 #directiost-listing-fields_wrapper .directorist-hide {
 	display: none !important;
+}
+#directiost-listing-fields_wrapper {
+	padding: 18px 20px;
 }
 #directiost-listing-fields_wrapper a:focus,
 #directiost-listing-fields_wrapper a:active {
@@ -390,6 +383,13 @@
 #directiost-listing-fields_wrapper .single_thm .btn_wrapper {
 	text-align: center;
 }
+#directiost-listing-fields_wrapper {
+	/***********************************************************
+  ************************************************************
+  css for Custom Field
+  *************************************************************
+  **************************************************************/
+}
 #directiost-listing-fields_wrapper .postbox table.widefat {
 	-webkit-box-shadow: none;
 	box-shadow: none;
@@ -410,6 +410,10 @@
 }
 #directiost-listing-fields_wrapper .atbdp-tick-cross2 {
 	margin-left: 25px;
+}
+#directiost-listing-fields_wrapper {
+	/*
+   for shortable field*/
 }
 #directiost-listing-fields_wrapper .ui-sortable tr:hover {
 	cursor: move;
@@ -9529,7 +9533,6 @@ body.stop-scrolling {
 	border: 1px solid var(--directorist-color-border-light);
 	-webkit-transition: background 0.2s ease;
 	transition: background 0.2s ease;
-	/* Legacy Icon */
 }
 .directorist-add-listing-types__single__link .directorist-icon-mask {
 	display: -webkit-box;
@@ -9572,6 +9575,9 @@ body.stop-scrolling {
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-primary);
 }
+.directorist-add-listing-types__single__link {
+	/* Legacy Icon */
+}
 .directorist-add-listing-types__single__link > i:not(.directorist-icon-mask) {
 	display: inline-block;
 	margin-bottom: 10px;
@@ -9611,7 +9617,6 @@ body.stop-scrolling {
 #directiost-listing-fields_wrapper .directorist-content-module {
 	margin-bottom: 35px;
 	border-radius: 12px;
-	/* social info */
 }
 @media (max-width: 991px) {
 	.directorist-add-listing-form .directorist-content-module,
@@ -9689,6 +9694,10 @@ body.stop-scrolling {
 	.directorist-form-address-field.atbdp-form-fade:after {
 	height: 40px;
 	top: 26px;
+}
+.directorist-add-listing-form .directorist-content-module,
+#directiost-listing-fields_wrapper .directorist-content-module {
+	/* social info */
 }
 .directorist-add-listing-form
 	.directorist-content-module
@@ -47361,6 +47370,12 @@ input[type="radio"]:checked::before {
 	}
 }
 
+.directorist_vertical-align-m .directorist_item {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+}
 .directorist_vertical-align-m {
 	display: -webkit-box;
 	display: -webkit-flex;
@@ -47370,12 +47385,6 @@ input[type="radio"]:checked::before {
 	-webkit-align-items: center;
 	-ms-flex-align: center;
 	align-items: center;
-}
-.directorist_vertical-align-m .directorist_item {
-	display: -webkit-box;
-	display: -webkit-flex;
-	display: -ms-flexbox;
-	display: flex;
 }
 
 .atbdp-settings-manager .atbdp-tab-sub-contents .directorist_btn-start {
@@ -52074,6 +52083,18 @@ span.drop-toggle-caret:before {
 	-ms-flex-wrap: wrap;
 	flex-wrap: wrap;
 }
+.directorist-ai-keyword-field__list-item.--h-24 {
+	height: 24px;
+}
+.directorist-ai-keyword-field__list-item.--h-32 {
+	height: 32px;
+}
+.directorist-ai-keyword-field__list-item.--px-8 {
+	padding: 0px 8px;
+}
+.directorist-ai-keyword-field__list-item.--px-12 {
+	padding: 0px 12px;
+}
 .directorist-ai-keyword-field__list-item {
 	display: -webkit-box;
 	display: -webkit-flex;
@@ -52092,18 +52113,6 @@ span.drop-toggle-caret:before {
 	font-weight: 600;
 	line-height: 16px;
 	letter-spacing: 0.12px;
-}
-.directorist-ai-keyword-field__list-item.--h-24 {
-	height: 24px;
-}
-.directorist-ai-keyword-field__list-item.--h-32 {
-	height: 32px;
-}
-.directorist-ai-keyword-field__list-item.--px-8 {
-	padding: 0px 8px;
-}
-.directorist-ai-keyword-field__list-item.--px-12 {
-	padding: 0px 12px;
 }
 .directorist-ai-keyword-field__list-item svg {
 	width: 20px;

--- a/assets/css/admin-main.css
+++ b/assets/css/admin-main.css
@@ -26444,7 +26444,7 @@ input[type="radio"]:checked::before {
 	align-items: center;
 	gap: 8px;
 	padding: 9px 20px;
-	margin: 12px 0 0 0;
+	margin: 0;
 	background-color: #fff;
 	color: #3e62f5;
 }
@@ -36600,7 +36600,7 @@ input[type="radio"]:checked::before {
 	align-items: center;
 	gap: 8px;
 	padding: 9px 20px;
-	margin: 12px 0 0 0;
+	margin: 0;
 	background-color: #fff;
 	color: #3e62f5;
 }
@@ -47049,7 +47049,7 @@ input[type="radio"]:checked::before {
 	align-items: center;
 	gap: 8px;
 	padding: 9px 20px;
-	margin: 12px 0 0 0;
+	margin: 0;
 	background-color: #fff;
 	color: #3e62f5;
 }

--- a/assets/css/admin-main.min.css
+++ b/assets/css/admin-main.min.css
@@ -25041,7 +25041,7 @@ input[type="radio"]:checked:before {
 	align-items: center;
 	gap: 8px;
 	padding: 9px 20px;
-	margin: 12px 0 0;
+	margin: 0;
 	background-color: #fff;
 	color: #3e62f5;
 }

--- a/assets/css/admin-main.rtl.css
+++ b/assets/css/admin-main.rtl.css
@@ -18,21 +18,14 @@
   !*** css ./node_modules/css-loader/dist/cjs.js??clonedRuleSet-4.use[1]!./node_modules/resolve-url-loader/index.js!./node_modules/postcss-loader/src/index.js??clonedRuleSet-4.use[3]!./node_modules/sass-loader/dist/cjs.js??clonedRuleSet-4.use[4]!./assets/src/scss/layout/admin/admin-style.scss (4) ***!
   \**********************************************************************************************************************************************************************************************************************************************************************************************************/
 /* typography */
-#directiost-listing-fields_wrapper {
-	padding: 18px 20px;
-	/***********************************************************
-  ************************************************************
-  css for Custom Field
-  *************************************************************
-  **************************************************************/
-	/*
-   for shortable field*/
-}
 #directiost-listing-fields_wrapper .directorist-show {
 	display: block !important;
 }
 #directiost-listing-fields_wrapper .directorist-hide {
 	display: none !important;
+}
+#directiost-listing-fields_wrapper {
+	padding: 18px 20px;
 }
 #directiost-listing-fields_wrapper a:focus,
 #directiost-listing-fields_wrapper a:active {
@@ -390,6 +383,13 @@
 #directiost-listing-fields_wrapper .single_thm .btn_wrapper {
 	text-align: center;
 }
+#directiost-listing-fields_wrapper {
+	/***********************************************************
+  ************************************************************
+  css for Custom Field
+  *************************************************************
+  **************************************************************/
+}
 #directiost-listing-fields_wrapper .postbox table.widefat {
 	-webkit-box-shadow: none;
 	box-shadow: none;
@@ -410,6 +410,10 @@
 }
 #directiost-listing-fields_wrapper .atbdp-tick-cross2 {
 	margin-right: 25px;
+}
+#directiost-listing-fields_wrapper {
+	/*
+   for shortable field*/
 }
 #directiost-listing-fields_wrapper .ui-sortable tr:hover {
 	cursor: move;
@@ -9529,7 +9533,6 @@ body.stop-scrolling {
 	border: 1px solid var(--directorist-color-border-light);
 	-webkit-transition: background 0.2s ease;
 	transition: background 0.2s ease;
-	/* Legacy Icon */
 }
 .directorist-add-listing-types__single__link .directorist-icon-mask {
 	display: -webkit-box;
@@ -9572,6 +9575,9 @@ body.stop-scrolling {
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-primary);
 }
+.directorist-add-listing-types__single__link {
+	/* Legacy Icon */
+}
 .directorist-add-listing-types__single__link > i:not(.directorist-icon-mask) {
 	display: inline-block;
 	margin-bottom: 10px;
@@ -9611,7 +9617,6 @@ body.stop-scrolling {
 #directiost-listing-fields_wrapper .directorist-content-module {
 	margin-bottom: 35px;
 	border-radius: 12px;
-	/* social info */
 }
 @media (max-width: 991px) {
 	.directorist-add-listing-form .directorist-content-module,
@@ -9689,6 +9694,10 @@ body.stop-scrolling {
 	.directorist-form-address-field.atbdp-form-fade:after {
 	height: 40px;
 	top: 26px;
+}
+.directorist-add-listing-form .directorist-content-module,
+#directiost-listing-fields_wrapper .directorist-content-module {
+	/* social info */
 }
 .directorist-add-listing-form
 	.directorist-content-module
@@ -47361,6 +47370,12 @@ input[type="radio"]:checked::before {
 	}
 }
 
+.directorist_vertical-align-m .directorist_item {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+}
 .directorist_vertical-align-m {
 	display: -webkit-box;
 	display: -webkit-flex;
@@ -47370,12 +47385,6 @@ input[type="radio"]:checked::before {
 	-webkit-align-items: center;
 	-ms-flex-align: center;
 	align-items: center;
-}
-.directorist_vertical-align-m .directorist_item {
-	display: -webkit-box;
-	display: -webkit-flex;
-	display: -ms-flexbox;
-	display: flex;
 }
 
 .atbdp-settings-manager .atbdp-tab-sub-contents .directorist_btn-start {
@@ -52074,6 +52083,18 @@ span.drop-toggle-caret:before {
 	-ms-flex-wrap: wrap;
 	flex-wrap: wrap;
 }
+.directorist-ai-keyword-field__list-item.--h-24 {
+	height: 24px;
+}
+.directorist-ai-keyword-field__list-item.--h-32 {
+	height: 32px;
+}
+.directorist-ai-keyword-field__list-item.--px-8 {
+	padding: 0px 8px;
+}
+.directorist-ai-keyword-field__list-item.--px-12 {
+	padding: 0px 12px;
+}
 .directorist-ai-keyword-field__list-item {
 	display: -webkit-box;
 	display: -webkit-flex;
@@ -52092,18 +52113,6 @@ span.drop-toggle-caret:before {
 	font-weight: 600;
 	line-height: 16px;
 	letter-spacing: 0.12px;
-}
-.directorist-ai-keyword-field__list-item.--h-24 {
-	height: 24px;
-}
-.directorist-ai-keyword-field__list-item.--h-32 {
-	height: 32px;
-}
-.directorist-ai-keyword-field__list-item.--px-8 {
-	padding: 0px 8px;
-}
-.directorist-ai-keyword-field__list-item.--px-12 {
-	padding: 0px 12px;
 }
 .directorist-ai-keyword-field__list-item svg {
 	width: 20px;

--- a/assets/css/admin-main.rtl.css
+++ b/assets/css/admin-main.rtl.css
@@ -26444,7 +26444,7 @@ input[type="radio"]:checked::before {
 	align-items: center;
 	gap: 8px;
 	padding: 9px 20px;
-	margin: 12px 0 0 0;
+	margin: 0;
 	background-color: #fff;
 	color: #3e62f5;
 }
@@ -36600,7 +36600,7 @@ input[type="radio"]:checked::before {
 	align-items: center;
 	gap: 8px;
 	padding: 9px 20px;
-	margin: 12px 0 0 0;
+	margin: 0;
 	background-color: #fff;
 	color: #3e62f5;
 }
@@ -47049,7 +47049,7 @@ input[type="radio"]:checked::before {
 	align-items: center;
 	gap: 8px;
 	padding: 9px 20px;
-	margin: 12px 0 0 0;
+	margin: 0;
 	background-color: #fff;
 	color: #3e62f5;
 }

--- a/assets/css/admin-main.rtl.min.css
+++ b/assets/css/admin-main.rtl.min.css
@@ -25045,7 +25045,7 @@ input[type="radio"]:checked:before {
 	align-items: center;
 	gap: 8px;
 	padding: 9px 20px;
-	margin: 12px 0 0;
+	margin: 0;
 	background-color: #fff;
 	color: #3e62f5;
 }

--- a/assets/css/all-listings.css
+++ b/assets/css/all-listings.css
@@ -3350,7 +3350,6 @@ body.stop-scrolling {
 	border: 1px solid var(--directorist-color-border-light);
 	-webkit-transition: background 0.2s ease;
 	transition: background 0.2s ease;
-	/* Legacy Icon */
 }
 .directorist-add-listing-types__single__link .directorist-icon-mask {
 	display: -webkit-box;
@@ -3393,6 +3392,9 @@ body.stop-scrolling {
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-primary);
 }
+.directorist-add-listing-types__single__link {
+	/* Legacy Icon */
+}
 .directorist-add-listing-types__single__link > i:not(.directorist-icon-mask) {
 	display: inline-block;
 	margin-bottom: 10px;
@@ -3432,7 +3434,6 @@ body.stop-scrolling {
 #directiost-listing-fields_wrapper .directorist-content-module {
 	margin-bottom: 35px;
 	border-radius: 12px;
-	/* social info */
 }
 @media (max-width: 991px) {
 	.directorist-add-listing-form .directorist-content-module,
@@ -3510,6 +3511,10 @@ body.stop-scrolling {
 	.directorist-form-address-field.atbdp-form-fade:after {
 	height: 40px;
 	top: 26px;
+}
+.directorist-add-listing-form .directorist-content-module,
+#directiost-listing-fields_wrapper .directorist-content-module {
+	/* social info */
 }
 .directorist-add-listing-form
 	.directorist-content-module
@@ -12536,13 +12541,15 @@ input.directorist-toggle-input:checked
 }
 .directorist-content-active .directorist-author-social__item a:hover {
 	background-color: var(--directorist-color-primary);
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-author-social__item
 	a:hover
 	.directorist-icon-mask::after {
 	background-color: var(--directorist-color-white);
+}
+.directorist-content-active .directorist-author-social__item a:hover {
+	/* Legacy Icon */
 }
 .directorist-content-active .directorist-author-social__item a:hover span.la,
 .directorist-content-active .directorist-author-social__item a:hover span.fa {
@@ -17554,7 +17561,6 @@ input.directorist-toggle-input:checked
 	-ms-flex-pack: center;
 	justify-content: center;
 	background-color: var(--directorist-color-white);
-	/* Styles */
 }
 .directorist-categories__single--image {
 	background-position: center;
@@ -17606,6 +17612,9 @@ input.directorist-toggle-input:checked
 	top: 0;
 	width: 100%;
 	height: 100%;
+}
+.directorist-categories__single {
+	/* Styles */
 }
 .directorist-categories__single--style-one
 	.directorist-categories__single__content
@@ -17737,10 +17746,6 @@ input.directorist-toggle-input:checked
 }
 
 /* Taxonomy List Style One */
-.directorist-taxonomy-list-one .directorist-taxonomy-list {
-	/* Sub Item */
-	/* Sub Item Toggle */
-}
 .directorist-taxonomy-list-one .directorist-taxonomy-list__card {
 	display: -webkit-box;
 	display: -webkit-flex;
@@ -17829,6 +17834,9 @@ input.directorist-toggle-input:checked
 	-webkit-transition: 0.3s ease;
 	transition: 0.3s ease;
 }
+.directorist-taxonomy-list-one .directorist-taxonomy-list {
+	/* Sub Item */
+}
 .directorist-taxonomy-list-one .directorist-taxonomy-list__sub-item {
 	margin: 0;
 	list-style: none;
@@ -17904,6 +17912,9 @@ input.directorist-toggle-input:checked
 	visibility: visible;
 	opacity: 1;
 	margin-top: 0;
+}
+.directorist-taxonomy-list-one .directorist-taxonomy-list {
+	/* Sub Item Toggle */
 }
 .directorist-taxonomy-list-one .directorist-taxonomy-list__sub-item-toggle {
 	display: -webkit-box;
@@ -18795,7 +18806,6 @@ input.directorist-toggle-input:checked
 	display: -ms-flexbox;
 	display: flex;
 	margin: 0;
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-authors__card__info-list
@@ -18822,6 +18832,9 @@ input.directorist-toggle-input:checked
 	.directorist-icon-mask:after {
 	width: 16px;
 	height: 16px;
+}
+.directorist-content-active .directorist-authors__card__info-list li {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-authors__card__info-list
@@ -19661,7 +19674,6 @@ input.directorist-toggle-input:checked
 	-ms-flex-align: center;
 	align-items: center;
 	gap: 5px;
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -19670,6 +19682,11 @@ input.directorist-toggle-input:checked
 	width: 15px;
 	height: 15px;
 	background-color: var(--directorist-color-light-gray);
+}
+.directorist-content-active
+	.directorist-listing-single__meta
+	.directorist-view-count {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -19704,12 +19721,6 @@ input.directorist-toggle-input:checked
 .directorist-content-active
 	.directorist-listing-single__meta
 	.directorist-listing-category
-	> a {
-	/* Legacy Icon */
-}
-.directorist-content-active
-	.directorist-listing-single__meta
-	.directorist-listing-category
 	> a
 	.directorist-icon-mask {
 	height: 34px;
@@ -19738,6 +19749,12 @@ input.directorist-toggle-input:checked
 	background-color: var(--directorist-color-primary);
 	width: 14px;
 	height: 14px;
+}
+.directorist-content-active
+	.directorist-listing-single__meta
+	.directorist-listing-category
+	> a {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -22521,7 +22538,6 @@ input.directorist-toggle-input:checked
 	display: -ms-flexbox;
 	display: flex;
 	gap: 10px;
-	/* Legacy Icon */
 }
 .directorist-single-tag-list a .directorist-icon-mask {
 	display: -webkit-inline-box;
@@ -22548,6 +22564,9 @@ input.directorist-toggle-input:checked
 }
 .directorist-single-tag-list a .directorist-icon-mask:after {
 	font-size: 15px;
+}
+.directorist-single-tag-list a {
+	/* Legacy Icon */
 }
 .directorist-single-tag-list a > span:not(.directorist-icon-mask) {
 	display: -webkit-inline-box;
@@ -25997,7 +26016,6 @@ Review: New Style
 	line-height: 2.65;
 	opacity: 0;
 	visibility: hidden;
-	/* Legacy Icon */
 }
 .directorist-favourite-items-wrap
 	.directorist-dashboard-items-list__single__action
@@ -26010,6 +26028,11 @@ Review: New Style
 	.directorist-favourite-remove-btn
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-white);
+}
+.directorist-favourite-items-wrap
+	.directorist-dashboard-items-list__single__action
+	.directorist-favourite-remove-btn {
+	/* Legacy Icon */
 }
 .directorist-favourite-items-wrap
 	.directorist-dashboard-items-list__single__action

--- a/assets/css/all-listings.rtl.css
+++ b/assets/css/all-listings.rtl.css
@@ -3350,7 +3350,6 @@ body.stop-scrolling {
 	border: 1px solid var(--directorist-color-border-light);
 	-webkit-transition: background 0.2s ease;
 	transition: background 0.2s ease;
-	/* Legacy Icon */
 }
 .directorist-add-listing-types__single__link .directorist-icon-mask {
 	display: -webkit-box;
@@ -3393,6 +3392,9 @@ body.stop-scrolling {
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-primary);
 }
+.directorist-add-listing-types__single__link {
+	/* Legacy Icon */
+}
 .directorist-add-listing-types__single__link > i:not(.directorist-icon-mask) {
 	display: inline-block;
 	margin-bottom: 10px;
@@ -3432,7 +3434,6 @@ body.stop-scrolling {
 #directiost-listing-fields_wrapper .directorist-content-module {
 	margin-bottom: 35px;
 	border-radius: 12px;
-	/* social info */
 }
 @media (max-width: 991px) {
 	.directorist-add-listing-form .directorist-content-module,
@@ -3510,6 +3511,10 @@ body.stop-scrolling {
 	.directorist-form-address-field.atbdp-form-fade:after {
 	height: 40px;
 	top: 26px;
+}
+.directorist-add-listing-form .directorist-content-module,
+#directiost-listing-fields_wrapper .directorist-content-module {
+	/* social info */
 }
 .directorist-add-listing-form
 	.directorist-content-module
@@ -12536,13 +12541,15 @@ input.directorist-toggle-input:checked
 }
 .directorist-content-active .directorist-author-social__item a:hover {
 	background-color: var(--directorist-color-primary);
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-author-social__item
 	a:hover
 	.directorist-icon-mask::after {
 	background-color: var(--directorist-color-white);
+}
+.directorist-content-active .directorist-author-social__item a:hover {
+	/* Legacy Icon */
 }
 .directorist-content-active .directorist-author-social__item a:hover span.la,
 .directorist-content-active .directorist-author-social__item a:hover span.fa {
@@ -17554,7 +17561,6 @@ input.directorist-toggle-input:checked
 	-ms-flex-pack: center;
 	justify-content: center;
 	background-color: var(--directorist-color-white);
-	/* Styles */
 }
 .directorist-categories__single--image {
 	background-position: center;
@@ -17606,6 +17612,9 @@ input.directorist-toggle-input:checked
 	top: 0;
 	width: 100%;
 	height: 100%;
+}
+.directorist-categories__single {
+	/* Styles */
 }
 .directorist-categories__single--style-one
 	.directorist-categories__single__content
@@ -17737,10 +17746,6 @@ input.directorist-toggle-input:checked
 }
 
 /* Taxonomy List Style One */
-.directorist-taxonomy-list-one .directorist-taxonomy-list {
-	/* Sub Item */
-	/* Sub Item Toggle */
-}
 .directorist-taxonomy-list-one .directorist-taxonomy-list__card {
 	display: -webkit-box;
 	display: -webkit-flex;
@@ -17829,6 +17834,9 @@ input.directorist-toggle-input:checked
 	-webkit-transition: 0.3s ease;
 	transition: 0.3s ease;
 }
+.directorist-taxonomy-list-one .directorist-taxonomy-list {
+	/* Sub Item */
+}
 .directorist-taxonomy-list-one .directorist-taxonomy-list__sub-item {
 	margin: 0;
 	list-style: none;
@@ -17904,6 +17912,9 @@ input.directorist-toggle-input:checked
 	visibility: visible;
 	opacity: 1;
 	margin-top: 0;
+}
+.directorist-taxonomy-list-one .directorist-taxonomy-list {
+	/* Sub Item Toggle */
 }
 .directorist-taxonomy-list-one .directorist-taxonomy-list__sub-item-toggle {
 	display: -webkit-box;
@@ -18795,7 +18806,6 @@ input.directorist-toggle-input:checked
 	display: -ms-flexbox;
 	display: flex;
 	margin: 0;
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-authors__card__info-list
@@ -18822,6 +18832,9 @@ input.directorist-toggle-input:checked
 	.directorist-icon-mask:after {
 	width: 16px;
 	height: 16px;
+}
+.directorist-content-active .directorist-authors__card__info-list li {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-authors__card__info-list
@@ -19661,7 +19674,6 @@ input.directorist-toggle-input:checked
 	-ms-flex-align: center;
 	align-items: center;
 	gap: 5px;
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -19670,6 +19682,11 @@ input.directorist-toggle-input:checked
 	width: 15px;
 	height: 15px;
 	background-color: var(--directorist-color-light-gray);
+}
+.directorist-content-active
+	.directorist-listing-single__meta
+	.directorist-view-count {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -19704,12 +19721,6 @@ input.directorist-toggle-input:checked
 .directorist-content-active
 	.directorist-listing-single__meta
 	.directorist-listing-category
-	> a {
-	/* Legacy Icon */
-}
-.directorist-content-active
-	.directorist-listing-single__meta
-	.directorist-listing-category
 	> a
 	.directorist-icon-mask {
 	height: 34px;
@@ -19738,6 +19749,12 @@ input.directorist-toggle-input:checked
 	background-color: var(--directorist-color-primary);
 	width: 14px;
 	height: 14px;
+}
+.directorist-content-active
+	.directorist-listing-single__meta
+	.directorist-listing-category
+	> a {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -22520,7 +22537,6 @@ input.directorist-toggle-input:checked
 	display: -ms-flexbox;
 	display: flex;
 	gap: 10px;
-	/* Legacy Icon */
 }
 .directorist-single-tag-list a .directorist-icon-mask {
 	display: -webkit-inline-box;
@@ -22547,6 +22563,9 @@ input.directorist-toggle-input:checked
 }
 .directorist-single-tag-list a .directorist-icon-mask:after {
 	font-size: 15px;
+}
+.directorist-single-tag-list a {
+	/* Legacy Icon */
 }
 .directorist-single-tag-list a > span:not(.directorist-icon-mask) {
 	display: -webkit-inline-box;
@@ -25996,7 +26015,6 @@ Review: New Style
 	line-height: 2.65;
 	opacity: 0;
 	visibility: hidden;
-	/* Legacy Icon */
 }
 .directorist-favourite-items-wrap
 	.directorist-dashboard-items-list__single__action
@@ -26009,6 +26027,11 @@ Review: New Style
 	.directorist-favourite-remove-btn
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-white);
+}
+.directorist-favourite-items-wrap
+	.directorist-dashboard-items-list__single__action
+	.directorist-favourite-remove-btn {
+	/* Legacy Icon */
 }
 .directorist-favourite-items-wrap
 	.directorist-dashboard-items-list__single__action

--- a/assets/css/public-main.css
+++ b/assets/css/public-main.css
@@ -3350,7 +3350,6 @@ body.stop-scrolling {
 	border: 1px solid var(--directorist-color-border-light);
 	-webkit-transition: background 0.2s ease;
 	transition: background 0.2s ease;
-	/* Legacy Icon */
 }
 .directorist-add-listing-types__single__link .directorist-icon-mask {
 	display: -webkit-box;
@@ -3393,6 +3392,9 @@ body.stop-scrolling {
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-primary);
 }
+.directorist-add-listing-types__single__link {
+	/* Legacy Icon */
+}
 .directorist-add-listing-types__single__link > i:not(.directorist-icon-mask) {
 	display: inline-block;
 	margin-bottom: 10px;
@@ -3432,7 +3434,6 @@ body.stop-scrolling {
 #directiost-listing-fields_wrapper .directorist-content-module {
 	margin-bottom: 35px;
 	border-radius: 12px;
-	/* social info */
 }
 @media (max-width: 991px) {
 	.directorist-add-listing-form .directorist-content-module,
@@ -3510,6 +3511,10 @@ body.stop-scrolling {
 	.directorist-form-address-field.atbdp-form-fade:after {
 	height: 40px;
 	top: 26px;
+}
+.directorist-add-listing-form .directorist-content-module,
+#directiost-listing-fields_wrapper .directorist-content-module {
+	/* social info */
 }
 .directorist-add-listing-form
 	.directorist-content-module
@@ -12536,13 +12541,15 @@ input.directorist-toggle-input:checked
 }
 .directorist-content-active .directorist-author-social__item a:hover {
 	background-color: var(--directorist-color-primary);
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-author-social__item
 	a:hover
 	.directorist-icon-mask::after {
 	background-color: var(--directorist-color-white);
+}
+.directorist-content-active .directorist-author-social__item a:hover {
+	/* Legacy Icon */
 }
 .directorist-content-active .directorist-author-social__item a:hover span.la,
 .directorist-content-active .directorist-author-social__item a:hover span.fa {
@@ -17554,7 +17561,6 @@ input.directorist-toggle-input:checked
 	-ms-flex-pack: center;
 	justify-content: center;
 	background-color: var(--directorist-color-white);
-	/* Styles */
 }
 .directorist-categories__single--image {
 	background-position: center;
@@ -17606,6 +17612,9 @@ input.directorist-toggle-input:checked
 	top: 0;
 	width: 100%;
 	height: 100%;
+}
+.directorist-categories__single {
+	/* Styles */
 }
 .directorist-categories__single--style-one
 	.directorist-categories__single__content
@@ -17737,10 +17746,6 @@ input.directorist-toggle-input:checked
 }
 
 /* Taxonomy List Style One */
-.directorist-taxonomy-list-one .directorist-taxonomy-list {
-	/* Sub Item */
-	/* Sub Item Toggle */
-}
 .directorist-taxonomy-list-one .directorist-taxonomy-list__card {
 	display: -webkit-box;
 	display: -webkit-flex;
@@ -17829,6 +17834,9 @@ input.directorist-toggle-input:checked
 	-webkit-transition: 0.3s ease;
 	transition: 0.3s ease;
 }
+.directorist-taxonomy-list-one .directorist-taxonomy-list {
+	/* Sub Item */
+}
 .directorist-taxonomy-list-one .directorist-taxonomy-list__sub-item {
 	margin: 0;
 	list-style: none;
@@ -17904,6 +17912,9 @@ input.directorist-toggle-input:checked
 	visibility: visible;
 	opacity: 1;
 	margin-top: 0;
+}
+.directorist-taxonomy-list-one .directorist-taxonomy-list {
+	/* Sub Item Toggle */
 }
 .directorist-taxonomy-list-one .directorist-taxonomy-list__sub-item-toggle {
 	display: -webkit-box;
@@ -18795,7 +18806,6 @@ input.directorist-toggle-input:checked
 	display: -ms-flexbox;
 	display: flex;
 	margin: 0;
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-authors__card__info-list
@@ -18822,6 +18832,9 @@ input.directorist-toggle-input:checked
 	.directorist-icon-mask:after {
 	width: 16px;
 	height: 16px;
+}
+.directorist-content-active .directorist-authors__card__info-list li {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-authors__card__info-list
@@ -19661,7 +19674,6 @@ input.directorist-toggle-input:checked
 	-ms-flex-align: center;
 	align-items: center;
 	gap: 5px;
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -19670,6 +19682,11 @@ input.directorist-toggle-input:checked
 	width: 15px;
 	height: 15px;
 	background-color: var(--directorist-color-light-gray);
+}
+.directorist-content-active
+	.directorist-listing-single__meta
+	.directorist-view-count {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -19704,12 +19721,6 @@ input.directorist-toggle-input:checked
 .directorist-content-active
 	.directorist-listing-single__meta
 	.directorist-listing-category
-	> a {
-	/* Legacy Icon */
-}
-.directorist-content-active
-	.directorist-listing-single__meta
-	.directorist-listing-category
 	> a
 	.directorist-icon-mask {
 	height: 34px;
@@ -19738,6 +19749,12 @@ input.directorist-toggle-input:checked
 	background-color: var(--directorist-color-primary);
 	width: 14px;
 	height: 14px;
+}
+.directorist-content-active
+	.directorist-listing-single__meta
+	.directorist-listing-category
+	> a {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -22521,7 +22538,6 @@ input.directorist-toggle-input:checked
 	display: -ms-flexbox;
 	display: flex;
 	gap: 10px;
-	/* Legacy Icon */
 }
 .directorist-single-tag-list a .directorist-icon-mask {
 	display: -webkit-inline-box;
@@ -22548,6 +22564,9 @@ input.directorist-toggle-input:checked
 }
 .directorist-single-tag-list a .directorist-icon-mask:after {
 	font-size: 15px;
+}
+.directorist-single-tag-list a {
+	/* Legacy Icon */
 }
 .directorist-single-tag-list a > span:not(.directorist-icon-mask) {
 	display: -webkit-inline-box;
@@ -25997,7 +26016,6 @@ Review: New Style
 	line-height: 2.65;
 	opacity: 0;
 	visibility: hidden;
-	/* Legacy Icon */
 }
 .directorist-favourite-items-wrap
 	.directorist-dashboard-items-list__single__action
@@ -26010,6 +26028,11 @@ Review: New Style
 	.directorist-favourite-remove-btn
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-white);
+}
+.directorist-favourite-items-wrap
+	.directorist-dashboard-items-list__single__action
+	.directorist-favourite-remove-btn {
+	/* Legacy Icon */
 }
 .directorist-favourite-items-wrap
 	.directorist-dashboard-items-list__single__action

--- a/assets/css/public-main.rtl.css
+++ b/assets/css/public-main.rtl.css
@@ -3350,7 +3350,6 @@ body.stop-scrolling {
 	border: 1px solid var(--directorist-color-border-light);
 	-webkit-transition: background 0.2s ease;
 	transition: background 0.2s ease;
-	/* Legacy Icon */
 }
 .directorist-add-listing-types__single__link .directorist-icon-mask {
 	display: -webkit-box;
@@ -3393,6 +3392,9 @@ body.stop-scrolling {
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-primary);
 }
+.directorist-add-listing-types__single__link {
+	/* Legacy Icon */
+}
 .directorist-add-listing-types__single__link > i:not(.directorist-icon-mask) {
 	display: inline-block;
 	margin-bottom: 10px;
@@ -3432,7 +3434,6 @@ body.stop-scrolling {
 #directiost-listing-fields_wrapper .directorist-content-module {
 	margin-bottom: 35px;
 	border-radius: 12px;
-	/* social info */
 }
 @media (max-width: 991px) {
 	.directorist-add-listing-form .directorist-content-module,
@@ -3510,6 +3511,10 @@ body.stop-scrolling {
 	.directorist-form-address-field.atbdp-form-fade:after {
 	height: 40px;
 	top: 26px;
+}
+.directorist-add-listing-form .directorist-content-module,
+#directiost-listing-fields_wrapper .directorist-content-module {
+	/* social info */
 }
 .directorist-add-listing-form
 	.directorist-content-module
@@ -12536,13 +12541,15 @@ input.directorist-toggle-input:checked
 }
 .directorist-content-active .directorist-author-social__item a:hover {
 	background-color: var(--directorist-color-primary);
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-author-social__item
 	a:hover
 	.directorist-icon-mask::after {
 	background-color: var(--directorist-color-white);
+}
+.directorist-content-active .directorist-author-social__item a:hover {
+	/* Legacy Icon */
 }
 .directorist-content-active .directorist-author-social__item a:hover span.la,
 .directorist-content-active .directorist-author-social__item a:hover span.fa {
@@ -17554,7 +17561,6 @@ input.directorist-toggle-input:checked
 	-ms-flex-pack: center;
 	justify-content: center;
 	background-color: var(--directorist-color-white);
-	/* Styles */
 }
 .directorist-categories__single--image {
 	background-position: center;
@@ -17606,6 +17612,9 @@ input.directorist-toggle-input:checked
 	top: 0;
 	width: 100%;
 	height: 100%;
+}
+.directorist-categories__single {
+	/* Styles */
 }
 .directorist-categories__single--style-one
 	.directorist-categories__single__content
@@ -17737,10 +17746,6 @@ input.directorist-toggle-input:checked
 }
 
 /* Taxonomy List Style One */
-.directorist-taxonomy-list-one .directorist-taxonomy-list {
-	/* Sub Item */
-	/* Sub Item Toggle */
-}
 .directorist-taxonomy-list-one .directorist-taxonomy-list__card {
 	display: -webkit-box;
 	display: -webkit-flex;
@@ -17829,6 +17834,9 @@ input.directorist-toggle-input:checked
 	-webkit-transition: 0.3s ease;
 	transition: 0.3s ease;
 }
+.directorist-taxonomy-list-one .directorist-taxonomy-list {
+	/* Sub Item */
+}
 .directorist-taxonomy-list-one .directorist-taxonomy-list__sub-item {
 	margin: 0;
 	list-style: none;
@@ -17904,6 +17912,9 @@ input.directorist-toggle-input:checked
 	visibility: visible;
 	opacity: 1;
 	margin-top: 0;
+}
+.directorist-taxonomy-list-one .directorist-taxonomy-list {
+	/* Sub Item Toggle */
 }
 .directorist-taxonomy-list-one .directorist-taxonomy-list__sub-item-toggle {
 	display: -webkit-box;
@@ -18795,7 +18806,6 @@ input.directorist-toggle-input:checked
 	display: -ms-flexbox;
 	display: flex;
 	margin: 0;
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-authors__card__info-list
@@ -18822,6 +18832,9 @@ input.directorist-toggle-input:checked
 	.directorist-icon-mask:after {
 	width: 16px;
 	height: 16px;
+}
+.directorist-content-active .directorist-authors__card__info-list li {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-authors__card__info-list
@@ -19661,7 +19674,6 @@ input.directorist-toggle-input:checked
 	-ms-flex-align: center;
 	align-items: center;
 	gap: 5px;
-	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -19670,6 +19682,11 @@ input.directorist-toggle-input:checked
 	width: 15px;
 	height: 15px;
 	background-color: var(--directorist-color-light-gray);
+}
+.directorist-content-active
+	.directorist-listing-single__meta
+	.directorist-view-count {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -19704,12 +19721,6 @@ input.directorist-toggle-input:checked
 .directorist-content-active
 	.directorist-listing-single__meta
 	.directorist-listing-category
-	> a {
-	/* Legacy Icon */
-}
-.directorist-content-active
-	.directorist-listing-single__meta
-	.directorist-listing-category
 	> a
 	.directorist-icon-mask {
 	height: 34px;
@@ -19738,6 +19749,12 @@ input.directorist-toggle-input:checked
 	background-color: var(--directorist-color-primary);
 	width: 14px;
 	height: 14px;
+}
+.directorist-content-active
+	.directorist-listing-single__meta
+	.directorist-listing-category
+	> a {
+	/* Legacy Icon */
 }
 .directorist-content-active
 	.directorist-listing-single__meta
@@ -22520,7 +22537,6 @@ input.directorist-toggle-input:checked
 	display: -ms-flexbox;
 	display: flex;
 	gap: 10px;
-	/* Legacy Icon */
 }
 .directorist-single-tag-list a .directorist-icon-mask {
 	display: -webkit-inline-box;
@@ -22547,6 +22563,9 @@ input.directorist-toggle-input:checked
 }
 .directorist-single-tag-list a .directorist-icon-mask:after {
 	font-size: 15px;
+}
+.directorist-single-tag-list a {
+	/* Legacy Icon */
 }
 .directorist-single-tag-list a > span:not(.directorist-icon-mask) {
 	display: -webkit-inline-box;
@@ -25996,7 +26015,6 @@ Review: New Style
 	line-height: 2.65;
 	opacity: 0;
 	visibility: hidden;
-	/* Legacy Icon */
 }
 .directorist-favourite-items-wrap
 	.directorist-dashboard-items-list__single__action
@@ -26009,6 +26027,11 @@ Review: New Style
 	.directorist-favourite-remove-btn
 	.directorist-icon-mask:after {
 	background-color: var(--directorist-color-white);
+}
+.directorist-favourite-items-wrap
+	.directorist-dashboard-items-list__single__action
+	.directorist-favourite-remove-btn {
+	/* Legacy Icon */
 }
 .directorist-favourite-items-wrap
 	.directorist-dashboard-items-list__single__action

--- a/assets/js/admin-multi-directory-builder.js
+++ b/assets/js/admin-multi-directory-builder.js
@@ -3661,9 +3661,6 @@
 														case 3:
 															response =
 																_context.sent;
-															console.log(
-																response
-															);
 															if (!response) {
 																_context.next = 4;
 																break;
@@ -3840,7 +3837,6 @@
 							)();
 						},
 						parseApiResponse: function parseApiResponse(response) {
-							console.log(response);
 							var data = response;
 
 							// Handle different API response formats
@@ -50679,7 +50675,7 @@
 							return options_values.includes(value);
 						},
 						/* syncValidationWithLocalState( validation_log ) {
-         return validation_log;
+          return validation_log;
     } */
 					},
 				};
@@ -72599,11 +72595,11 @@
 													},
 													[
 														_vm._v(
-															'\n            ' +
+															'\r\n            ' +
 																_vm._s(
 																	alert.message
 																) +
-																'\n        '
+																'\r\n        '
 														),
 													]
 												);

--- a/assets/js/admin-settings-manager.js
+++ b/assets/js/admin-settings-manager.js
@@ -3554,9 +3554,6 @@
 														case 3:
 															response =
 																_context.sent;
-															console.log(
-																response
-															);
 															if (!response) {
 																_context.next = 4;
 																break;
@@ -3733,7 +3730,6 @@
 							)();
 						},
 						parseApiResponse: function parseApiResponse(response) {
-							console.log(response);
 							var data = response;
 
 							// Handle different API response formats
@@ -50334,7 +50330,7 @@
 							return options_values.includes(value);
 						},
 						/* syncValidationWithLocalState( validation_log ) {
-         return validation_log;
+          return validation_log;
     } */
 					},
 				};
@@ -72387,11 +72383,11 @@
 													},
 													[
 														_vm._v(
-															'\n            ' +
+															'\r\n            ' +
 																_vm._s(
 																	alert.message
 																) +
-																'\n        '
+																'\r\n        '
 														),
 													]
 												);

--- a/assets/js/range-slider.js
+++ b/assets/js/range-slider.js
@@ -728,8 +728,7 @@
              - The provided value for the option;
              - A reference to the options object;
              - The name for the option;
-  
-         The testing function returns false when an error is detected,
+          The testing function returns false when an error is detected,
          or true when everything is OK. It can also modify the option
          object, to make sure all values can be correctly looped elsewhere. */
 			//region Defaults

--- a/assets/src/js/admin/vue/mixins/form-fields/select-api-field.js
+++ b/assets/src/js/admin/vue/mixins/form-fields/select-api-field.js
@@ -136,8 +136,6 @@ export default {
 			try {
 				const response = await this.makeApiRequest();
 
-				console.log(response);
-
 				if (response) {
 					const parsedOptions = this.parseApiResponse(response);
 					this.fetchedOptions = parsedOptions;
@@ -193,8 +191,6 @@ export default {
 		},
 
 		parseApiResponse(response) {
-			console.log(response);
-
 			const data = response;
 
 			// Handle different API response formats

--- a/assets/src/scss/layout/admin/builder/_builder_style.scss
+++ b/assets/src/scss/layout/admin/builder/_builder_style.scss
@@ -7324,7 +7324,7 @@ input[type="radio"] {
 		align-items: center;
 		gap: 8px;
 		padding: 9px 20px;
-		margin: 12px 0 0 0;
+		margin: 0;
 		background-color: #fff;
 		color: #3e62f5;
 		&:hover {

--- a/includes/modules/multi-directory-setup/class-builder-data.php
+++ b/includes/modules/multi-directory-setup/class-builder-data.php
@@ -2265,7 +2265,8 @@ class Builder_Data {
 
                 'enable_single_listing_page'                  => [
                     'type'            => 'toggle',
-                    'toggle_position' => 'left',
+                    // Toggle moved to the right side as per new UI requirement
+                    'toggle_position' => 'right',
                     'label'           => __( 'Enable Custom Single Listing Page', 'directorist' ),
                     'description'     => __(
                         'When enabled, the default single listing is replaced by your selected page.', 'directorist' 
@@ -2277,8 +2278,9 @@ class Builder_Data {
                 'single_listings_shortcodes'                  => [
                     'type'        => 'shortcode-list',
                     'buttonLabel' => __( 'Generate Shortcodes', 'directorist' ),
+                    // Label & description removed as per new UI requirement
                     'label'       => __( 'Generate shortcodes', 'directorist' ),
-                    'description' => __( 'Shortcodes are required. Without them, the selected page will show blank content.', 'directorist' ),
+                    'description' => '',
                     'shortcodes'  => [
                         '[directorist_single_listings_header]',
                         [
@@ -2312,8 +2314,9 @@ class Builder_Data {
                 'single_listing_page_title'                    => [
                     'label'             => __( 'Single listing page', 'directorist' ),
                     'type'              => 'title',
-                    'title'             => 'Assign Your Page',
-                    'description'       => 'Select a page that contains the generated shortcodes.',
+                    // Title & description removed as per new UI requirement
+                    'title'             => '',
+                    'description'       => '',
                     'show_if'           => [
                         'where'      => 'enable_single_listing_page',
                         'conditions' => [
@@ -2880,8 +2883,9 @@ class Builder_Data {
                             'container' => 'short-wide',
                             'sections' => [
                                 'page_settings' => [
-                                    'title' => __( 'Custom Single Listing Page', 'directorist' ),
-                                    'description' => __( 'Replace the default single listing layout with your own custom-built page.', 'directorist' ),
+                                    // Title & description removed as per new UI requirement
+                                    'title' => '',
+                                    'description' => '',
                                     'fields' => [
                                         'enable_single_listing_page',
                                         'single_listings_shortcodes',

--- a/includes/modules/multi-directory-setup/class-builder-data.php
+++ b/includes/modules/multi-directory-setup/class-builder-data.php
@@ -2268,7 +2268,7 @@ class Builder_Data {
                     'toggle_position' => 'right',
                     'label'           => __( 'Enable Custom Single Listing Page', 'directorist' ),
                     'description'     => __(
-                        'When enabled, the default single listing is replaced by your selected page.', 'directorist' 
+                        'Enabling this option will replace the default single listing page. After enabling you must create and assign a new page with generated shortcodes to display single listing content', 'directorist'
                     ),
                     'labelType' => 'h3',
                     'value'     => false,

--- a/includes/modules/multi-directory-setup/class-builder-data.php
+++ b/includes/modules/multi-directory-setup/class-builder-data.php
@@ -2265,7 +2265,6 @@ class Builder_Data {
 
                 'enable_single_listing_page'                  => [
                     'type'            => 'toggle',
-                    // Toggle moved to the right side as per new UI requirement
                     'toggle_position' => 'right',
                     'label'           => __( 'Enable Custom Single Listing Page', 'directorist' ),
                     'description'     => __(
@@ -2278,7 +2277,6 @@ class Builder_Data {
                 'single_listings_shortcodes'                  => [
                     'type'        => 'shortcode-list',
                     'buttonLabel' => __( 'Generate Shortcodes', 'directorist' ),
-                    // Label & description removed as per new UI requirement
                     'label'       => __( 'Generate shortcodes', 'directorist' ),
                     'description' => '',
                     'shortcodes'  => [


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

Requirement: 
https://shottr.cc/s/6ZlA/SCR-20251217-knf.png

Implement: 
1. Removed redundant helper descriptions from the Custom Single Listing Page section while keeping the generate shortcodes label.
2. Moved the “Enable Custom Single Listing Page” toggle to the right for consistent UI alignment.

Before
https://prnt.sc/s8Ibb6Hkwe09
After
https://prnt.sc/2W8jNx1l0jrs

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
