### PR TITLE
fix: initialize ajax html editor on listing type switch

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -47,3 +47,4 @@
 /README.md
 /node-update-notes.md
 /CLAUDE.md
+/AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ languages/directorist-en_GB-backup-202002181356150.po~
 /.cursor
 /.husky
 /.claude
+/.agents
 /.cursor
 /node-update-notes.md
 /pnpm-workspace.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,277 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+> Last updated: 2026-04-09
+
+## Project
+
+- **Name:** Directorist — Business Directory Solution
+- **Type:** WordPress plugin (GPLv3)
+- **Version:** 8.6.7+
+- **Repo:** https://github.com/sovware/directorist
+- **Entry point:** `directorist-base.php` → singleton `Directorist_Base`
+- **Config:** `config.php` — constants: `ATBDP_VERSION`, `ATBDP_POST_TYPE` (`at_biz_dir`), `ATBDP_TEXTDOMAIN` (`directorist`)
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| PHP | 7.0+ (PHPCS targets 7.4), WordPress 4.6+ (tested 6.9) |
+| Admin UI | Vue 2.6 + Vuex (builder/settings), jQuery (legacy) |
+| Blocks | React via @wordpress/components |
+| CSS | SCSS → Webpack → CSS + RTL variants |
+| Build | Webpack 5, npm scripts, Husky + lint-staged |
+| PHP QA | PHPCS + WordPress Coding Standards 2.3 |
+| JS QA | Prettier 3.5.3, wp-scripts |
+
+## Commands
+
+| Task | Command |
+|------|---------|
+| Dev build (JS/CSS) | `npm run dev` |
+| Dev build (Vue) | `npm run dev-vue` |
+| Production build | `npm run prod` |
+| Format JS/CSS/SCSS | `npm run format` |
+| PHP lint | `composer phpcs` |
+| PHP auto-fix | `composer format` |
+| PHP 8.1 compat check | `composer sniffer:php8.1` |
+
+## Workflow
+
+- **Main branch:** `trunk`
+- **Branch prefixes:** `fix/`, `add/`, `improve/`, `feature/`, `style/`, `build/`
+- **Commit style:** Conventional — `fix:`, `improve:`, `revert:`, `style:`, `build:`
+- **CI:** PHPCS on PRs (`phpcs.yml`), WordPress.org SVN deploy on tags (`wp-deploy.yml`), FTP staging on `development` push
+- **Pre-commit:** Husky runs Prettier (JS/CSS/SCSS) + phpcbf (PHP) via lint-staged
+
+## Architecture Overview
+
+```
+includes/
+├── classes/          # Core classes (ajax, email, extension, listing, metabox, settings, user, tools)
+├── model/            # Data models (9 classes — see Model Layer below)
+├── fields/           # Custom field type system (Base_Field + 24 field types)
+├── rest-api/         # REST controllers: Version1/ (16), Version2/ (1)
+├── checkout/         # Checkout flow (ATBDP_Checkout)
+├── gateways/         # Payment gateways (ATBDP_Gateway base, ATBDP_Offline_Gateway)
+├── payments/         # Order management (ATBDP_Order)
+├── elementor/        # 19 Elementor widgets
+├── hooks/            # Hook registration
+├── helpers/          # Traits: Icon, Markup, URI
+├── modules/          # Background processing, multi-directory setup, Appsero
+├── review/           # Review system
+├── database/         # ATBDP_Database base class
+├── data-store/       # Term caching (ATBDP_Terms_Store)
+├── asset-loader/     # Dynamic asset enqueue system
+└── widgets/          # Classic WordPress widgets
+templates/            # Public templates (theme-overridable)
+views/admin-templates/ # Admin UI templates
+blocks/src/ → build/  # 21 Gutenberg blocks
+assets/src/js/        # JS source (public/, admin/, global/, lib/)
+assets/src/scss/      # SCSS source
+```
+
+## REST API
+
+**Namespace:** `directorist/v1` (and `directorist/v2`)
+**Base classes:** `Abstract_Controller` (extends `WP_REST_Controller`) → `Posts_Controller` | `Terms_Controller`
+
+| Controller | Route | Base |
+|-----------|-------|------|
+| Listings_Controller | `/listings` | Posts_Controller |
+| Listings_Actions_Controller | `/listings/{id}/actions` | Abstract_Controller |
+| Listing_Reviews_Controller | `/listings/reviews` | Abstract_Controller |
+| Categories_Controller | `/listings/categories` | Terms_Controller |
+| Locations_Controller | `/listings/locations` | Terms_Controller |
+| Tags_Controller | `/listings/tags` | Terms_Controller |
+| Directories_Controller | `/directories` | Terms_Controller |
+| Users_Controller | `/users` | Abstract_Controller |
+| User_Favorites_Controller | `/users/{id}/favorites` | Abstract_Controller |
+| Users_Account_Controller | `/users/account/...` | Abstract_Controller |
+| Builder_Controller | `/builder/{tab}` | Abstract_Controller |
+| Plans_Controller | `/plans` | Posts_Controller |
+| Orders_Controller | `/orders` | Posts_Controller |
+| Pages_Controller | `/pages` | Abstract_Controller |
+| Admin_Controller | `/admin/install-plugin` | Abstract_Controller |
+| Temporary_Media_Upload_Controller | `/temp-media-upload` | Abstract_Controller |
+| v2 Listings_Controller | `/listings` (v2) | v1 Listings_Controller |
+
+Location: `includes/rest-api/Version1/`, `includes/rest-api/Version2/`
+
+## Field/Form Builder System
+
+**Base class:** `Directorist\Fields\Base_Field` (`includes/fields/class-directorist-base-field.php`)
+**Manager:** `Directorist\Fields\Fields` — `register()`, `get()`, `create()`, `exists()`
+**Registration:** Each field extends `Base_Field`, sets `$type`, auto-registers at include time.
+**Legacy mapping:** `Fields::translate_key_to_field()` + filter `directorist_listing_form_fields_class_map`
+
+**24 field types:** text, textarea, number, url, date, time, color_picker, select, checkbox, radio, file, description, viewcount, email, video, switch, taxonomy, locations, categories, tags, pricing, map, social_info, image_upload
+
+Location: `includes/fields/`
+
+## Vue Admin Builder
+
+**Entry points:**
+- `assets/src/js/admin/multi-directory-builder.js` → mounts on `#atbdp-cpt-manager`
+- Settings manager entry in `webpack-entry-list.js`
+
+**Store:** `assets/src/js/admin/vue/store/CPT_Manager_Store.js` (Vuex)
+- State: `fields`, `layouts`, `options`, `config`, `listing_type_id`, `metaKeys`, `sidebarNavigation`
+- 18 mutations for managing builder data
+
+**Apps:** `assets/src/js/admin/vue/apps/`
+- `cpt-manager/` — listing type builder (CPT_Manager.vue)
+- `settings-manager/` — settings UI (Settings_Manager.vue)
+
+**Modules:** Auto-registered via `require.context()` in `global-component.js` (PascalCase naming)
+- 17 card widget components, form builder drag-drop components, 66 form field components
+- **Mixins:** 30 files in `vue/mixins/` for shared field logic
+- **Themes:** Form fields support Default and Butterfly theme variants
+
+**Data flow:** Server → base64-encoded JSON in DOM `data-builder-data` attribute → Vue instance → Vuex store
+
+## Model Layer
+
+| Model | File | Purpose |
+|-------|------|---------|
+| Listings | Listings.php (115 KB) | Core listing queries, taxonomy filtering, search, rendering |
+| SingleListing | SingleListing.php (59 KB) | Single listing page: metadata, pricing, coordinates, reviews |
+| SearchForm | SearchForm.php (47 KB) | Search form builder and filter management |
+| ListingForm | ListingForm.php (43 KB) | Listing entry form, field handling, post management |
+| ListingDashboard | ListingDashboard.php (25 KB) | User dashboard, listing management, renewals |
+| ListingTaxonomy | ListingTaxonomy.php (19 KB) | Category/location/tag queries and display |
+| ListingAuthor | ListingAuthor.php (13 KB) | Author profile with ratings and listing queries |
+| Account | Account.php (12 KB) | Sign-in/sign-up shortcode and forms |
+| All_Authors | All_Authors.php (5 KB) | Author listing with sorting |
+
+Location: `includes/model/` — namespace `Directorist`
+
+## Payment & Orders
+
+**Gateway base:** `ATBDP_Gateway` (`includes/gateways/class-gateway.php`)
+**Built-in:** `ATBDP_Offline_Gateway` (bank transfer)
+**Checkout:** `ATBDP_Checkout` (`includes/checkout/class-checkout.php`) — `create_order()`, `process_payment()`, `complete_free_order()`
+**Order post type:** `atbdp_orders`
+
+**Order meta keys:** `_listing_id`, `_featured`, `_amount`, `_payment_gateway`, `_payment_status` (created/completed/pending), `_transaction_id`, `_refresh_renewal_token`
+
+**Key hooks:** `atbdp_order_created`, `atbdp_order_completed`, `atbdp_process_{$gateway}_payment` (dynamic per gateway)
+
+## Template System
+
+**Lookup hierarchy** (via `atbdp_get_template()`):
+1. Child theme: `wp-content/themes/{child}/directorist/{file}.php`
+2. Parent theme: `wp-content/themes/{parent}/directorist/{file}.php`
+3. Plugin fallback: `views/{file}.php`
+
+**Functions:** `atbdp_get_template()`, `atbdp_get_template_path()`, `atbdp_get_admin_template()`, `atbdp_get_widget_template()`, `atbdp_get_extension_template()`
+
+Location: `includes/template-functions.php`, public templates in `templates/`, admin in `views/admin-templates/`
+
+## Block Editor (Gutenberg)
+
+**21 blocks** registered in `blocks/init.php` via `register_block_type()` with `block.json` (apiVersion 3):
+account-button, author-profile, authors, categories, checkout, dashboard, listing-form, listings, locations, payment-receipt, search-form, search-modal, search-result, signin-signup, single-category, single-listing, single-location, single-tag, transaction-failure, vendors
+
+**Pattern:** Render callback (`directorist_block_render_callback`) converts block attributes to shortcode calls.
+**Category:** `directorist-blocks-collection`
+**Source:** `blocks/src/` → `blocks/build/`
+
+## Elementor Integration
+
+**19 widgets** in `includes/elementor/` — namespace `AazzTech\Directorist\Elementor`, base class in `base.php`
+Widgets: all-listing, all-categories, all-locations, category, location, tag, search-listing, search-result, add-listing, user-login, custom-registration, user-dashboard, author-profile, transaction-failure, payment-receipt, checkout, deprecated-notice
+**Theme override:** `STYLESHEETPATH/directorist-elementor/{widget}.php`
+
+## AJAX Endpoints
+
+**Handler:** `includes/classes/class-ajax-handler.php` (89 KB)
+**Naming:** `wp_ajax_atbdp_*` (legacy) and `wp_ajax_directorist_*` (new)
+
+**Key categories:**
+- **Listings:** `remove_listing`, `directorist_upload_listing_image`, `directorist_import_listings`, `directorist_track_listing_views`
+- **Search:** `directorist_instant_search`, `directorist_zipcode_search`, `bdas_public_dropdown_terms`, `directorist_category_custom_field_search`
+- **Users:** `update_user_profile`, `update_user_preferences`, `ajaxlogin`, `atbdp_ajax_quick_login`, `atbdp_become_author`, `directorist_register_form`
+- **Favorites:** `atbdp_public_add_remove_favorites`, `atbdp-favourites-all-listing`
+- **Contact:** `atbdp_public_report_abuse`, `atbdp_public_send_contact_email`
+- **Admin/Builder:** `directorist_type_slug_change`, `directorist_load_category_custom_fields`, `save_settings_data`, `atbdp_listing_default_type`
+- **Extensions:** `atbdp_authenticate_the_customer`, `atbdp_download_file`, `atbdp_install_file_from_subscriptions`, `atbdp_plugins_bulk_action`
+- **Taxonomy options:** `directorist_get_category_options`, `directorist_get_tag_options`, `directorist_get_location_options`
+
+## Key Hooks & Filters
+
+**Lifecycle:** `directorist_loaded`, `directorist_installed`, `directorist_updated`
+
+**Listing CRUD:** `atbdp_listing_inserted`, `atbdp_listing_updated`, `atbdp_listing_published`, `atbdp_before_processing_listing_frontend`, `atbdp_after_created_listing`
+
+**Data filters:** `atbdp_listing_meta_user_submission`, `directorist_update_listing_data`, `directorist_insert_listing_data`, `atbdp_add_listing_form_validation_logic`
+
+**Email:** `directorist_email_on_notify_owner_*` (order_created, order_completed, listing_submitted, listing_published, listing_edited, listing_to_expire, listing_expired), `directorist_replace_in_content`
+
+**Extension:** `directorist_extensions_aliases`, `directorist_required_extensions`
+**Settings:** `atbdp_listing_type_settings_field_list`
+**Templates:** `directorist_admin_template`
+**Display:** `directorist_localized_data`, `directorist_scripts`, `directorist_load_inline_style`
+
+**Prefix convention:** `atbdp_` (legacy, still widely used) → `directorist_` (new standard)
+
+## Database Schema
+
+**Post Types:** `at_biz_dir` (listings), `atbdp_orders`, `atbdp_fields` (custom fields)
+**Taxonomies:** `at_biz_dir-category`, `at_biz_dir-location`, `at_biz_dir-tags`, `atbdp_listing_types` (directory types)
+
+**Listing meta (`at_biz_dir`):** `_price`, `_price_range`, `_atbd_listing_pricing`, `_address`, `_email`, `_phone`, `_tagline`, `_social` (JSON), `_manual_lat`, `_manual_lng`, `_hide_map`, `_featured`, `_listing_status`, `_expiry_date`, `_never_expire`, `_directory_type`, `_disable_bz_hour_listing`
+
+**Order meta (`atbdp_orders`):** `_listing_id`, `_featured`, `_amount`, `_payment_gateway`, `_payment_status`, `_transaction_id`
+
+**User meta:** `_user_type`, `pro_pic` (profile picture), `_atbdp_purchased_products`, `_atbdp_has_subscriptions_sassion`, `_subscribed_users_plan_id`
+
+**Term meta:** `_directory_type` (taxonomy→directory association), `_default`, `_created_date`
+
+## Settings Architecture
+
+**Class:** `ATBDP_Settings_Panel` (`includes/classes/class-settings-panel.php`, 263 KB)
+**Registration:** Add fields via `atbdp_listing_type_settings_field_list` filter
+**Save:** `wp_ajax_save_settings_data`
+**Options prefix:** `atbdp_` (legacy) and `directorist_` (new)
+**Features:** Import/export settings, restore defaults, per-directory-type settings, conditional field visibility (show-if)
+
+## Build Pipeline
+
+| Config | Purpose | Watch |
+|--------|---------|-------|
+| `webpack.common.js` | Shared loaders (Vue, Babel, SASS, images) | — |
+| `webpack.dev.js` | JS/CSS dev build (commonEntries) | Yes |
+| `webpack.dev.vue.js` | Vue admin dev build (vueEntries) | Yes |
+| `webpack.prod.js` | Minified + RTL + zip packaging | No |
+
+**Entry list:** `webpack-entry-list.js` defines `commonEntries` (30+ public/admin/global bundles) and `vueEntries` (admin-multi-directory-builder, admin-settings-manager)
+**Output:** `assets/js/`, `assets/css/` — production adds `.min.js`, `.min.css`, `.rtl.min.css`
+**Packaging:** Production builds to `__build/directorist/` → `directorist.zip`
+**RTL:** Auto-generated via webpack-rtl-plugin
+
+## Naming Conventions
+
+- **PHP functions:** `snake_case` — `get_directorist_option()`
+- **PHP classes:** `PascalCase` — `namespace Directorist;`
+- **JS functions:** `camelCase`
+- **CSS classes:** `directorist-` prefix, BEM-inspired — `.directorist-alert__close`
+- **CSS variables:** `--directorist-color-primary`
+- **Hooks:** `atbdp_` (legacy) / `directorist_` (new)
+- **Text domain:** `directorist` (constant `ATBDP_TEXTDOMAIN`)
+- **Custom PHPCS rules:** `directorist_clean` (sanitization), `directorist_kses` (escaping), `directorist_verify_nonce` (nonce)
+
+## Extension System
+
+**Manager:** `includes/classes/class-extension.php` (144 KB)
+**Lifecycle:** Authentication → download → install → activate (via AJAX)
+**Key AJAX actions:** `atbdp_authenticate_the_customer`, `atbdp_download_file`, `atbdp_install_file_from_subscriptions`
+**Filters:** `directorist_extensions_aliases` (deprecated name mapping), `directorist_required_extensions`
+
+## Notes
+
+- Legacy prefix `atbdp_` (AT Business Directory Plus) coexists with `directorist_` — new code should use `directorist_`
+- Build files (`assets/css/`, `assets/js/`) are committed to the repo
+- Multi-directory support: each listing type (`atbdp_listing_types` taxonomy) has its own builder config stored as term meta
+- Builder data is base64-encoded JSON containing fields, layouts, options, config

