### PR TITLE
Fix SearchForm top categories crash when category directory type meta is not an array

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -2266,7 +2266,7 @@ function search_category_location_filter( $settings, $taxonomy_id, $prefix = '' 
             $directory_type = get_term_meta( $term->term_id, '_directory_type', true );
             $icon           = get_cat_icon( $term->term_id );
             $icon_src       = \Directorist\Helper::get_icon_src( $icon );
-            $directory_type = ! empty( $directory_type ) ? $directory_type : [];
+            $directory_type = ! empty( $directory_type ) ? (array) $directory_type : [];
             if ( in_array( $settings['listing_type'], $directory_type ) ) {
                 $settings['term_id'] = $term->term_id;
 

--- a/includes/model/SearchForm.php
+++ b/includes/model/SearchForm.php
@@ -840,7 +840,7 @@ class Directorist_Listing_Search_Form {
 
         foreach ( $cats as $cat ) {
             $directory_type      = get_term_meta( $cat->term_id, '_directory_type', true );
-            $directory_type      = ! empty( $directory_type ) ? $directory_type : [];
+            $directory_type = empty($directory_type) ? [] : (array) $directory_type;
             $listing_type_id     = $this->listing_type;
 
             if ( in_array( $listing_type_id, $directory_type ) ) {

--- a/includes/model/SearchForm.php
+++ b/includes/model/SearchForm.php
@@ -840,7 +840,7 @@ class Directorist_Listing_Search_Form {
 
         foreach ( $cats as $cat ) {
             $directory_type      = get_term_meta( $cat->term_id, '_directory_type', true );
-            $directory_type = empty($directory_type) ? [] : (array) $directory_type;
+            $directory_type = empty( $directory_type ) ? [] : (array) $directory_type;
             $listing_type_id     = $this->listing_type;
 
             if ( in_array( $listing_type_id, $directory_type ) ) {


### PR DESCRIPTION

## PR Type

- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description

**What changed**  
On PHP 8+, `in_array()` requires the second argument to be an array. Directorist sometimes stores term meta `_directory_type` as a single scalar (e.g. term ID) instead of an array. That triggered fatals in `SearchForm::top_categories()` and in the category/location search helper where the same meta is used.

**Normalisation**  
Before calling `in_array()` against listing/directory type:

- empty meta → `[]`
- non-array scalar → `[ $value ]`
- already an array → unchanged

## Screenshot 
**before** https://prnt.sc/E3Cv66B5lkcz
**after** https://prnt.sc/N2tI_md-ymee

### How to reproduce the issue

1. Use WordPress 6.7+ and PHP 8.x with Directorist active.
2. Ensure at least one listing category has `_directory_type` stored as a single ID (legacy or mixed data).
3. Load a page that builds popular top categories or the search form category tree.
4. Observe blank page / fatal in logs: `in_array(): Argument #2 ($haystack) must be of type array, int given`.

### How to test the changes

1. Apply the patch (SearchForm + helper-functions if both are in this PR).
2. Reload the same frontend pages (home, archive, search).
3. Confirm the UI renders and `debug.log` no longer shows the `in_array` TypeError for those paths.
4. Smoke-test category filtering with multiple directory types if applicable.

## Any linked issues

Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
