### PR TITLE
fix: remove branches filter from pr-review workflow trigger

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,7 +3,6 @@ name: Claude Code Review
 on:
   pull_request_target:
     types: [opened, synchronize]
-    branches: [development]
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
## Problem

The `claude-review` workflow uses `pull_request_target` with `branches: [development]`, but the workflow never triggered on any PR. The `branches` filter on `pull_request_target` matches the HEAD (feature) branch name rather than the PR's base branch, so `development` never matched.

## Fix

Remove the `branches: [development]` filter. The workflow is safe without it — `pull_request_target` runs in the base repo context with only `contents: read` permission and checks out a pinned SHA, so no untrusted code can run.

## Testing

Once merged into `development`, opening any PR against `development` should trigger the Claude Code Review workflow.