### PR TITLE
fix: remove tooltip from enquiry modal close button

### DIFF
--- a/assets/src/js/formgent-integration/components/EnquiryDetailsModal.js
+++ b/assets/src/js/formgent-integration/components/EnquiryDetailsModal.js
@@ -22,7 +22,7 @@ import {
 	getStatusBadgeText,
 	markEnquiryAsRead,
 } from '../utils/enquiryUtils';
-import { EnquiryDetailsModalStyle } from './style';
+import { EnquiryDetailsModalStyle, EnquiryModalGlobalStyle } from './style';
 
 /**
  * EnquiryDetailsModal Component
@@ -147,135 +147,180 @@ export default function EnquiryDetailsModal({
 	}
 
 	return (
-		<Modal
-			title={`Enquiry Details - ${matchedEnquiry?.listing_title || 'Unknown Listing'}`}
-			onRequestClose={onClose}
-			className="directorist-enquiry-modal"
-			size="large"
-		>
-			<EnquiryDetailsModalStyle className="directorist-enquiry-modal-content">
-				{loading && (
-					<div className="directorist-loading">
-						<p>{__('Loading enquiry details...', 'directorist')}</p>
-					</div>
-				)}
-
-				{error && (
-					<div className="directorist-error">
-						<p>{error}</p>
-					</div>
-				)}
-
-				{!loading && !error && (
-					<>
-						<div className="directorist-enquiry-modal-info">
-							<div className="directorist-enquiry-sender">
-								<div className="directorist-enquiry-sender-avatar">
-									<img
-										src={
-											matchedEnquiry?.user?.profile_url ||
-											singleItem?.response?.user_email
-										}
-										alt={
-											matchedEnquiry?.user
-												?.display_name ||
-											singleItem?.response?.username
-										}
-									/>
-								</div>
-								<div className="directorist-enquiry-sender-info">
-									<h2>
-										{matchedEnquiry?.user?.display_name ||
-											singleItem?.response?.username}
-										<span
-											className={`directorist-badge directorist-badge-${statusBadge(singleItem?.response?.is_read)}`}
-										>
-											{getStatusBadgeText(
-												singleItem?.response?.is_read
-											)}
-										</span>
-									</h2>
-									<p>
-										{matchedEnquiry?.user?.user_email ||
-											singleItem?.response?.user_email}
-									</p>
-									<span>
-										{singleItem?.response?.created_at}
-									</span>
-								</div>
-							</div>
-							<div className="directorist-enquiry-listing">
-								<h3>
-									{__('Regarding Listing', 'directorist')}
-								</h3>
-								<a
-									href={singleItem?.listing_permalink || '#'}
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{matchedEnquiry?.listing_title ||
-										__('Unknown Listing', 'directorist')}
-								</a>
-							</div>
+		<>
+			<EnquiryModalGlobalStyle />
+			<Modal
+				title={`Enquiry Details - ${matchedEnquiry?.listing_title || 'Unknown Listing'}`}
+				onRequestClose={onClose}
+				className="directorist-enquiry-modal"
+				size="large"
+				isDismissible={false}
+			>
+				{/* Custom close button without tooltip - positioned in header via global CSS */}
+				<button
+					type="button"
+					className="directorist-enquiry-modal-close"
+					onClick={onClose}
+					aria-label=""
+				>
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						viewBox="0 0 24 24"
+						width="24"
+						height="24"
+						aria-hidden="true"
+						focusable="false"
+					>
+						<path d="m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z" />
+					</svg>
+				</button>
+				<EnquiryDetailsModalStyle className="directorist-enquiry-modal-content">
+					{loading && (
+						<div className="directorist-loading">
+							<p>
+								{__(
+									'Loading enquiry details...',
+									'directorist'
+								)}
+							</p>
 						</div>
+					)}
 
