### PR TITLE
feat(Listings): add map_card_renderer extension point

### DIFF
--- a/includes/model/Listings.php
+++ b/includes/model/Listings.php
@@ -19,6 +19,12 @@ class Directorist_Listings {
 
     public $options = [];
 
+    /**
+     * Optional callable to override map card rendering.
+     * Signature: callable( int $listing_id, array $opt ): string
+     */
+    public $map_card_renderer = null;
+
     public $atts;
 
     public $type;
@@ -1671,8 +1677,12 @@ class Directorist_Listings {
 
                 $opt['ls_data'] = $ls_data;
 
+                $content = is_callable( $this->map_card_renderer )
+                    ? call_user_func( $this->map_card_renderer, $listings_id, $opt )
+                    : Helper::get_template_contents( 'archive/fields/openstreet-map', $opt );
+
                 $map_data[] = [
-                    'content'   => Helper::get_template_contents( 'archive/fields/openstreet-map', $opt ),
+                    'content'   => $content,
                     'latitude'  => get_post_meta( $listings_id, '_manual_lat', true ),
                     'longitude' => get_post_meta( $listings_id, '_manual_lng', true ),
                     'cat_icon'  => $cat_icon,
@@ -1757,7 +1767,11 @@ class Directorist_Listings {
 
                     if ( ! empty( $ls_data['manual_lat'] ) && ! empty( $ls_data['manual_lng'] ) ) {
                         $opt['ls_data'] = $ls_data;
-                        Helper::get_template( 'archive/fields/google-map', $opt );
+                        if ( is_callable( $this->map_card_renderer ) ) {
+                            echo call_user_func( $this->map_card_renderer, $listings_id, $opt );
+                        } else {
+                            Helper::get_template( 'archive/fields/google-map', $opt );
+                        }
                     }
 
                 endforeach;


### PR DESCRIPTION
## Summary

- Adds a public nullable callable property `$map_card_renderer` to `Directorist_Listings`
- When set, it replaces the default template call for each map marker card in both `openstreet_map_card_data()` (OpenStreet) and `load_google_map()` (Google Maps)
- Defaults to `null` — all existing behaviour is fully preserved, zero breaking changes

## Motivation

Integrations such as page builders need to render map popup cards using their own block/component system rather than the default Directorist templates. The only prior option was hooking `directorist_template_file_path` (a global filter that fires on every template load) and passing data through shared static state — both are fragile and carry unnecessary overhead.

`$map_card_renderer` gives integrations a direct, scoped, zero-side-effect extension point.

## Usage

```php
$listings->map_card_renderer = function( int $listing_id, array $opt ): string {
    // $opt contains map options + $opt['ls_data'] with listing data
    ob_start();
    // render your custom markup here
    return ob_get_clean();
};

$listings->render_map();
$listings->map_card_renderer = null; // always clean up
```

## Test plan

- [ ] Map view renders correctly with `$map_card_renderer = null` (default — no regression)
- [ ] OpenStreet map: custom renderer output appears in marker popups
- [ ] Google map: custom renderer output appears in marker info windows
- [ ] Setting renderer to `null` after `render_map()` leaves no side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)