### PR TITLE
fix: display total enquiry count in dashboard Enquiries tab title

### DIFF
--- a/includes/model/ListingDashboard.php
+++ b/includes/model/ListingDashboard.php
@@ -396,8 +396,11 @@ class Directorist_Listing_Dashboard {
         }
 
         if ( $is_formgent_active ) {
+            $enquiry_kpis  = ATBDP()->formgent->get_kpis();
+            $enquiry_count = ! empty( $enquiry_kpis['total'] ) ? $enquiry_kpis['total'] : 0;
+
             $dashboard_tabs['dashboard_formgent'] = [
-                'title'     => __( 'Enquiries', 'directorist' ),
+                'title'     => sprintf( '%1$s (%2$s)', __( 'Enquiries', 'directorist' ), $enquiry_count ),
                 'content'   => Helper::get_template_contents( 'dashboard/tab-formgent', [ 'dashboard' => $this ] ),
                 'icon'      => 'las la-inbox',
             ];


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
The **"Enquiries"** tab on the user dashboard did not display the total enquiry count next to its title, unlike the **"My Listings"** tab which shows its count (e.g. `My Listings (12)`).

### Solution
The total enquiry count is now fetched using:
`ATBDP()->formgent->get_kpis()`

The count is appended to the tab title using the same `sprintf` pattern, resulting in:
`Enquiries (5)`

Before
https://share.cleanshot.com/LqhyvwK1
After
https://prnt.sc/s1yd7AcKNI3P

### Changed File
- `includes/model/ListingDashboard.php`

### Notes
- Guarded inside the existing `$is_formgent_active` check  
- No effect when **FormGent** is inactive  
- Read-only operation  
- No side effects on other dashboard tabs


## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