--- a/assets/js/admin-main.js
+++ b/assets/js/admin-main.js
@@ -422,7 +422,7 @@ window.addEventListener('load', function () {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/typeof */ "./node_modules/@babel/runtime/helpers/esm/typeof.js");
+/* harmony import */ var _babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/typeof */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/typeof.js");
 /* harmony import */ var _global_components_debounce__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../../global/components/debounce */ "./assets/src/js/global/components/debounce.js");
 
 
@@ -823,6 +823,11 @@ document.addEventListener('DOMContentLoaded', function () {
     });
     return Object.keys(idsMap);
   }
+  function hasServerRenderedEditorMarkup(editorId, $container) {
+    var $scope = $container && $container.length ? $container : $(document.body);
+    var $wrap = $scope.find('#wp-' + editorId + '-wrap');
+    return !!($wrap.length && $wrap.find('.wp-editor-container textarea#' + editorId).length);
+  }
   function unlockListingFormUi() {
     $('#listing_form_info').find('.directorist_loader').remove();
     $('select[name="directory_type"]').parent('.inside').find('.directorist_loader').remove();
@@ -842,6 +847,39 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
     editorLifecycleLog('dispatched-events', directoryTypeReloadEventNames);
+  }
+  function getWpEditorApi() {
+    return typeof window.wp !== 'undefined' && window.wp ? window.wp.editor || window.wp.oldEditor || null : null;
+  }
+  function getEditorTinyMceSettings(editorId, mceInit) {
+    var fallbackTinyMce = mceInit && (0,_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__["default"])(mceInit) === 'object' ? {} : {
+      plugins: 'charmap,colorpicker,hr,lists,media,paste,tabfocus,textcolor,fullscreen,wordpress,wpautoresize,wpeditimage,wpgallery,wplink,wpdialogs,wptextpattern,wpview',
+      toolbar1: 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,fullscreen,wp_adv',
+      toolbar2: 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+      menubar: false,
+      branding: false
+    };
+    return Object.assign({}, fallbackTinyMce, mceInit || {}, {
+      selector: '#' + editorId
+    });
+  }
+  function getEditorQuicktagsSettings(editorId, qtInit) {
+    var fallbackQuicktags = qtInit && (0,_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0__["default"])(qtInit) === 'object' ? {} : {
+      buttons: 'strong,em,link,block,del,ins,img,ul,ol,li,code,more,close'
+    };
+    return Object.assign({}, fallbackQuicktags, qtInit || {}, {
+      id: editorId
+    });
+  }
+  function initializeExistingEditorMarkup(editorId, mceInit, qtInit, $container) {
+    if (!document.getElementById(editorId + '_ifr') && !$container.find('#wp-' + editorId + '-wrap .mce-tinymce').length && typeof window.tinymce !== 'undefined' && window.tinymce && typeof window.tinymce.init === 'function' && mceInit !== false) {
+      try {
+        window.tinymce.init(getEditorTinyMceSettings(editorId, mceInit));
+      } catch (e) {
+        editorLifecycleLog('reinit-tinymce-fail', editorId, e && e.message ? e.message : e);
+      }
+    }
+    ensureQuicktagsForEditor(editorId, getEditorQuicktagsSettings(editorId, qtInit), $container);
   }
 
   // ─── WP Editor — destroy ──────────────────────────────────────────────────────
