### PR TITLE
Fix guest preview publish nonce flow

### DIFF
--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -511,10 +511,6 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
                     $data['redirect_url'] = Helper::escape_query_strings_from_url( $posted_data['redirect_url'] );
                 }
 
-                if ( $preview_enable ) {
-                    $data['redirect_url'] = wp_nonce_url( $data['redirect_url'], 'directorist_listing_form_redirect_url_' . $listing_id, '_token' );
-                }
-
                 $data['redirect_url'] = urlencode( $data['redirect_url'] );
 
                 $data = apply_filters( 'directorist_ajax_listing_submission_response', $data );

--- a/includes/classes/class-listing.php
+++ b/includes/classes/class-listing.php
@@ -126,10 +126,14 @@ if ( ! class_exists( 'ATBDP_Listing' ) ) :
             if ( ( empty( $_GET['listing_status'] ) && empty( $_GET['reviewed'] ) ) || isset( $_GET['preview'] ) ) {
                 return;
             }
-
             // Retrieve listing ID from multiple possible query parameters
             $listing_id = $this->get_listing_id_from_request();
+
             if ( ! $listing_id || ! directorist_is_listing_post_type( $listing_id ) ) {
+                return;
+            }
+
+            if ( ! current_user_can( get_post_type_object( ATBDP_POST_TYPE )->cap->edit_post, $listing_id ) ) {
                 return;
             }
 

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -993,7 +993,6 @@ class Directorist_Single_Listing {
         return $link;
     }
 
-
     public function has_redirect_link() {
         return isset( $_GET['redirect'] );
     }

--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -951,15 +951,14 @@ class Directorist_Single_Listing {
     }
 
     public function submit_link() {
-        $payment    = isset( $_GET['payment'] ) ? sanitize_text_field( wp_unslash( $_GET['payment'] ) ) : '';
-        
+        $payment = isset( $_GET['payment'] ) ? sanitize_text_field( wp_unslash( $_GET['payment'] ) ) : '';
+
         $redirect = '';
         if ( isset( $_GET['redirect'] ) ) {
             // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
             $redirect = wp_validate_redirect( wp_unslash( $_GET['redirect'] ), '' );
         }
-        
-        
+
         $listing_id = isset( $_GET['post_id'] ) ? sanitize_text_field( wp_unslash( $_GET['post_id'] ) ) : get_the_ID();
         $listing_id = isset( $_GET['p'] ) ? sanitize_text_field( wp_unslash( $_GET['p'] ) ) : $listing_id;
         $link       = '';
@@ -978,20 +977,22 @@ class Directorist_Single_Listing {
                     'p'        => $listing_id,
                     'post_id'  => $listing_id,
                     'reviewed' => 'yes',
-                    'edited'   => $edited ? 'yes' : 'no'
+                    'edited'   => $edited ? 'yes' : 'no',
                 ];
             } else {
                 $args = [
                     'atbdp_listing_id' => $listing_id,
-                    'reviewed'         => 'yes'
+                    'reviewed'         => 'yes',
                 ];
             }
 
             $link = add_query_arg( $args, $redirect );
+            $link = wp_nonce_url( $link, 'directorist_listing_form_redirect_url_' . $listing_id, '_token' );
         }
 
         return $link;
     }
+
 
     public function has_redirect_link() {
         return isset( $_GET['redirect'] );


### PR DESCRIPTION
Move preview publish nonce generation to the preview page so guest submissions use the authenticated session after account creation. Also add an edit capability check before updating listing status after review.

## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1.
2.
3.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
