### PR TITLE
Fix single listing map popup image fallback

### DIFF
--- a/includes/model/SingleListing.php
+++ b/includes/model/SingleListing.php
@@ -1353,11 +1353,32 @@ class Directorist_Single_Listing {
         $display_favorite_badge_map = get_directorist_option( 'display_favorite_badge_map', 1 );
 
         $listing_prv_img = directorist_get_listing_preview_image( $id );
-        $default_image = get_directorist_option( 'default_preview_image', DIRECTORIST_ASSETS . 'images/grid.jpg' );
-        $listing_prv_imgurl = ! empty( $listing_prv_img ) ? atbdp_get_image_source( $listing_prv_img, 'small' ) : '';
-        $listing_prv_imgurl = atbdp_image_cropping( $listing_prv_img, 150, 150, true, 100 )['url'];
-        $img_url = ! empty( $listing_prv_imgurl ) ? $listing_prv_imgurl : $default_image;
-        $image = "<figure><img src=" . $img_url . " /></figure>";
+        $listing_img     = directorist_get_listing_gallery_images( $id );
+        $listing_type    = directorist_get_listing_directory( $id );
+        $default_image   = Helper::default_preview_image_src( $listing_type );
+        $listing_title   = get_the_title( $id );
+        $img_url         = '';
+
+        if ( ! empty( $listing_prv_img ) ) {
+            $cropped_image = atbdp_image_cropping( $listing_prv_img, 150, 150, true, 100 );
+            $img_url = ! empty( $cropped_image['url'] ) ? $cropped_image['url'] : atbdp_get_image_source( $listing_prv_img, 'small' );
+        }
+
+        if ( empty( $img_url ) && ! empty( $listing_img[0] ) ) {
+            $gallery_image_id = (int) $listing_img[0];
+            $cropped_image = atbdp_image_cropping( $gallery_image_id, 150, 150, true, 100 );
+            $img_url = ! empty( $cropped_image['url'] ) ? $cropped_image['url'] : atbdp_get_image_source( $gallery_image_id, 'small' );
+        }
+
+        if ( empty( $img_url ) ) {
+            $img_url = $default_image;
+        }
+
+        $image = sprintf(
+            "<figure><img src='%s' alt='%s' /></figure>",
+            esc_url( $img_url ),
+            esc_attr( $listing_title )
+        );
         if ( empty( $display_image_map ) ) {
             $image = '';
         }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

This fixes the single listing map popup image not showing the correct listing image when a listing does not have a preview image.

Previously, `Directorist_Single_Listing::map_data()` only checked the preview image and then fell back directly to the default image. Because of that, listings that had gallery images but no preview image still showed the fallback `grid.jpg` image in the single listing map popup.

This change updates the image fallback order in the single listing map data to:

1. Preview image
2. First gallery image
3. Directory default preview image

It also uses `Helper::default_preview_image_src()` for the default image source and escapes the rendered image output properly.

### Steps to reproduce
1. Create or edit a listing with:
   - no preview image
   - one or more gallery images
2. Open the single listing page.
3. In the `Location` section, open the listing marker popup on the map.
4. Notice the popup shows the fallback `grid.jpg` image instead of the uploaded listing image.

### Expected result
If no preview image is set, the single listing map popup should use the first gallery image before falling back to the default image.

### How to test the fix
1. Go to a single listing page that has:
   - no preview image
   - at least one gallery image
2. Open the map popup from the `Location` section.
3. Confirm the popup now shows the first gallery image.
4. Test a listing with a preview image and confirm the preview image is still shown first.
5. Test a listing with neither preview nor gallery image and confirm the directory default image is shown.

## Any linked issues
Support ticket:
- https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/2913

Related screenshots:
- Issue: https://prnt.sc/mPMRSbjnJkQ-
- Fix: https://prnt.sc/yX_Nokqddkw7

## Screenshot
- https://prnt.sc/yX_Nokqddkw7

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)