@@ -874,9 +912,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // 1. wp.editor.remove() — the correct WP public API (WP >= 4.8).
       //    This handles both TinyMCE and Quicktags in one call.
-      if (typeof window.wp !== 'undefined' && wp.editor && typeof wp.editor.remove === 'function') {
+      var wpEditor = getWpEditorApi();
+      if (wpEditor && typeof wpEditor.remove === 'function') {
         try {
-          wp.editor.remove(editorId);
+          wpEditor.remove(editorId);
         } catch (e) {/* ignore */}
       }
 
@@ -969,17 +1008,19 @@ document.addEventListener('DOMContentLoaded', function () {
             } catch (e) {/* ignore */}
           }
         }
-        if (typeof window.wp === 'undefined' || !wp.editor || typeof wp.editor.initialize !== 'function') {
+        var wpEditor = getWpEditorApi();
+        if (!wpEditor || typeof wpEditor.initialize !== 'function') {
           editorLifecycleLog('reinit-skip', editorId, 'wp-editor-unavailable');
           return;
         }
         var preinit = window.tinyMCEPreInit || {};
         var mceInit = (preinit.mceInit || {})[editorId];
         var qtInit = (preinit.qtInit || {})[editorId];
+        var hasRenderedMarkup = hasServerRenderedEditorMarkup(editorId, $container);
 
         // AJAX-injected wp_editor() output should register per-editor preinit.
         // If missing, wait briefly before falling back to defaults.
-        if (!mceInit && retryAttempt < maxRetryAttempts) {
+        if (!mceInit && !hasRenderedMarkup && retryAttempt < maxRetryAttempts) {
           hasPendingEditorInit = true;
           editorLifecycleLog('reinit-wait', editorId, 'preinit-missing');
           return;
@@ -990,21 +1031,19 @@ document.addEventListener('DOMContentLoaded', function () {
           editorLifecycleLog('reinit-wait', editorId, 'qtags-buttons-pending');
           return;
         }
-
-        // Prefer per-editor preinit config. If missing, use WP defaults.
-        var mceSettings = mceInit ? Object.assign({}, mceInit, {
-          selector: '#' + editorId
-        }) : true;
-        wp.editor.initialize(editorId, {
-          tinymce: mceSettings,
-          quicktags: qtInit ? Object.assign({}, qtInit) : true,
-          mediaButtons: true
-        });
-        editorLifecycleLog('reinit-done', editorId, mceInit ? 'preinit' : 'wp-default');
-        setTimeout(function () {
-          ensureQuicktagsForEditor(editorId, qtInit, $container);
-        }, 0);
-        var wantsTinyMce = mceSettings !== false;
+        var mceSettings = getEditorTinyMceSettings(editorId, mceInit);
+        if (hasRenderedMarkup) {
+          initializeExistingEditorMarkup(editorId, mceInit, qtInit, $container);
+          editorLifecycleLog('reinit-done', editorId, mceInit ? 'existing-markup-preinit' : 'existing-markup-default');
+        } else {
+          wpEditor.initialize(editorId, {
+            tinymce: mceSettings,
+            quicktags: getEditorQuicktagsSettings(editorId, qtInit),
+            mediaButtons: true
+          });
+          editorLifecycleLog('reinit-done', editorId, mceInit ? 'wp-initialize-preinit' : 'wp-initialize-default');
+        }
+        var wantsTinyMce = mceInit !== false;
         if (wantsTinyMce) {
           var _ensureTinyMceReady = function ensureTinyMceReady(verifyAttempt) {
             var tinyMceEditor = typeof window.tinymce !== 'undefined' && window.tinymce && typeof window.tinymce.get === 'function' ? window.tinymce.get(editorId) : null;
@@ -1012,6 +1051,7 @@ document.addEventListener('DOMContentLoaded', function () {
             var hasTinyMceContainer = $container.find('#wp-' + editorId + '-wrap .mce-tinymce').length > 0;
             if (hasTinyMceEditor || hasTinyMceContainer) {
               editorLifecycleLog('reinit-verify', editorId, 'tinymce-ready', verifyAttempt);
+              switchDirectoristHtmlEditorMode(editorId, 'tmce');
               return;
             }
             if (verifyAttempt < maxRetryAttempts) {
@@ -1023,14 +1063,6 @@ document.addEventListener('DOMContentLoaded', function () {
             editorLifecycleLog('reinit-verify', editorId, 'tinymce-missing-after-init');
           };
           setTimeout(function () {
-            if (typeof window.switchEditors !== 'undefined' && window.switchEditors && typeof window.switchEditors.go === 'function') {
-              try {
-                window.switchEditors.go(editorId, 'tmce');
-                editorLifecycleLog('reinit-switch', editorId, 'tmce');
-              } catch (e) {
-                editorLifecycleLog('reinit-switch-fail', editorId, e && e.message ? e.message : e);
-              }
-            }
             _ensureTinyMceReady(0);
           }, 0);
         }
@@ -1043,6 +1075,38 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   // ─── Race-condition guard ─────────────────────────────────────────────────────
+  function syncDirectoristHtmlEditorModeUi(editorId, mode) {
+    var isVisualMode = mode === 'tmce';
+    var $wrap = $('#wp-' + editorId + '-wrap');
+    if (!$wrap.length) {
+      return;
+    }
+    $wrap.toggleClass('tmce-active', isVisualMode).toggleClass('html-active', !isVisualMode);
+    $('#' + editorId).toggle(!isVisualMode);
+    $('#qt_' + editorId + '_toolbar').toggle(!isVisualMode);
+    $wrap.find('.mce-tinymce').toggle(isVisualMode);
+    $('#' + editorId + '-tmce').attr('aria-pressed', isVisualMode ? 'true' : 'false');
+    $('#' + editorId + '-html').attr('aria-pressed', isVisualMode ? 'false' : 'true');
+  }
+  function switchDirectoristHtmlEditorMode(editorId, mode) {
+    if (typeof window.switchEditors !== 'undefined' && window.switchEditors && typeof window.switchEditors.go === 'function') {
+      try {
+        window.switchEditors.go(editorId, mode);
+        syncDirectoristHtmlEditorModeUi(editorId, mode);
+        editorLifecycleLog('switch-ready', editorId, mode);
+        return true;
+      } catch (e) {
+        editorLifecycleLog('switch-ready-fail', editorId, e && e.message ? e.message : e);
+      }
+    }
+    syncDirectoristHtmlEditorModeUi(editorId, mode);
+    return false;
+  }
+  function ensureDirectoristHtmlEditor(editorId) {
+    var $container = $('#' + editorId).closest('#directiost-listing-fields_wrapper .directorist-listing-fields, .directorist-form-group');
+    var preinit = window.tinyMCEPreInit || {};
+    initializeExistingEditorMarkup(editorId, (preinit.mceInit || {})[editorId], (preinit.qtInit || {})[editorId], $container.length ? $container : $(document.body));
+  }
   var ajaxRequestSeq = 0;
   var activeListingFormRequest = null;
 
@@ -1060,15 +1124,21 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     }
   }, 270));
-  $(document).off('click.directorist-switch-html', '.wp-switch-editor.switch-html').on('click.directorist-switch-html', '.wp-switch-editor.switch-html', function () {
+  $(document).off('click.directorist-switch-html', '.wp-switch-editor.switch-html, .wp-switch-editor.switch-tmce').on('click.directorist-switch-html', '.wp-switch-editor.switch-html, .wp-switch-editor.switch-tmce', function (event) {
     var editorId = $(this).attr('data-wp-editor-id');
     if (!editorId || editorId.indexOf('directorist_html_') !== 0) {
       return;
     }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if ($(this).hasClass('switch-tmce')) {
+      ensureDirectoristHtmlEditor(editorId);
+      switchDirectoristHtmlEditorMode(editorId, 'tmce');
+      return;
+    }
     setTimeout(function () {
-      var preinit = window.tinyMCEPreInit || {};
-      var qtInit = (preinit.qtInit || {})[editorId];
-      ensureQuicktagsForEditor(editorId, qtInit);
+      ensureDirectoristHtmlEditor(editorId);
+      switchDirectoristHtmlEditorMode(editorId, 'html');
     }, 0);
   });
 
@@ -2762,7 +2832,7 @@ function selec2_adjust_space_for_addons() {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/defineProperty */ "./node_modules/@babel/runtime/helpers/esm/defineProperty.js");
+/* harmony import */ var _babel_runtime_helpers_defineProperty__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/defineProperty */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/defineProperty.js");
 /* harmony import */ var _lib_helper__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./../../lib/helper */ "./assets/src/js/lib/helper.js");
 /* harmony import */ var _select2_custom_control__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./select2-custom-control */ "./assets/src/js/global/components/select2-custom-control.js");
 /* harmony import */ var _select2_custom_control__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(_select2_custom_control__WEBPACK_IMPORTED_MODULE_2__);
@@ -3026,7 +3096,7 @@ function maybeLazyLoadTaxonomyTermsSelect2(args) {
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _babel_runtime_helpers_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/toConsumableArray */ "./node_modules/@babel/runtime/helpers/esm/toConsumableArray.js");
+/* harmony import */ var _babel_runtime_helpers_toConsumableArray__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @babel/runtime/helpers/toConsumableArray */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toConsumableArray.js");
 
 document.addEventListener('load', init, false);
 function Tasks() {
@@ -3235,10 +3305,10 @@ __webpack_require__.r(__webpack_exports__);
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js":
-/*!*********************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js ***!
-  \*********************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js":
+/*!**************************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js ***!
+  \**************************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3255,10 +3325,10 @@ function _arrayLikeToArray(r, a) {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js":
-/*!**********************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js ***!
-  \**********************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js":
+/*!***************************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js ***!
+  \***************************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3266,7 +3336,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": function() { return /* binding */ _arrayWithoutHoles; }
 /* harmony export */ });
-/* harmony import */ var _arrayLikeToArray_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js");
+/* harmony import */ var _arrayLikeToArray_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js");
 
 function _arrayWithoutHoles(r) {
   if (Array.isArray(r)) return (0,_arrayLikeToArray_js__WEBPACK_IMPORTED_MODULE_0__["default"])(r);
@@ -3275,10 +3345,10 @@ function _arrayWithoutHoles(r) {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/defineProperty.js":
-/*!*******************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/defineProperty.js ***!
-  \*******************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/defineProperty.js":
+/*!************************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/defineProperty.js ***!
+  \************************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3286,7 +3356,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": function() { return /* binding */ _defineProperty; }
 /* harmony export */ });
-/* harmony import */ var _toPropertyKey_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/@babel/runtime/helpers/esm/toPropertyKey.js");
+/* harmony import */ var _toPropertyKey_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./toPropertyKey.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js");
 
 function _defineProperty(e, r, t) {
   return (r = (0,_toPropertyKey_js__WEBPACK_IMPORTED_MODULE_0__["default"])(r)) in e ? Object.defineProperty(e, r, {
@@ -3300,10 +3370,10 @@ function _defineProperty(e, r, t) {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/iterableToArray.js":
-/*!********************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/iterableToArray.js ***!
-  \********************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/iterableToArray.js":
+/*!*************************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/iterableToArray.js ***!
+  \*************************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3318,10 +3388,10 @@ function _iterableToArray(r) {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js":
-/*!**********************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js ***!
-  \**********************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js":
+/*!***************************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js ***!
+  \***************************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3336,10 +3406,10 @@ function _nonIterableSpread() {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/toConsumableArray.js":
-/*!**********************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/toConsumableArray.js ***!
-  \**********************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toConsumableArray.js":
+/*!***************************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toConsumableArray.js ***!
+  \***************************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3347,10 +3417,10 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": function() { return /* binding */ _toConsumableArray; }
 /* harmony export */ });
-/* harmony import */ var _arrayWithoutHoles_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./arrayWithoutHoles.js */ "./node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js");
-/* harmony import */ var _iterableToArray_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./iterableToArray.js */ "./node_modules/@babel/runtime/helpers/esm/iterableToArray.js");
-/* harmony import */ var _unsupportedIterableToArray_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js");
-/* harmony import */ var _nonIterableSpread_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./nonIterableSpread.js */ "./node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js");
+/* harmony import */ var _arrayWithoutHoles_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./arrayWithoutHoles.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/arrayWithoutHoles.js");
+/* harmony import */ var _iterableToArray_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./iterableToArray.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/iterableToArray.js");
+/* harmony import */ var _unsupportedIterableToArray_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./unsupportedIterableToArray.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js");
+/* harmony import */ var _nonIterableSpread_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./nonIterableSpread.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/nonIterableSpread.js");
 
 
 
