### PR TITLE
Fix dLawyers gender field validation

### DIFF
--- a/includes/fields/class-directorist-fields.php
+++ b/includes/fields/class-directorist-fields.php
@@ -110,7 +110,7 @@ class Fields {
             'dhotels-number'              => 'number',
             'dhotels-area'                => 'number',
             'dlawyers_age'                => 'number',
-            'dlawyers_gender'             => 'number',
+            'dlawyers_gender'             => 'radio',
             'drealestate-number'          => 'number',
             'drealestate-area'            => 'number',
             'dclassified-bullet-list'      => 'textarea',


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

This fixes the dLawyers gender field validation error on the add listing form.

The dLawyers theme registers `dlawyers_gender` as a radio field and the submitted value is a string such as `Male` or `Female`. Directorist's theme custom field map incorrectly translated `dlawyers_gender` to the `number` field type, so the number validator rejected the submitted radio value and returned `Gender: Invalid number.`

This change maps `dlawyers_gender` to the `radio` field type so it is validated with the radio field validator instead of the number validator.

### Steps to reproduce
1. Use the dLawyers add listing form.
2. Select a gender option in the `Personal Information` section.
3. Continue to the finish step and submit/save the listing.
4. Notice the form returns `Gender: Invalid number.` even though a radio option is selected.

### Expected result
The dLawyers gender radio field should accept the selected radio option and should not be validated as a number.

### How to test the fix
1. Open the dLawyers add listing form.
2. Select a gender option.
3. Submit/save the listing.
4. Confirm the `Gender: Invalid number.` validation error no longer appears.
5. Confirm regular numeric fields such as dLawyers age still use number validation.

## Any linked issues
Support ticket:
- https://taiga-sovware-u10698.vm.elestio.app/project/directorist/issue/2942

Related screenshot:
- Issue: https://prnt.sc/KzaALCVCS9gT

## Screenshot
- https://prnt.sc/KzaALCVCS9gT

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)