### PR TITLE
Fix widgets default preview image in single listing sidebar

### DIFF
--- a/templates/widgets/featured-listing.php
+++ b/templates/widgets/featured-listing.php
@@ -57,7 +57,7 @@ $default_icon = 'las la-tags';
                 <div class="directorist-widget-listing__single">
                     <div class="directorist-widget-listing__image">
                         <?php
-                        $default_image = get_directorist_option( 'default_preview_image', DIRECTORIST_ASSETS . 'images/grid.jpg' );
+                        $default_image = \Directorist\Helper::default_preview_image_src( directorist_get_listing_directory( get_the_ID() ) );
                         if ( ! empty( $listing_prv_img ) ) {
                             echo '<a href="' . esc_url( get_the_permalink() ) . '"><img src="' . esc_url( wp_get_attachment_image_url( $listing_prv_img, [90, 90] ) ) . '" alt="listing image"></a>';
                         } elseif ( ! empty( $listing_img[0] ) && empty( $listing_prv_img ) ) {

--- a/templates/widgets/popular-listings.php
+++ b/templates/widgets/popular-listings.php
@@ -42,7 +42,7 @@ $default_icon = 'las la-tags';
                             <a href="<?php echo esc_url( get_the_permalink() ); ?>">
                             <?php
                         }
-                        $default_image = get_directorist_option( 'default_preview_image', DIRECTORIST_ASSETS . 'images/grid.jpg' );
+                        $default_image = \Directorist\Helper::default_preview_image_src( directorist_get_listing_directory( get_the_ID() ) );
                         if ( ! empty( $listing_prv_img ) ) {
                             echo '<img src="' . esc_url( wp_get_attachment_image_url( $listing_prv_img, [ 90, 90 ] ) ) . '" alt="' . esc_attr( get_the_title() ) . '">';
                         } elseif ( ! empty( $listing_img[0] ) && empty( $listing_prv_img ) ) {

--- a/templates/widgets/similar-listing.php
+++ b/templates/widgets/similar-listing.php
@@ -43,7 +43,7 @@ $default_icon = 'las la-tags';
             <a href="<?php echo esc_url( get_post_permalink( $related_listing->ID ) ); ?>">
                 <?php
             }
-            $default_image = get_directorist_option( 'default_preview_image', DIRECTORIST_ASSETS . 'images/grid.jpg' );
+            $default_image = \Directorist\Helper::default_preview_image_src( directorist_get_listing_directory( $related_listing->ID ) );
             if ( ! empty( $listing_prv_img ) ) {
                 echo '<img src="' . esc_url( wp_get_attachment_image_url( $listing_prv_img, [90, 90] ) ) . '" alt="listing image">';
             } elseif ( ! empty( $listing_img[0] ) && empty( $listing_prv_img ) ) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

1. In Directorist, set a directory-specific `Default listing preview image` in the directory builder `General` settings.
2. Create a featured/popular/similar listing without uploading a preview image or gallery image.
3. Open the single listing page and check the sidebar widgets.
4. Before this change, the widgets used Directorist's placeholder `grid.jpg` instead of the user-configured default listing preview image.
5. After this change, the widgets now use the directory-specific default preview image first, and only fall back to the placeholder if no default image is configured.

## Any linked issues
Fixes # https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/2891

## Screenshot
- https://prnt.sc/FOBdEpKfnhTb

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