-						<div className="directorist-answers-section">
-							{singleItem?.response?.answers.map(
-								(answer, index) => {
-									return (
-										<TableDrawerAnswer
-											key={index}
-											answer={answer}
-											handleAnswerIcon={handleAnswerIcon}
-											getFormattedAnswer={
-												getFormattedAnswer
+					{error && (
+						<div className="directorist-error">
+							<p>{error}</p>
+						</div>
+					)}
+
+					{!loading && !error && (
+						<>
+							<div className="directorist-enquiry-modal-info">
+								<div className="directorist-enquiry-sender">
+									<div className="directorist-enquiry-sender-avatar">
+										<img
+											src={
+												matchedEnquiry?.user
+													?.profile_url ||
+												singleItem?.response?.user_email
 											}
-											ReactSVG={ReactSVG}
-											useState={useState}
-											useEffect={useEffect}
-											isLoadedFromDirectorist={true}
+											alt={
+												matchedEnquiry?.user
+													?.display_name ||
+												singleItem?.response?.username
+											}
 										/>
-									);
-								}
-							)}
-						</div>
+									</div>
+									<div className="directorist-enquiry-sender-info">
+										<h2>
+											{matchedEnquiry?.user
+												?.display_name ||
+												singleItem?.response?.username}
+											<span
+												className={`directorist-badge directorist-badge-${statusBadge(singleItem?.response?.is_read)}`}
+											>
+												{getStatusBadgeText(
+													singleItem?.response
+														?.is_read
+												)}
+											</span>
+										</h2>
+										<p>
+											{matchedEnquiry?.user?.user_email ||
+												singleItem?.response
+													?.user_email}
+										</p>
+										<span>
+											{singleItem?.response?.created_at}
+										</span>
+									</div>
+								</div>
+								<div className="directorist-enquiry-listing">
+									<h3>
+										{__('Regarding Listing', 'directorist')}
+									</h3>
+									<a
+										href={
+											singleItem?.listing_permalink || '#'
+										}
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{matchedEnquiry?.listing_title ||
+											__(
+												'Unknown Listing',
+												'directorist'
+											)}
+									</a>
+								</div>
+							</div>
 
-						<div className="directorist-enquiry-modal-footer">
-							<button
-								className="directorist-enquiry-modal-btn directorist-enquiry-modal-btn-reply"
-								onClick={() =>
-									handleSendEmail(singleItem?.response)
-								}
-							>
-								<Reply />
-								<span>{__('Send Email', 'directorist')}</span>
-							</button>
-							<button
-								className={`directorist-enquiry-modal-btn directorist-enquiry-modal-btn-resolved ${singleItem?.response?.is_read === '1' ? 'directorist-btn-disabled' : ''}`}
-								onClick={handleMarkAsReadClick}
-								disabled={singleItem?.response?.is_read === '1'}
-							>
-								<Check />
-								<span>
-									{singleItem?.response?.is_read === '1'
-										? __('Marked as read', 'directorist')
-										: __('Mark as read', 'directorist')}
-								</span>
-							</button>
-							<button
-								className="directorist-enquiry-modal-btn directorist-enquiry-modal-btn-delete"
-								onClick={() => {
-									handleDeleteItem(singleItem?.response);
-									onClose();
-								}}
-							>
-								<Trash />
-								<span>{__('Delete', 'directorist')}</span>
-							</button>
-						</div>
-					</>
-				)}
-			</EnquiryDetailsModalStyle>
-		</Modal>
+							<div className="directorist-answers-section">
+								{singleItem?.response?.answers.map(
+									(answer, index) => {
+										return (
+											<TableDrawerAnswer
+												key={index}
+												answer={answer}
+												handleAnswerIcon={
+													handleAnswerIcon
+												}
+												getFormattedAnswer={
+													getFormattedAnswer
+												}
+												ReactSVG={ReactSVG}
+												useState={useState}
+												useEffect={useEffect}
+												isLoadedFromDirectorist={true}
+											/>
+										);
+									}
+								)}
+							</div>
+
+							<div className="directorist-enquiry-modal-footer">
+								<button
+									className="directorist-enquiry-modal-btn directorist-enquiry-modal-btn-reply"
+									onClick={() =>
+										handleSendEmail(singleItem?.response)
+									}
+								>
+									<Reply />
+									<span>
+										{__('Send Email', 'directorist')}
+									</span>
+								</button>
+								<button
+									className={`directorist-enquiry-modal-btn directorist-enquiry-modal-btn-resolved ${singleItem?.response?.is_read === '1' ? 'directorist-btn-disabled' : ''}`}
+									onClick={handleMarkAsReadClick}
+									disabled={
+										singleItem?.response?.is_read === '1'
+									}
+								>
+									<Check />
+									<span>
+										{singleItem?.response?.is_read === '1'
+											? __(
+													'Marked as read',
+													'directorist'
+												)
+											: __('Mark as read', 'directorist')}
+									</span>
+								</button>
+								<button
+									className="directorist-enquiry-modal-btn directorist-enquiry-modal-btn-delete"
+									onClick={() => {
+										handleDeleteItem(singleItem?.response);
+										onClose();
+									}}
+								>
+									<Trash />
+									<span>{__('Delete', 'directorist')}</span>
+								</button>
+							</div>
+						</>
+					)}
+				</EnquiryDetailsModalStyle>
+			</Modal>
+		</>
 	);
 }

