### PR TITLE
build: fix claude-code-action OIDC error in pr-review workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -27,6 +27,11 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,7 +3,6 @@ name: Claude Code Review
 on:
   pull_request_target:
     types: [opened, synchronize]
-    branches: [development]
   issue_comment:
     types: [created]
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEW }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Review this pull request thoroughly. Focus on:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,21 +1,19 @@
 name: Claude Code Review
 
 on:
-  pull_request_target:
-    types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
 
-# Cancel in-progress reviews when new commits are pushed to the same PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    # Run on PR events, or on issue comments that start with @claude
     if: |
-      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude'))
@@ -24,7 +22,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -33,12 +30,10 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEW }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: "claude-sonnet-4-20250514"
-          direct_prompt: |
+          prompt: |
             Review this pull request thoroughly. Focus on:
 
             1. **Code Quality**: Clean code, readability, maintainability, proper error handling

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
   issue_comment:
     types: [created]
 
@@ -16,23 +18,20 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' &&
        contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_PR_REVIEW }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Review this pull request thoroughly. Focus on:
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ languages/directorist-en_GB-backup-202002181356150.po~
 /.cursor
 /node-update-notes.md
 /pnpm-workspace.yaml
-/openspec


### PR DESCRIPTION
## PR Type
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Summary
Fixes the Claude Code PR review workflow by passing `GITHUB_TOKEN` explicitly instead of relying on OIDC authentication. Also improves trigger configuration and removes unnecessary checkout step.

## What Changed

### Function Changes
- Add `github_token: ${{ secrets.GITHUB_TOKEN }}` to bypass OIDC authentication
- Change `contents` permission from `read` to `write`
- Add `pull_request_review_comment` trigger for inline @claude mentions
- Add condition for `pull_request_review_comment` event in job `if` block
- Remove `actions/checkout@v4` step (action handles checkout internally)

### UX Changes
- PR review workflow will run without OIDC token errors
- Team can invoke @claude in inline review comments, not just issue comments

### UI Changes
- No UI changes.

## Files Changed

**Config / CI**
- `.github/workflows/pr-review.yml` — Fix authentication, add trigger, remove redundant checkout

## How to Test
1. Merge this PR to `trunk`
2. Ensure `ANTHROPIC_API_KEY_PR_REVIEW` secret exists in repo Settings → Secrets → Actions
3. Open a test PR against `trunk` with a small code change
4. Verify the `Claude Code Review` workflow triggers and completes without errors
5. Try commenting `@claude` on a PR review comment to test inline trigger

## Any linked issues
Fixes #

## Checklist
- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)

## Additional Context
> The workflow was previously failing because `claude-code-action@v1` defaults to OIDC authentication for GitHub tokens. Passing `GITHUB_TOKEN` explicitly is simpler and requires no GitHub App installation.
