### PR TITLE
build: track openspec directory in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ languages/directorist-en_GB-backup-202002181356150.po~
 /.cursor
 /node-update-notes.md
 /pnpm-workspace.yaml
-/openspec


### PR DESCRIPTION
## PR Type
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Summary
Removes `/openspec` from `.gitignore` so that OpenSpec planning and spec files are tracked in the repository. This allows team members to share AI-generated specs, proposals, and implementation plans via version control.

## What Changed

### Function Changes
- No function changes.

### UX Changes
- No UX changes.

### UI Changes
- No UI changes.

## Files Changed

**Other**
- `.gitignore` — Remove `/openspec` exclusion rule to allow openspec directory tracking

## How to Test
1. Clone the repo fresh or pull latest
2. Run any `/opsx:propose` or `/opsx:apply` command in Claude Code
3. Verify `openspec/` files appear in `git status` as trackable
4. Run `git add openspec/` — confirm no "ignored" warning

## Any linked issues
Fixes #

## Checklist
- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)

## Additional Context
> OpenSpec files are Claude Code AI workflow artifacts (specs, tasks, design docs). Tracking them enables async collaboration — team members can review planning decisions alongside the code changes they produced.