--- a/assets/src/js/formgent-integration/components/style.js
+++ b/assets/src/js/formgent-integration/components/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 
 const EnquiriesComponentStyle = styled.div`
 	.directorist-enquiries-header {
@@ -124,14 +124,14 @@ const EnquiriesComponentStyle = styled.div`
 			border-color: transparent !important;
 		}
 		.dataviews-view-table {
-			border:none;
+			border: none;
 			tbody {
 				td {
 					vertical-align: middle;
 				}
 			}
 		}
-		.dataviews-view-table__row{
+		.dataviews-view-table__row {
 			white-space: nowrap;
 		}
 		.dataviews__view-actions {
@@ -231,7 +231,7 @@ const EnquiriesComponentStyle = styled.div`
 	.dataviews-view-table__actions-column {
 		padding: 30px 0;
 		width: auto;
-		border:none;
+		border: none;
 	}
 	.dataviews-wrapper {
 		.components-h-stack {
@@ -601,4 +601,44 @@ const EnquiryDetailsModalStyle = styled.div`
 	}
 `;
 
-export { EnquiriesComponentStyle, EnquiryDetailsModalStyle };
+// Global style for custom close button in modal header
+const EnquiryModalGlobalStyle = createGlobalStyle`
+	.directorist-enquiry-modal .components-modal__header {
+		position: relative;
+		padding: 0 40px 0 0;
+	}
+	.directorist-enquiry-modal .components-modal__content {
+		margin-top: 0 !important;
+	}
+	.directorist-enquiry-modal-close {
+		position: absolute;
+		top: 40px;
+		right: 16px;
+		transform: translateY(-50%);
+		width: 32px;
+		height: 32px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border: none;
+		background: transparent;
+		cursor: pointer;
+		padding: 0;
+		color: #1e1e1e;
+		transition: opacity 0.2s;
+		&:hover {
+			opacity: 0.7;
+		}
+		svg {
+			width: 24px;
+			height: 24px;
+			fill: currentColor;
+		}
+	}
+`;
+
+export {
+	EnquiriesComponentStyle,
+	EnquiryDetailsModalStyle,
+	EnquiryModalGlobalStyle,
+};


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

Removes unwanted "Close" tooltip from enquiry modal close button using WordPress Modal API.

**Solution:**
- Use `isDismissible={false}` to disable default WordPress Modal close button
- Implement custom close button without tooltip
- Minimal `useEffect` to position button in modal header
- Remove margin-top from modal content for better spacing

**Approach:**
Uses WordPress Modal's native `isDismissible` API instead of hiding tooltips, following senior developer's recommendation for a cleaner solution.

## How to test

1. Go to Dashboard → My Enquiries
2. Click "View" on any enquiry
3. Hover over close button (X icon) in modal header
4. **Expected**: No tooltip appears, button works normally

## Any linked issues
Fixes tooltip display issue in enquiry details modal close button.


## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
