### PR TITLE
fix: prevent Section Name input from losing focus on every keystroke

### DIFF
--- a/assets/src/js/admin/vue/modules/Field_List_Component.vue
+++ b/assets/src/js/admin/vue/modules/Field_List_Component.vue
@@ -57,8 +57,11 @@ export default {
     fieldList() {
       this.filterFieldList();
     },
-    value() {
-      this.filterFieldList();
+    value: {
+      handler() {
+        this.filterFieldList();
+      },
+      deep: true,
     },
   },
 

--- a/assets/src/js/admin/vue/modules/form-builder-modules/widget-group-components/Form_Builder_Widget_Group_Header_Component.vue
+++ b/assets/src/js/admin/vue/modules/form-builder-modules/widget-group-components/Form_Builder_Widget_Group_Header_Component.vue
@@ -246,25 +246,21 @@ export default {
     },
 
     /**
-     * Generate a unique key for field-list-component based on group data
-     * This ensures the component re-renders when the label changes,
-     * updating the input field with the new value.
+     * Generate a stable key for field-list-component.
      *
-     * By including the label in the key, Vue will treat it as a new component
-     * instance when the label changes, forcing a fresh render with updated values.
+     * Important: Do NOT include groupData.label (or any value the user is
+     * actively typing) in this key. Doing so causes Vue to destroy and
+     * recreate the field-list-component on every keystroke, which makes
+     * the Section Name input lose focus after a single character.
      *
-     * @returns {string} Unique key combining groupKey and label
+     * Reactivity for label changes coming from other sources (e.g. inline
+     * header editing) is handled by the deep watcher on the `value` prop
+     * inside Field_List_Component.vue.
+     *
+     * @returns {string} Stable key based on groupKey only
      */
     fieldListComponentKey() {
-      // Include label in the key so component re-renders when label changes
-      // This ensures the "Section Name" input field shows the updated label value
-      const label = this.getSearchGroup()
-        ? this.getSearchLabelContent()
-        : this.groupData?.label || "";
-
-      // Use groupKey and label to create a unique key
-      // When label changes, the key changes, forcing Vue to re-render the component
-      return `group_${this.groupKey}_label_${label}`;
+      return `group_${this.groupKey}`;
     },
   },
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
In the **Add Listing Form Builder**, opening **Configure Section** and typing in the **Section Name** input caused the field to lose focus after every keystroke. https://prnt.sc/B4yEqT7pE0Ii

### 🔍 Root Cause
The `fieldListComponentKey` computed property in  
`Form_Builder_Widget_Group_Header_Component.vue` included `groupData.label` in the Vue `:key`.

Each character update:
- Changed the `label`
- Changed the `key`
- Forced Vue to destroy & recreate `field-list-component`
- Destroyed the input DOM → focus lost

### ✅ Fix
- Removed `groupData.label` from `fieldListComponentKey` to keep the key stable during typing.
- Added `deep: true` to the `value` watcher in `Field_List_Component.vue` so label updates from other sources (e.g. inline header label editing) still sync properly without relying on key-based re-rendering.

### 📂 Files Changed
- `assets/src/js/admin/vue/modules/form-builder-modules/widget-group-components/Form_Builder_Widget_Group_Header_Component.vue`
- `assets/src/js/admin/vue/modules/Field_List_Component.vue`


## Any linked issues
Fixes #
https://github.com/sovware/directorist/issues/2655

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