@@ -3362,10 +3432,10 @@ function _toConsumableArray(r) {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/toPrimitive.js":
-/*!****************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/toPrimitive.js ***!
-  \****************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toPrimitive.js":
+/*!*********************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toPrimitive.js ***!
+  \*********************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3373,7 +3443,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": function() { return /* binding */ toPrimitive; }
 /* harmony export */ });
-/* harmony import */ var _typeof_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/esm/typeof.js");
+/* harmony import */ var _typeof_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./typeof.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/typeof.js");
 
 function toPrimitive(t, r) {
   if ("object" != (0,_typeof_js__WEBPACK_IMPORTED_MODULE_0__["default"])(t) || !t) return t;
@@ -3389,10 +3459,10 @@ function toPrimitive(t, r) {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/toPropertyKey.js":
-/*!******************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/toPropertyKey.js ***!
-  \******************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js":
+/*!***********************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toPropertyKey.js ***!
+  \***********************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3400,8 +3470,8 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": function() { return /* binding */ toPropertyKey; }
 /* harmony export */ });
-/* harmony import */ var _typeof_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./typeof.js */ "./node_modules/@babel/runtime/helpers/esm/typeof.js");
-/* harmony import */ var _toPrimitive_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/@babel/runtime/helpers/esm/toPrimitive.js");
+/* harmony import */ var _typeof_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./typeof.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/typeof.js");
+/* harmony import */ var _toPrimitive_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./toPrimitive.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/toPrimitive.js");
 
 
 function toPropertyKey(t) {
@@ -3412,10 +3482,10 @@ function toPropertyKey(t) {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/typeof.js":
-/*!***********************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/typeof.js ***!
-  \***********************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/typeof.js":
+/*!****************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/typeof.js ***!
+  \****************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3436,10 +3506,10 @@ function _typeof(o) {
 
 /***/ }),
 
