### PR TITLE
fix: Replace placeholder href with actual sort-by link URL in sort-by dropdown

### DIFF
--- a/templates/archive/sortby-dropdown.php
+++ b/templates/archive/sortby-dropdown.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
             foreach ( $listings->get_sort_by_link_list() as $key => $value ) {
                 $active_class = ( $value['key'] == $current_order ) ? ' active' : '';
                 ?>
-                <a href="#" class="directorist-dropdown__links__single directorist-dropdown__links__single-js <?php echo esc_attr( $active_class );?>" data-link="<?php echo esc_attr( $value['link'] ); ?>"><?php echo esc_html( $value['label'] );?></a>
+                <a href="<?php echo esc_url( $value['link'] ); ?>" class="directorist-dropdown__links__single directorist-dropdown__links__single-js <?php echo esc_attr( $active_class );?>" data-link="<?php echo esc_attr( $value['link'] ); ?>"><?php echo esc_html( $value['label'] );?></a>
                 <?php
             }
             ?>


### PR DESCRIPTION
## Summary

- Sort-by dropdown `<a>` tags were using `href="#"` as a placeholder, relying only on the `data-link` attribute and JavaScript for navigation
- Replaced with `esc_url( $value['link'] )` so the correct URL is rendered directly in the `href` attribute
- The `data-link` attribute is retained for existing JS-driven behavior (e.g. AJAX filtering)

## Why this matters

- **Accessibility**: Screen readers and keyboard users expect functional `href` values on anchor elements
- **SEO**: Search engine crawlers follow `href` links, not `data-*` attributes — sort options were invisible to crawlers
- **Graceful degradation**: Sort links now work even if JavaScript fails or is disabled

## Changes

**`templates/archive/sortby-dropdown.php`**
```diff
- <a href="#" class="..." data-link="<?php echo esc_attr( $value['link'] ); ?>">
+ <a href="<?php echo esc_url( $value['link'] ); ?>" class="..." data-link="<?php echo esc_attr( $value['link'] ); ?>">
```

## Test plan

- [ ] Visit a listing archive page with the sort-by dropdown visible
- [ ] Inspect anchor elements — confirm `href` now contains the correct sort URL
- [ ] Click each sort option and verify the page sorts correctly
- [ ] Disable JavaScript and verify sort links still navigate to the correct URL
- [ ] Confirm no regression in JS-driven AJAX sort behavior