### PR TITLE
change default value of "Permanently Delete Expired Listings" to false ( for new users )

### DIFF
--- a/includes/classes/class-settings-panel.php
+++ b/includes/classes/class-settings-panel.php
@@ -811,7 +811,7 @@ Please remember that your order may be canceled if you do not make your payment 
                         'label'       => __( 'Permanently Delete Expired Listings', 'directorist' ),
                         'type'        => 'toggle',
                         'description' => __( 'Automatically delete trashed listings permanently after the defined duration', 'directorist' ),
-                        'value'       => true,
+                        'value'       => false,
                     ],
                     'delete_expired_listings_after' => [
                         'label' => __( 'Permanently Delete After (days) of Expiration', 'directorist' ),


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.
2.
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