-/***/ "./node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js":
-/*!*******************************************************************************!*\
-  !*** ./node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js ***!
-  \*******************************************************************************/
+/***/ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js":
+/*!************************************************************************************************************************!*\
+  !*** ./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/unsupportedIterableToArray.js ***!
+  \************************************************************************************************************************/
 /***/ (function(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
@@ -3447,7 +3517,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": function() { return /* binding */ _unsupportedIterableToArray; }
 /* harmony export */ });
-/* harmony import */ var _arrayLikeToArray_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js");
+/* harmony import */ var _arrayLikeToArray_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./arrayLikeToArray.js */ "./node_modules/.pnpm/@babel+runtime@7.29.2/node_modules/@babel/runtime/helpers/esm/arrayLikeToArray.js");
 
 function _unsupportedIterableToArray(r, a) {
   if (r) {

--- a/assets/src/js/admin/components/block-3.js
+++ b/assets/src/js/admin/components/block-3.js
@@ -454,6 +454,13 @@ document.addEventListener('DOMContentLoaded', () => {
 		return Object.keys(idsMap);
 	}
 
+	function hasServerRenderedEditorMarkup(editorId, $container) {
+		const $scope = $container && $container.length ? $container : $(document.body);
+		const $wrap = $scope.find('#wp-' + editorId + '-wrap');
+
+		return !!($wrap.length && $wrap.find('.wp-editor-container textarea#' + editorId).length);
+	}
+
 	function unlockListingFormUi() {
 		$('#listing_form_info').find('.directorist_loader').remove();
 		$('select[name="directory_type"]')
@@ -485,6 +492,55 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		});
 		editorLifecycleLog('dispatched-events', directoryTypeReloadEventNames);
+	}
+
+	function getWpEditorApi() {
+		return typeof window.wp !== 'undefined' && window.wp
+			? window.wp.editor || window.wp.oldEditor || null
+			: null;
+	}
+
+	function getEditorTinyMceSettings(editorId, mceInit) {
+		const fallbackTinyMce = mceInit && typeof mceInit === 'object'
+			? {}
+			: {
+				plugins:  'charmap,colorpicker,hr,lists,media,paste,tabfocus,textcolor,fullscreen,wordpress,wpautoresize,wpeditimage,wpgallery,wplink,wpdialogs,wptextpattern,wpview',
+				toolbar1: 'formatselect,bold,italic,bullist,numlist,blockquote,alignleft,aligncenter,alignright,link,wp_more,fullscreen,wp_adv',
+				toolbar2: 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent,undo,redo,wp_help',
+				menubar:  false,
+				branding: false,
+			};
+
+		return Object.assign({}, fallbackTinyMce, mceInit || {}, { selector: '#' + editorId });
+	}
+
+	function getEditorQuicktagsSettings(editorId, qtInit) {
+		const fallbackQuicktags = qtInit && typeof qtInit === 'object'
+			? {}
+			: {
+				buttons: 'strong,em,link,block,del,ins,img,ul,ol,li,code,more,close',
+			};
+
+		return Object.assign({}, fallbackQuicktags, qtInit || {}, { id: editorId });
+	}
+
+	function initializeExistingEditorMarkup(editorId, mceInit, qtInit, $container) {
+		if (
+			!document.getElementById(editorId + '_ifr') &&
+			!$container.find('#wp-' + editorId + '-wrap .mce-tinymce').length &&
+			typeof window.tinymce !== 'undefined' &&
+			window.tinymce &&
+			typeof window.tinymce.init === 'function' &&
+			mceInit !== false
+		) {
+			try {
+				window.tinymce.init(getEditorTinyMceSettings(editorId, mceInit));
+			} catch (e) {
+				editorLifecycleLog('reinit-tinymce-fail', editorId, e && e.message ? e.message : e);
+			}
+		}
+
+		ensureQuicktagsForEditor(editorId, getEditorQuicktagsSettings(editorId, qtInit), $container);
 	}
 
 	// ─── WP Editor — destroy ──────────────────────────────────────────────────────
@@ -527,12 +583,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			// 1. wp.editor.remove() — the correct WP public API (WP >= 4.8).
 			//    This handles both TinyMCE and Quicktags in one call.
-			if (
-				typeof window.wp !== 'undefined' &&
-				wp.editor &&
-				typeof wp.editor.remove === 'function'
-			) {
-				try { wp.editor.remove(editorId); } catch (e) { /* ignore */ }
+			const wpEditor = getWpEditorApi();
+			if (wpEditor && typeof wpEditor.remove === 'function') {
+				try { wpEditor.remove(editorId); } catch (e) { /* ignore */ }
 			}
 
 			// 2. Belt-and-suspenders: direct TinyMCE teardown in case wp.editor.remove
@@ -627,11 +680,8 @@ document.addEventListener('DOMContentLoaded', () => {
 					}
 				}
 
-				if (
-					typeof window.wp === 'undefined' ||
-					!wp.editor ||
-					typeof wp.editor.initialize !== 'function'
-				) {
+				const wpEditor = getWpEditorApi();
+				if (!wpEditor || typeof wpEditor.initialize !== 'function') {
 					editorLifecycleLog('reinit-skip', editorId, 'wp-editor-unavailable');
 					return;
 				}
@@ -639,10 +689,11 @@ document.addEventListener('DOMContentLoaded', () => {
 				const preinit = window.tinyMCEPreInit || {};
 				const mceInit = (preinit.mceInit || {})[editorId];
 				const qtInit  = (preinit.qtInit  || {})[editorId];
+				const hasRenderedMarkup = hasServerRenderedEditorMarkup(editorId, $container);
 
 				// AJAX-injected wp_editor() output should register per-editor preinit.
 				// If missing, wait briefly before falling back to defaults.
-				if (!mceInit && retryAttempt < maxRetryAttempts) {
+				if (!mceInit && !hasRenderedMarkup && retryAttempt < maxRetryAttempts) {
 					hasPendingEditorInit = true;
 					editorLifecycleLog('reinit-wait', editorId, 'preinit-missing');
 					return;
@@ -661,22 +712,21 @@ document.addEventListener('DOMContentLoaded', () => {
 					return;
 				}
 
-				// Prefer per-editor preinit config. If missing, use WP defaults.
-				const mceSettings = mceInit
-					? Object.assign({}, mceInit, { selector: '#' + editorId })
-					: true;
+				const mceSettings = getEditorTinyMceSettings(editorId, mceInit);
 
-				wp.editor.initialize(editorId, {
-					tinymce:      mceSettings,
-					quicktags:    qtInit ? Object.assign({}, qtInit) : true,
-					mediaButtons: true,
-				});
-				editorLifecycleLog('reinit-done', editorId, mceInit ? 'preinit' : 'wp-default');
-				setTimeout(function () {
-					ensureQuicktagsForEditor(editorId, qtInit, $container);
-				}, 0);
+				if (hasRenderedMarkup) {
+					initializeExistingEditorMarkup(editorId, mceInit, qtInit, $container);
+					editorLifecycleLog('reinit-done', editorId, mceInit ? 'existing-markup-preinit' : 'existing-markup-default');
+				} else {
+					wpEditor.initialize(editorId, {
+						tinymce:      mceSettings,
+						quicktags:    getEditorQuicktagsSettings(editorId, qtInit),
+						mediaButtons: true,
+					});
+					editorLifecycleLog('reinit-done', editorId, mceInit ? 'wp-initialize-preinit' : 'wp-initialize-default');
+				}
 
-				const wantsTinyMce = mceSettings !== false;
+				const wantsTinyMce = mceInit !== false;
 				if (wantsTinyMce) {
 					const ensureTinyMceReady = function (verifyAttempt) {
 						const tinyMceEditor = (
@@ -689,6 +739,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 						if (hasTinyMceEditor || hasTinyMceContainer) {
 							editorLifecycleLog('reinit-verify', editorId, 'tinymce-ready', verifyAttempt);
+							switchDirectoristHtmlEditorMode(editorId, 'tmce');
 							return;
 						}
 
@@ -703,19 +754,6 @@ document.addEventListener('DOMContentLoaded', () => {
 					};
 
 					setTimeout(function () {
-						if (
-							typeof window.switchEditors !== 'undefined' &&
-							window.switchEditors &&
-							typeof window.switchEditors.go === 'function'
-						) {
-							try {
-								window.switchEditors.go(editorId, 'tmce');
-								editorLifecycleLog('reinit-switch', editorId, 'tmce');
-							} catch (e) {
-								editorLifecycleLog('reinit-switch-fail', editorId, e && e.message ? e.message : e);
-							}
-						}
-
 						ensureTinyMceReady(0);
 					}, 0);
 				}
@@ -729,6 +767,58 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	// ─── Race-condition guard ─────────────────────────────────────────────────────
+	function syncDirectoristHtmlEditorModeUi(editorId, mode) {
+		const isVisualMode = mode === 'tmce';
+		const $wrap = $('#wp-' + editorId + '-wrap');
+
+		if (!$wrap.length) {
+			return;
+		}
+
+		$wrap
+			.toggleClass('tmce-active', isVisualMode)
+			.toggleClass('html-active', !isVisualMode);
+
+		$('#' + editorId).toggle(!isVisualMode);
+		$('#qt_' + editorId + '_toolbar').toggle(!isVisualMode);
+		$wrap.find('.mce-tinymce').toggle(isVisualMode);
+
+		$('#' + editorId + '-tmce').attr('aria-pressed', isVisualMode ? 'true' : 'false');
+		$('#' + editorId + '-html').attr('aria-pressed', isVisualMode ? 'false' : 'true');
+	}
+
+	function switchDirectoristHtmlEditorMode(editorId, mode) {
+		if (
+			typeof window.switchEditors !== 'undefined' &&
+			window.switchEditors &&
+			typeof window.switchEditors.go === 'function'
+		) {
+			try {
+				window.switchEditors.go(editorId, mode);
+				syncDirectoristHtmlEditorModeUi(editorId, mode);
+				editorLifecycleLog('switch-ready', editorId, mode);
+				return true;
+			} catch (e) {
+				editorLifecycleLog('switch-ready-fail', editorId, e && e.message ? e.message : e);
+			}
+		}
+
+		syncDirectoristHtmlEditorModeUi(editorId, mode);
+		return false;
+	}
+
+	function ensureDirectoristHtmlEditor(editorId) {
+		const $container = $('#' + editorId).closest('#directiost-listing-fields_wrapper .directorist-listing-fields, .directorist-form-group');
+		const preinit = window.tinyMCEPreInit || {};
+
+		initializeExistingEditorMarkup(
+			editorId,
+			(preinit.mceInit || {})[editorId],
+			(preinit.qtInit || {})[editorId],
+			$container.length ? $container : $(document.body)
+		);
+	}
+
 	let ajaxRequestSeq = 0;
 	let activeListingFormRequest = null;
 
@@ -767,15 +857,23 @@ document.addEventListener('DOMContentLoaded', () => {
 	);
 
 	$(document)
-		.off('click.directorist-switch-html', '.wp-switch-editor.switch-html')
-		.on('click.directorist-switch-html', '.wp-switch-editor.switch-html', function () {
+		.off('click.directorist-switch-html', '.wp-switch-editor.switch-html, .wp-switch-editor.switch-tmce')
+		.on('click.directorist-switch-html', '.wp-switch-editor.switch-html, .wp-switch-editor.switch-tmce', function (event) {
 			const editorId = $(this).attr('data-wp-editor-id');
 			if (!editorId || editorId.indexOf('directorist_html_') !== 0) { return; }
 
+			event.preventDefault();
+			event.stopImmediatePropagation();
+
+			if ($(this).hasClass('switch-tmce')) {
+				ensureDirectoristHtmlEditor(editorId);
+				switchDirectoristHtmlEditorMode(editorId, 'tmce');
+				return;
+			}
+
 			setTimeout(function () {
-				const preinit = window.tinyMCEPreInit || {};
-				const qtInit = (preinit.qtInit || {})[editorId];
-				ensureQuicktagsForEditor(editorId, qtInit);
+				ensureDirectoristHtmlEditor(editorId);
+				switchDirectoristHtmlEditorMode(editorId, 'html');
 			}, 0);
 		});
 

--- a/includes/asset-loader/init.php
+++ b/includes/asset-loader/init.php
@@ -295,6 +295,8 @@ class Asset_Loader {
             wp_enqueue_style( 'directorist-admin-style' );
             wp_enqueue_script( 'directorist-admin-script' );
         } elseif ( Helper::is_admin_page( 'add_listing' ) ) {
+            global $pagenow;
+
             wp_enqueue_style( 'directorist-admin-style' );
             wp_enqueue_style( 'directorist-unicons' );
             wp_enqueue_script( 'directorist-admin-script' );
@@ -302,6 +304,10 @@ class Asset_Loader {
             wp_enqueue_script( 'directorist-select2-script' );
             wp_enqueue_script( 'directorist-add-listing' );
             wp_enqueue_media();
+
+            if ( in_array( $pagenow, [ 'post.php', 'post-new.php' ], true ) && function_exists( 'wp_enqueue_editor' ) ) {
+                wp_enqueue_editor();
+            }
 
             wp_enqueue_script( 'iris', admin_url( 'js/iris.min.js' ), [ 'jquery-ui-draggable', 'jquery-ui-slider', 'jquery-touch-punch' ], Helper::get_script_version() );
             wp_enqueue_script( 'wp-color-picker', admin_url( 'js/color-picker.min.js' ), [ 'iris', 'wp-i18n' ], Helper::get_script_version() );

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "wp-pot": "^1.10.2"
   },
   "engines": {
-    "node": "24.14.1",
+    "node": "24.15.0",
     "npm": "11.6.2"
   },
   "browserslist": [


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Text changes
- [x] Other... Please describe: Added Codex/Claude agent context for repository workflow support.

## Description
How to reproduce the issue or how to test the changes

1. In wp-admin, open `post-new.php?post_type=at_biz_dir` or edit an existing `at_biz_dir` listing.
2. Select a directory type that does not initially include an HTML custom field, then switch to a directory type that includes an HTML custom field.
3. Confirm the HTML editor renders correctly: Add Media works, Visual mode shows the TinyMCE toolbar, Code mode shows QuickTags buttons, and no `mce_SELRES_*` text appears in the textarea.
4. Switch repeatedly between directory types with and without HTML custom fields to confirm the editor remains stable after AJAX reloads.
5. Confirm the included Node update and Codex/Claude agent context files are present for the updated development workflow.

## Any linked issues
Fixes #

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)