### PR TITLE
Fix PHP 8 type error in search category location filter when directory type is string

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -2266,7 +2266,7 @@ function search_category_location_filter( $settings, $taxonomy_id, $prefix = '' 
             $directory_type = get_term_meta( $term->term_id, '_directory_type', true );
             $icon           = get_cat_icon( $term->term_id );
             $icon_src       = \Directorist\Helper::get_icon_src( $icon );
-            $directory_type = ! empty( $directory_type ) ? $directory_type : [];
+            $directory_type = ! empty( $directory_type ) ? (array) $directory_type : [];
             if ( in_array( $settings['listing_type'], $directory_type ) ) {
                 $settings['term_id'] = $term->term_id;
 


### PR DESCRIPTION
## PR Type
**What kind of change does this PR introduce?**
This PR fixes a PHP 8+ `TypeError` that occurs when the `_directory_type` term meta is stored as a scalar string and used in `search_category_location_filter()`.

Currently, `get_term_meta( $term->term_id, '_directory_type', true )` can return a string like `'191'`, but later is passed directly to: in_array( $settings['listing_type'], $directory_type );

- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. Found   PHP Fatal error:  Uncaught TypeError: in_array(): Argument  must be of type array, string given
2.
3.

## Any linked issues
Fixes # 
https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/2735

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
