### PR TITLE
improve: add Listing Type field to conditional logic available fields

### DIFF
--- a/assets/js/add-listing.js
+++ b/assets/js/add-listing.js
@@ -1009,7 +1009,8 @@ function mapFieldKeyToSelector(fieldKey) {
     miles: '[name="miles"], .directorist-custom-range-slider__range',
     search_by_rating: '[name="search_by_rating[]"]',
     review: '[name="search_by_rating[]"]',
-    image_upload: '[name="listing_img[]"], .directorist-form-image_upload-field'
+    image_upload: '[name="listing_img[]"], .directorist-form-image_upload-field',
+    listing_type: 'input[name="listing_type"]'
   };
   if (fieldKeyMap[fieldKey]) {
     return fieldKeyMap[fieldKey];

--- a/assets/js/admin-multi-directory-builder.js
+++ b/assets/js/admin-multi-directory-builder.js
@@ -3550,6 +3550,17 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
         }
       }
 
+      // Handle listing_type field - return "General" and "Featured" options
+      if (fieldKeyNorm === 'listing_type') {
+        return [{
+          value: 'general',
+          label: 'General'
+        }, {
+          value: 'featured',
+          label: 'Featured'
+        }];
+      }
+
       // Handle search_by_rating (Review) - checkbox field with star options
       if (fieldKeyNorm === 'search_by_rating' || fieldKeyNorm === 'search_by_rating[]' || fieldKeyNorm === 'review' || widgetName && String(widgetName).toLowerCase() === 'review') {
         return [{
@@ -22526,7 +22537,7 @@ __webpack_require__.r(__webpack_exports__);
 
       // Use the stored field key (set when conditional logic was enabled)
       var currentFieldKey = this.currentFieldKeyForExclusion;
-      var skipKeys = ["logic", "conditional_logic", "conditional-logic", "conditionalLogic", "submission_form_fields", "search_form_fields", "widgets", "fields", "social", "pricing", "map", "listing_type"];
+      var skipKeys = ["logic", "conditional_logic", "conditional-logic", "conditionalLogic", "submission_form_fields", "search_form_fields", "widgets", "fields", "social", "pricing", "map"];
 
       // Filter out the current field, conditional logic keys, and excluded types
       var filtered = this.availableFields.filter(function (field) {
@@ -22594,7 +22605,7 @@ __webpack_require__.r(__webpack_exports__);
       var fieldValue = (condition.field || "").toString().trim().toLowerCase();
 
       // File fields (including listing_img), radio fields, privacy policy field: only show "is" and "is not"
-      if (fieldType === "file" || fieldType === "file_upload" || fieldType === "radio" || fieldValue === "privacy_policy") {
+      if (fieldType === "file" || fieldType === "file_upload" || fieldType === "radio" || fieldValue === "privacy_policy" || fieldValue === "listing_type") {
         return this.operatorOptions.filter(function (operator) {
           return ["is", "is not"].includes(operator.value);
         });

--- a/assets/js/admin-settings-manager.js
+++ b/assets/js/admin-settings-manager.js
@@ -3550,6 +3550,17 @@ function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t =
         }
       }
 
+      // Handle listing_type field - return "General" and "Featured" options
+      if (fieldKeyNorm === 'listing_type') {
+        return [{
+          value: 'general',
+          label: 'General'
+        }, {
+          value: 'featured',
+          label: 'Featured'
+        }];
+      }
+
       // Handle search_by_rating (Review) - checkbox field with star options
       if (fieldKeyNorm === 'search_by_rating' || fieldKeyNorm === 'search_by_rating[]' || fieldKeyNorm === 'review' || widgetName && String(widgetName).toLowerCase() === 'review') {
         return [{
@@ -22433,7 +22444,7 @@ __webpack_require__.r(__webpack_exports__);
 
       // Use the stored field key (set when conditional logic was enabled)
       var currentFieldKey = this.currentFieldKeyForExclusion;
-      var skipKeys = ["logic", "conditional_logic", "conditional-logic", "conditionalLogic", "submission_form_fields", "search_form_fields", "widgets", "fields", "social", "pricing", "map", "listing_type"];
+      var skipKeys = ["logic", "conditional_logic", "conditional-logic", "conditionalLogic", "submission_form_fields", "search_form_fields", "widgets", "fields", "social", "pricing", "map"];
 
       // Filter out the current field, conditional logic keys, and excluded types
       var filtered = this.availableFields.filter(function (field) {
@@ -22501,7 +22512,7 @@ __webpack_require__.r(__webpack_exports__);
       var fieldValue = (condition.field || "").toString().trim().toLowerCase();
 
       // File fields (including listing_img), radio fields, privacy policy field: only show "is" and "is not"
-      if (fieldType === "file" || fieldType === "file_upload" || fieldType === "radio" || fieldValue === "privacy_policy") {
+      if (fieldType === "file" || fieldType === "file_upload" || fieldType === "radio" || fieldValue === "privacy_policy" || fieldValue === "listing_type") {
         return this.operatorOptions.filter(function (operator) {
           return ["is", "is not"].includes(operator.value);
         });

--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -1009,7 +1009,8 @@ function mapFieldKeyToSelector(fieldKey) {
     miles: '[name="miles"], .directorist-custom-range-slider__range',
     search_by_rating: '[name="search_by_rating[]"]',
     review: '[name="search_by_rating[]"]',
-    image_upload: '[name="listing_img[]"], .directorist-form-image_upload-field'
+    image_upload: '[name="listing_img[]"], .directorist-form-image_upload-field',
+    listing_type: 'input[name="listing_type"]'
   };
   if (fieldKeyMap[fieldKey]) {
     return fieldKeyMap[fieldKey];

--- a/assets/src/js/admin/vue/mixins/form-fields/conditional-logic-field.js
+++ b/assets/src/js/admin/vue/mixins/form-fields/conditional-logic-field.js
@@ -837,6 +837,14 @@ export default {
 				}
 			}
 
+			// Handle listing_type field - return "General" and "Featured" options
+			if (fieldKeyNorm === 'listing_type') {
+				return [
+					{ value: 'general', label: 'General' },
+					{ value: 'featured', label: 'Featured' },
+				];
+			}
+
 			// Handle search_by_rating (Review) - checkbox field with star options
 			if (
 				fieldKeyNorm === 'search_by_rating' ||

--- a/assets/src/js/admin/vue/modules/form-fields/themes/default/Conditional_Logic_Field_Theme_Default.vue
+++ b/assets/src/js/admin/vue/modules/form-fields/themes/default/Conditional_Logic_Field_Theme_Default.vue
@@ -619,7 +619,6 @@ export default {
         "social",
         "pricing",
         "map",
-        "listing_type",
       ];
 
       // Filter out the current field, conditional logic keys, and excluded types
@@ -712,7 +711,8 @@ export default {
         fieldType === "file" ||
         fieldType === "file_upload" ||
         fieldType === "radio" ||
-        fieldValue === "privacy_policy"
+        fieldValue === "privacy_policy" ||
+        fieldValue === "listing_type"
       ) {
         return this.operatorOptions.filter((operator) =>
           ["is", "is not"].includes(operator.value),

--- a/assets/src/js/global/components/conditional-logic/field-mapping.js
+++ b/assets/src/js/global/components/conditional-logic/field-mapping.js
@@ -177,6 +177,7 @@ export function mapFieldKeyToSelector(fieldKey) {
 		review: '[name="search_by_rating[]"]',
 		image_upload:
 			'[name="listing_img[]"], .directorist-form-image_upload-field',
+		listing_type: 'input[name="listing_type"]',
 	};
 
 	if (fieldKeyMap[fieldKey]) {

--- a/includes/model/ListingForm.php
+++ b/includes/model/ListingForm.php
@@ -724,6 +724,11 @@ class Directorist_Listing_Form {
             $valid_conditions = [];
             foreach ( $group['conditions'] as $condition ) {
                 if ( ! empty( $condition['field'] ) && ! empty( $condition['operator'] ) ) {
+                    // listing_type is not rendered in admin — skip its conditions so
+                    // dependent fields are always visible when editing a listing.
+                    if ( is_admin() && 'listing_type' === $condition['field'] ) {
+                        continue;
+                    }
                     $valid_conditions[] = $condition;
                 }
             }


### PR DESCRIPTION
- Remove listing_type from skipKeys so it appears in the "Select a field" dropdown
- Add listing_type to mapFieldKeyToSelector for reliable DOM value reading
- Return hardcoded General/Featured options in getValueOptions so a select dropdown renders instead of a free text input
- Limit operator options to "is / is not" only (same as privacy_policy) to avoid meaningless operators on a binary radio field

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.
2.
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
