### PR TITLE
fix: use wp_kses with input allowlist to fix email verified checkbox …

### DIFF
--- a/includes/classes/class-user.php
+++ b/includes/classes/class-user.php
@@ -304,7 +304,15 @@ if ( ! class_exists( 'ATBDP_User' ) ) :
             <script>
                 jQuery(($) => {
                     $('#your-profile .user-email-wrap, #createuser .user-pass2-wrap').after(`<?php
-                        echo wp_kses_post( $email_verify_checkbox );
+                        echo wp_kses( $email_verify_checkbox, array_merge( wp_kses_allowed_html( 'post' ), [
+                                'input' => [
+                                    'type'    => true,
+                                    'name'    => true,
+                                    'id'      => true,
+                                    'value'   => true,
+                                    'checked' => true,
+                                ],
+                            ] ) );
                     ?>`);
                 });
             </script>

--- a/includes/classes/class-user.php
+++ b/includes/classes/class-user.php
@@ -304,15 +304,19 @@ if ( ! class_exists( 'ATBDP_User' ) ) :
             <script>
                 jQuery(($) => {
                     $('#your-profile .user-email-wrap, #createuser .user-pass2-wrap').after(`<?php
-                        echo wp_kses( $email_verify_checkbox, array_merge( wp_kses_allowed_html( 'post' ), [
-                                'input' => [
+                        $allowed_tags = array_merge(
+                            wp_kses_allowed_html( 'post' ),
+                            array(
+                                'input' => array(
                                     'type'    => true,
                                     'name'    => true,
                                     'id'      => true,
                                     'value'   => true,
                                     'checked' => true,
-                                ],
-                            ] ) );
+                                ),
+                            )
+                        );
+                        echo wp_kses( $email_verify_checkbox, $allowed_tags );
                     ?>`);
                 });
             </script>

--- a/includes/classes/class-user.php
+++ b/includes/classes/class-user.php
@@ -300,24 +300,24 @@ if ( ! class_exists( 'ATBDP_User' ) ) :
                     <label for="directorist_user_email_verified"><?php esc_html_e( 'Check this option to mark user email as verified', 'directorist' ); ?></label>
                 </td>
             </tr>
-            <?php $email_verify_checkbox = ob_get_clean(); ?>
+            <?php
+            $email_verify_checkbox = ob_get_clean();
+            $allowed_tags          = array_merge(
+                wp_kses_allowed_html( 'post' ),
+                array(
+                    'input' => array(
+                        'type'    => true,
+                        'name'    => true,
+                        'id'      => true,
+                        'value'   => true,
+                        'checked' => true,
+                    ),
+                )
+            );
+            ?>
             <script>
                 jQuery(($) => {
-                    $('#your-profile .user-email-wrap, #createuser .user-pass2-wrap').after(`<?php
-                        $allowed_tags = array_merge(
-                            wp_kses_allowed_html( 'post' ),
-                            array(
-                                'input' => array(
-                                    'type'    => true,
-                                    'name'    => true,
-                                    'id'      => true,
-                                    'value'   => true,
-                                    'checked' => true,
-                                ),
-                            )
-                        );
-                        echo wp_kses( $email_verify_checkbox, $allowed_tags );
-                    ?>`);
+                    $('#your-profile .user-email-wrap, #createuser .user-pass2-wrap').after(`<?php echo wp_kses( $email_verify_checkbox, $allowed_tags ); ?>`);
                 });
             </script>
             <?php


### PR DESCRIPTION
…not rendering

wp_kses_post strips <input> tags, causing the checkbox to be silently removed while the label remained. Extended the allowlist to permit input with safe attributes.

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.
2.
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
