### PR TITLE
Fix ZIP-based radius search field visibility

### DIFF
--- a/assets/js/search-form.js
+++ b/assets/js/search-form.js
@@ -4442,46 +4442,41 @@ document.addEventListener('DOMContentLoaded', function () {
       window.history.back();
     });
 
+    function getRadiusVisibilityContext() {
+      var $element = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : $();
+      var $context = $element.closest('.directorist-contents-wrap, .directorist-search-form, form');
+      return $context.length ? $context.first() : $(document.body);
+    }
+
     // Radius Search Field Hide on Empty Location Field
     function handleRadiusVisibility() {
+      var $scope = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
       // Add class to mark the radius search field
       $('.directorist-range-slider-wrap').closest('.directorist-search-field').addClass('directorist-search-field-radius_search');
-      var radius_search_item_selector = null;
-      var radius_search_based_on = $('.directorist-radius_search_based_on').val();
-
-      // Determine which search item selector to use
-      if (radius_search_based_on === 'address') {
-        radius_search_item_selector = '.directorist-location-js';
-      } else if (radius_search_based_on === 'zip') {
-        radius_search_item_selector = '.directorist-zipcode-search .zip-radius-search';
-      } else {
-        // Default fallback
-        radius_search_item_selector = '.directorist-location-js';
+      var $radiusFields = $('.directorist-search-field-radius_search, .directorist-radius-search');
+      if ($scope && $scope.length) {
+        $radiusFields = $scope.find('.directorist-search-field-radius_search, .directorist-radius-search');
+        if (!$radiusFields.length && $scope.is('.directorist-search-field-radius_search, .directorist-radius-search')) {
+          $radiusFields = $scope;
+        }
       }
-
-      // Check if radius search item selector elements exist
-      var $radiusSearchItems = $(radius_search_item_selector);
-      if ($radiusSearchItems.length === 0) {
-        // If no elements found, hide all radius search containers
-        $('.directorist-search-field-radius_search, .directorist-radius-search').css({
-          display: 'none'
+      $radiusFields.each(function (index, radiusFieldDOM) {
+        var $radiusField = $(radiusFieldDOM);
+        var $context = getRadiusVisibilityContext($radiusField);
+        var radius_search_based_on = $radiusField.find('.directorist-radius_search_based_on').first().val() || $context.find('.directorist-radius_search_based_on').first().val() || 'address';
+        var radius_search_item_selector = radius_search_based_on === 'zip' ? '.directorist-zipcode-search .zip-radius-search' : '.directorist-location-js';
+        var hasValue = $context.find(radius_search_item_selector).filter(function (itemIndex, locationDOM) {
+          return String($(locationDOM).val()).trim() !== '';
+        }).length > 0;
+        $radiusField.css({
+          display: hasValue ? 'block' : 'none'
         });
-      } else {
-        // Loop through the elements
-        $radiusSearchItems.each(function (index, locationDOM) {
-          var $location = $(locationDOM);
-          var isEmpty = $location.val() === '';
-          var $container = $location.closest('.directorist-contents-wrap').find('.directorist-search-field-radius_search, .directorist-radius-search');
-          $container.css({
-            display: isEmpty ? 'none' : 'block'
-          });
-        });
-      }
+      });
     }
 
     // handleRadiusVisibility Trigger
     $('body').on('keyup keydown input change focus', '.directorist-location-js, .zip-radius-search', function (e) {
-      handleRadiusVisibility();
+      handleRadiusVisibility(getRadiusVisibilityContext($(this)));
     });
 
     // rangeSlider, defaultTags Trigger on directory type | page change
@@ -4499,6 +4494,7 @@ document.addEventListener('DOMContentLoaded', function () {
       directorist_custom_range_slider();
       defaultTags();
     });
+    handleRadiusVisibility();
 
     // active class add on view as button
     $('body').on('click', '.directorist-viewas .directorist-viewas__item', function (e) {

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -1500,54 +1500,62 @@ document.addEventListener('DOMContentLoaded', () => {
 			window.history.back();
 		});
 
+		function getRadiusVisibilityContext($element = $()) {
+			const $context = $element.closest(
+				'.directorist-contents-wrap, .directorist-search-form, form'
+			);
+
+			return $context.length ? $context.first() : $(document.body);
+		}
+
 		// Radius Search Field Hide on Empty Location Field
-		function handleRadiusVisibility() {
+		function handleRadiusVisibility($scope = null) {
 			// Add class to mark the radius search field
 			$('.directorist-range-slider-wrap')
 				.closest('.directorist-search-field')
 				.addClass('directorist-search-field-radius_search');
 
-			let radius_search_item_selector = null;
-			const radius_search_based_on = $(
-				'.directorist-radius_search_based_on'
-			).val();
+			let $radiusFields = $(
+				'.directorist-search-field-radius_search, .directorist-radius-search'
+			);
 
-			// Determine which search item selector to use
-			if (radius_search_based_on === 'address') {
-				radius_search_item_selector = '.directorist-location-js';
-			} else if (radius_search_based_on === 'zip') {
-				radius_search_item_selector =
-					'.directorist-zipcode-search .zip-radius-search';
-			} else {
-				// Default fallback
-				radius_search_item_selector = '.directorist-location-js';
-			}
-
-			// Check if radius search item selector elements exist
-			const $radiusSearchItems = $(radius_search_item_selector);
-
-			if ($radiusSearchItems.length === 0) {
-				// If no elements found, hide all radius search containers
-				$(
+			if ($scope && $scope.length) {
+				$radiusFields = $scope.find(
 					'.directorist-search-field-radius_search, .directorist-radius-search'
-				).css({
-					display: 'none',
-				});
-			} else {
-				// Loop through the elements
-				$radiusSearchItems.each((index, locationDOM) => {
-					const $location = $(locationDOM);
-					const isEmpty = $location.val() === '';
+				);
 
-					const $container = $location
-						.closest('.directorist-contents-wrap')
-						.find(
-							'.directorist-search-field-radius_search, .directorist-radius-search'
-						);
-
-					$container.css({ display: isEmpty ? 'none' : 'block' });
-				});
+				if (
+					!$radiusFields.length &&
+					$scope.is(
+						'.directorist-search-field-radius_search, .directorist-radius-search'
+					)
+				) {
+					$radiusFields = $scope;
+				}
 			}
+
+			$radiusFields.each((index, radiusFieldDOM) => {
+				const $radiusField = $(radiusFieldDOM);
+				const $context = getRadiusVisibilityContext($radiusField);
+				const radius_search_based_on =
+					$radiusField.find('.directorist-radius_search_based_on').first().val() ||
+					$context.find('.directorist-radius_search_based_on').first().val() ||
+					'address';
+				const radius_search_item_selector =
+					radius_search_based_on === 'zip'
+						? '.directorist-zipcode-search .zip-radius-search'
+						: '.directorist-location-js';
+				const hasValue =
+					$context
+						.find(radius_search_item_selector)
+						.filter((itemIndex, locationDOM) => {
+							return String($(locationDOM).val()).trim() !== '';
+						}).length > 0;
+
+				$radiusField.css({
+					display: hasValue ? 'block' : 'none',
+				});
+			});
 		}
 
 		// handleRadiusVisibility Trigger
@@ -1555,7 +1563,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			'keyup keydown input change focus',
 			'.directorist-location-js, .zip-radius-search',
 			function (e) {
-				handleRadiusVisibility();
+				handleRadiusVisibility(getRadiusVisibilityContext($(this)));
 			}
 		);
 
@@ -1581,6 +1589,8 @@ document.addEventListener('DOMContentLoaded', () => {
 				defaultTags();
 			}
 		);
+
+		handleRadiusVisibility();
 
 		// active class add on view as button
 		$('body').on(

--- a/templates/search-form/fields/zip.php
+++ b/templates/search-form/fields/zip.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 $conditional_logic_attr = $searchform->get_conditional_logic_attributes( $data );
 $field_key              = ! empty( $data['field_key'] ) ? $data['field_key'] : ( ! empty( $data['widget_name'] ) ? $data['widget_name'] : 'zip' );
+$value                  = ! empty( $value ) ? $value : ( ! empty( $_REQUEST[ $field_key ] ) ? sanitize_text_field( wp_unslash( $_REQUEST[ $field_key ] ) ) : '' );
 $lat                    = ! empty( $_REQUEST['zip_cityLat'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['zip_cityLat'] ) ) : '';
 $lng                    = ! empty( $_REQUEST['zip_cityLng'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['zip_cityLng'] ) ) : '';
 ?>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
This PR fixes an issue with ZIP-based radius search where the radius field could be hidden unexpectedly and the ZIP value was not always preserved on the search result page.

Directorist supports radius search based on ZIP code. When `Radius Search` is configured to work based on `ZIP`, the radius field should appear when a ZIP code is entered and should remain visible when the search result page loads with a ZIP value in the request.

Before this change:
- The radius visibility logic used global selectors instead of the active search form context.
- ZIP-based radius visibility could behave inconsistently when other search fields or forms existed on the page.
- The ZIP field could render empty on the search result page even when `zip` existed in the request.
- Because of that, the radius field could remain hidden after page load.

After this change:
- Radius visibility is checked within the active search form context.
- ZIP-based radius forms now react to ZIP input correctly.
- Address input no longer controls radius visibility when the form is configured for ZIP-based radius search.
- The ZIP field falls back to the request value when its rendered value is empty.
- The radius field remains visible on the search result page when ZIP is already present.

## How to reproduce / How to test

1. In Directorist Search Form Builder, add `ZIP` and `Radius Search` fields.
2. Configure `Radius Search` to work based on `ZIP`.
3. Open the search page.
4. Enter a ZIP code.

Before this change:
- The radius field could remain hidden or behave inconsistently.

After this change:
- The radius field becomes visible after entering a ZIP code.

Additional test:

1. Visit a search result page with a ZIP query in the URL.
2. Example:
   `?directory_type=basic&zip=80331&miles=0-98&view=list`

Before this change:
- The ZIP field could appear empty.
- The radius field could be hidden on page load.

After this change:
- The ZIP field remains populated.
- The radius field remains visible.

Regression check:

1. Keep the form configured for ZIP-based radius search.
2. Enter only Address without entering ZIP.
3. Confirm the radius field does not appear.
4. This confirms ZIP-based radius visibility is not incorrectly controlled by Address input.

## Any linked issues
Fixes: https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/2917

## Screenshot
- https://prnt.sc/yCrUJN59WF3R
- https://prnt.sc/5jLL4jcKjBTj

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)