### PR TITLE
docs: add Directorist settings panel agent guide

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -44,6 +44,7 @@
 /webpack.prod.js
 
 # Documentation & notes
+/docs
 /README.md
 /node-update-notes.md
 /CLAUDE.md

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.cache               export-ignore
 /.github              export-ignore
 /.wordpress-org       export-ignore
+/docs                 export-ignore
 
 /assets/src           export-ignore
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,7 @@ Widgets: all-listing, all-categories, all-locations, category, location, tag, se
 **Save:** `wp_ajax_save_settings_data`
 **Options prefix:** `atbdp_` (legacy) and `directorist_` (new)
 **Features:** Import/export settings, restore defaults, per-directory-type settings, conditional field visibility (show-if)
+**Settings panel agent:** Before redesigning, auditing, or adding settings-panel features, load `docs/agents/directorist-settings-panel/SKILL.md` and follow its report-first workflow.
 
 ## Build Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,7 @@ Widgets: all-listing, all-categories, all-locations, category, location, tag, se
 **Save:** `wp_ajax_save_settings_data`
 **Options prefix:** `atbdp_` (legacy) and `directorist_` (new)
 **Features:** Import/export settings, restore defaults, per-directory-type settings, conditional field visibility (show-if)
+**Settings panel agent:** Before redesigning, auditing, or adding settings-panel features, load `docs/agents/directorist-settings-panel/SKILL.md` and follow its report-first workflow.
 
 ## Build Pipeline
 

--- a/docs/agents/directorist-settings-panel/README.md
+++ b/docs/agents/directorist-settings-panel/README.md
@@ -1,0 +1,73 @@
+# Directorist Settings Panel Agent Skill
+
+This folder contains a tracked repo-local skill/playbook for agents working on the Directorist settings panel. It is intentionally stored in `docs/agents/directorist-settings-panel/` because `.agents/` is ignored in this repo.
+
+## What This Skill Is For
+
+Use it when you want an agent to:
+
+- redesign the Directorist settings panel from a Figma design, screenshot, or idea
+- add a new settings-panel feature
+- add or adjust settings fields
+- audit settings-panel limitations before implementation
+- produce a report showing what is easy, what is complex, and what needs your decision
+
+## How To Use
+
+When starting a settings-panel task, tell the agent:
+
+```text
+Use docs/agents/directorist-settings-panel/SKILL.md for this task.
+```
+
+Then provide one of these:
+
+- a Figma node/link or screenshot
+- a written feature idea
+- the current problem you want solved
+- the settings page URL you want tested
+
+The agent should first inspect the current source, then produce a feasibility report before making code changes.
+
+## Expected First Output
+
+The first useful output should be a report with:
+
+- design or feature summary
+- what can be achieved easily
+- what is complex or risky
+- affected settings/data/UI areas
+- questions before risky work
+- verification plan
+
+If the change is visual-only and low risk, the report should say so. If the change affects storage, settings keys, AJAX save behavior, permissions, nonce handling, field contracts, layout structure, or extension-facing hooks, the agent must ask before implementation.
+
+## Build Policy
+
+The agent must not run these commands without your approval:
+
+- `npm run dev`
+- `npm run dev-vue`
+- `npm run prod`
+- any formatter or build command that rewrites tracked files
+
+Your preferred workflow is to run `npm run dev-vue` manually when needed. The agent can then use the local admin page for browser QA if the compiled output is available.
+
+## Local Settings URL
+
+Default local page for QA:
+
+```text
+http://directorist-core.local/wp-admin/edit.php?post_type=at_biz_dir&page=atbdp-settings
+```
+
+## Files In This Package
+
+- `SKILL.md`: the actual agent instructions
+- `references/current-settings-panel-map.md`: architecture map and known limitations
+- `references/settings-option-catalog.md`: grouped settings option map with purpose notes
+- `templates/feasibility-report.md`: reusable report template
+
+## Maintenance
+
+When a future settings-panel task reveals a confirmed architecture fact, limitation, or setting-key change, update the reference notes in this folder. Keep the skill concise and keep detailed discoveries in `references/`.

--- a/docs/agents/directorist-settings-panel/SKILL.md
+++ b/docs/agents/directorist-settings-panel/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: directorist-settings-panel-agent
+description: Use this skill whenever the user wants to redesign, extend, audit, or implement features in the Directorist WordPress plugin settings panel. Trigger for Directorist settings panel work, Figma-to-settings-panel tasks, wp-admin settings UI redesigns, adding settings fields, changing settings save behavior, or assessing whether a proposed settings feature is safe. This skill is intentionally strict: it must inspect the current settings architecture, produce a feasibility report first, and ask before risky structural changes.
+---
+
+# Directorist Settings Panel Agent
+
+This skill guides safe redesign and feature work for the Directorist settings panel. Directorist is production software used by many sites, so preserve existing behavior unless the user explicitly approves a structural change after seeing the risk.
+
+## Core Rule
+
+Always produce a report before implementation. Do not start code changes until the report identifies easy work, risky work, affected systems, and open questions for the user.
+
+## Required Context Pass
+
+Before planning or editing, inspect the current implementation in the local repo:
+
+- `includes/classes/class-settings-panel.php`
+- `views/admin-templates/settings-manager/settings.php`
+- `assets/src/js/admin/settings-manager.js`
+- `assets/src/js/admin/vue/apps/settings-manager/Settings_Manager.vue`
+- `assets/src/js/admin/vue/apps/settings-manager/TabContents.vue`
+- `assets/src/js/admin/vue/store/CPT_Manager_Store.js`
+- `assets/src/scss/layout/admin/settings-manager.scss`
+- `assets/src/scss/layout/admin/builder/_builder_style__settings_panel.scss`
+- `webpack-entry-list.js`
+
+Also search for any setting key or UI class named by the user before assuming where it lives.
+
+For bundled core modules that inject settings through filters, inspect the source that owns the injected section before planning:
+
+- Review settings: `includes/review/class-settings-screen.php`
+- Schema Markup settings: `includes/classes/class-schema.php`
+
+For any setting-key, section, or behavior change, also read:
+
+- `docs/agents/directorist-settings-panel/references/settings-option-catalog.md`
+
+If the task mentions extensions, extension settings, or a design inside the Extensions menu, first identify whether the target UI is core extension discovery or an installed extension's own settings. Extension-specific settings depend on the installed/active extension set.
+
+## Architecture Summary
+
+- PHP class `ATBDP_Settings_Panel` prepares settings fields, layouts, and config.
+- The admin template outputs base64-encoded JSON in `data-builder-data` on `#atbdp-settings-manager`.
+- `assets/src/js/admin/settings-manager.js` decodes that JSON and mounts the Vue 2 app.
+- `Settings_Manager.vue` renders the top bar, breadcrumbs, search, save buttons, sidebar, and tab contents.
+- `TabContents.vue` renders the active menu/submenu sections through globally registered Vue modules.
+- `CPT_Manager_Store.js` stores `fields`, `layouts`, `config`, cached field values, active navigation, and highlighted search results.
+- Settings save through the AJAX action `save_settings_data`.
+- Saved values are written into the shared WordPress option `atbdp_option`.
+- `directorist_options_updated` fires after option updates and can affect rewrite rules, cache, pages, emails, maps, listings, payments, and extensions.
+
+## Safety Rules
+
+- Do not run `npm run dev`, `npm run dev-vue`, `npm run prod`, formatters, code generators, or build commands that write tracked files unless the user explicitly approves.
+- If the user says they are manually running `npm run dev-vue`, use the generated output and browser QA, but do not start the command yourself.
+- Do not replace the settings system with a new framework or persistence layer.
+- Preserve the field/layout/config data contract unless the user approves a structural change.
+- Do not change settings keys, option storage, nonce handling, capability checks, AJAX action names, or `atbdp_option` behavior without explicit QA with the user.
+- Do not remove legacy `atbdp_` behavior just because new code prefers `directorist_`.
+- Keep generated build assets out of scope unless the user approves the required build command or specifically asks to edit committed build output.
+- Treat Figma as design intent, not a reason to rewrite data flow.
+
+## Work Classification
+
+Classify every requested change before implementation.
+
+Low risk:
+
+- Visual-only SCSS changes scoped to the settings panel.
+- Reordering or spacing within existing Vue structure without changing data flow.
+- Copy, typography, alignment, responsive layout, and focus-state improvements.
+- Search/breadcrumb/sidebar presentation changes that preserve existing store mutations.
+
+Medium risk:
+
+- Adding a new Vue-only interaction or UI state.
+- Adding a new reusable form-field component that uses existing save conventions.
+- Changing sidebar/search behavior while preserving hashes and layout paths.
+- Adding a setting field that stores a new key in `atbdp_option`.
+
+High risk:
+
+- Changing save payload shape, sanitization, nonce, or permissions.
+- Moving settings out of `atbdp_option`.
+- Changing layout JSON structure, field type contracts, or `show-if` behavior.
+- Changing page/permalink/map/payment/email settings because many frontend systems read them.
+- Changes that require migrations, upgrade routines, or extension compatibility decisions.
+
+Ask the user before medium-risk work if the report shows meaningful tradeoffs. Always ask before high-risk work.
+
+## Figma Or Design Workflow
+
+When the user provides a Figma design, screenshot, or visual reference:
+
+1. Inspect the existing settings implementation first.
+2. Extract layout, spacing, typography, color, navigation, and interaction intent.
+3. Map each design area to existing shell, sidebar, sections, and field components.
+4. Identify what can be achieved with SCSS/Vue template changes only.
+5. Identify any design detail that would require new data shape, new field type, or changed save behavior.
+6. Produce the required report and ask only the questions needed to resolve risky items.
+
+Prefer matching the design through the existing Vue/settings architecture. Do not rebuild the panel from scratch unless the user explicitly approves a rewrite.
+
+## Feature Workflow
+
+When the user asks for a new setting or behavior:
+
+1. Find existing related setting keys with `rg`.
+2. Check `references/settings-option-catalog.md` to understand the existing settings area and nearby option keys.
+3. Identify the connected frontend/admin systems that read those options.
+4. Decide whether the feature is UI-only, new setting storage, or behavior-changing.
+5. Confirm defaults, backward compatibility, and migration needs before editing.
+6. Use existing field types and `show-if` conventions when possible.
+7. If adding, removing, renaming, moving, or repurposing a key, update the settings option catalog after the implementation is confirmed.
+8. If adding a new key, document default value, sanitize behavior, and all readers.
+
+## Extension Settings Workflow
+
+The `Extensions` menu is core, but many extension-specific settings are not present unless the related Directorist extension is installed and active.
+
+When a design or feature targets extension UI/settings:
+
+1. Identify the exact extension name/slug from the user's design, URL, screenshot, or installed plugins list.
+2. Inspect active plugins and extension filter usage before treating any setting as available.
+3. If the required extension is missing or inactive, ask the user before installing or activating it.
+4. After the extension is active, inspect its filters, setting fields, layouts, templates, scripts, and styles.
+5. Produce the feasibility report using both core settings-panel context and extension-specific source context.
+6. Do not document extension-provided settings as core. Add them to the catalog only under an extension-specific heading after source/filter evidence confirms them.
+7. If the design could affect multiple extensions, ask for the target extension before implementation.
+
+## Required Report Template
+
+Use this exact structure before implementation:
+
+```markdown
+# Settings Panel Feasibility Report
+
+## Summary
+- Request:
+- Recommended approach:
+- Risk level:
+
+## Easy To Achieve
+- ...
+
+## Complex Or Risky
+- ...
+
+## Affected Areas
+- PHP settings builder:
+- Vue app/store:
+- SCSS/build output:
+- Saved options/data:
+- Connected frontend/admin behavior:
+
+## Questions Before Risky Work
+- ...
+
+## Verification Plan
+- Static checks:
+- Browser/manual QA:
+- Build policy:
+```
+
+If there are no risky questions, say that clearly and proceed only if the active collaboration mode allows implementation.
+
+## Verification Expectations
+
+Use the smallest verification set that matches the change:
+
+- Static inspection with `rg`, `git diff`, and focused file reads.
+- PHP syntax checks for touched PHP files.
+- Browser QA on the local settings URL when available:
+  `http://directorist-core.local/wp-admin/edit.php?post_type=at_biz_dir&page=atbdp-settings`
+- Confirm save still posts to `save_settings_data` and unchanged fields are not rewritten unnecessarily.
+- Confirm responsive behavior at desktop and mobile widths for visual redesign work.
+- Confirm no build commands were run unless the user approved them.
+
+## Self-Learning Protocol
+
+Self-learning is tracked-reference learning, not automatic memory. The agent learns only when it updates files in this package with confirmed repo facts.
+
+Update the tracked references when:
+
+- a settings-panel task confirms a new architecture fact, limitation, dependency, or regression pattern
+- a setting key is added, removed, renamed, moved between sections, or given new behavior
+- a core module injects settings through filters and the catalog does not yet identify that source
+- an installed extension adds settings through filters and the user approves documenting that extension-specific behavior
+- a Figma/design implementation reveals a reusable UI constraint or compatibility issue
+- a verification step discovers a required QA path that future agents should repeat
+
+Only record confirmed learning:
+
+- facts observed in source code, diffs, browser QA, tests, or user-approved decisions
+- exact file paths, option keys, hooks, filters, routes, and build constraints
+- current behavior with the review date when the behavior may change later
+
+Do not record:
+
+- guesses, opinions, or unverified assumptions as architecture facts
+- temporary implementation details that were reverted or not accepted
+- user-private context that is not needed for future repo work
+- broad lessons that are not specific to the Directorist settings panel
+
+Keep learning useful:
+
+- put architecture and constraints in `references/current-settings-panel-map.md`
+- put setting areas, keys, and purposes in `references/settings-option-catalog.md`
+- keep `SKILL.md` short and workflow-focused
+- update references after the code/design decision is confirmed, not before

--- a/docs/agents/directorist-settings-panel/references/current-settings-panel-map.md
+++ b/docs/agents/directorist-settings-panel/references/current-settings-panel-map.md
@@ -1,0 +1,81 @@
+# Current Settings Panel Map
+
+Last reviewed: 2026-06-04
+
+## Main Entry Points
+
+- PHP builder: `includes/classes/class-settings-panel.php`
+- Admin template: `views/admin-templates/settings-manager/settings.php`
+- Vue mount: `assets/src/js/admin/settings-manager.js`
+- Main Vue shell: `assets/src/js/admin/vue/apps/settings-manager/Settings_Manager.vue`
+- Tab renderer: `assets/src/js/admin/vue/apps/settings-manager/TabContents.vue`
+- Vuex store: `assets/src/js/admin/vue/store/CPT_Manager_Store.js`
+- SCSS entry: `assets/src/scss/layout/admin/settings-manager.scss`
+- Settings-specific SCSS partial: `assets/src/scss/layout/admin/builder/_builder_style__settings_panel.scss`
+- Vue build entry: `webpack-entry-list.js` key `admin-settings-manager`
+
+## Data Flow
+
+1. `ATBDP_Settings_Panel::prepare_settings()` builds `$this->fields`, `$this->layouts`, and `$this->config`.
+2. `ATBDP_Settings_Panel::menu_page_callback__settings_manager()` sanitizes field data, base64-encodes JSON, and passes it as `settings_builder_data`.
+3. `views/admin-templates/settings-manager/settings.php` renders `#atbdp-settings-manager` with `data-builder-data`.
+4. `assets/src/js/admin/settings-manager.js` decodes the base64 JSON, parses it, and mounts Vue 2.
+5. `Settings_Manager.vue` commits `fields`, `layouts`, and `config` into `CPT_Manager_Store.js`.
+6. The store prepares active navigation and search layout paths.
+7. Field modules update values in the Vuex `fields` object.
+8. Save collects changed fields and posts a `FormData` payload to the configured AJAX endpoint.
+9. PHP verifies nonce and capability, sanitizes submitted values, writes changed keys into `atbdp_option`, and fires `directorist_options_updated`.
+
+## Save Contract
+
+- AJAX action: `save_settings_data`
+- Capability check: `current_user_can( 'manage_options' )`
+- Nonce check: `directorist_verify_nonce()`
+- Payload includes `field_list`, then one entry per changed field.
+- Complex values are JSON/base64 encoded by the Vue helper before submit.
+- PHP decodes with `Directorist\Helper::maybe_json()`.
+- Only keys registered in `$this->fields` are saved.
+- Values persist inside the shared WordPress option `atbdp_option`.
+
+## UI Contract
+
+- The settings shell owns the top bar, breadcrumbs, search, save buttons, sidebar, tab contents, and footer save area.
+- Sidebar navigation depends on `layouts` and active menu/submenu state.
+- Deep links use URL hashes in the pattern `menu__submenu__section__field`.
+- Search suggestions are built from cached field labels and jump to layout paths prepared by the store.
+- Field rendering is handled by globally registered Vue modules under `assets/src/js/admin/vue/modules`.
+- Existing field types and theme variants should be reused before adding new components.
+
+## Connected Systems
+
+Settings values are read throughout Directorist. Treat these areas as connected when changing settings:
+
+- listing submission and listing display
+- page setup and permalink routing
+- maps and geolocation
+- search and archive behavior
+- review behavior
+- email templates and notifications
+- payments, checkout, gateways, and orders
+- multi-directory behavior
+- cache/rewrite updates via `directorist_options_updated`
+- extensions that filter or read settings data
+
+## Known Limitations And Cautions
+
+- The settings panel is a Vue 2 app, not a React or WordPress components UI.
+- The same Vuex store is also used by builder-related flows, so changes must be scoped carefully.
+- Settings are stored in one shared option, so key changes can break existing installations.
+- Some settings control frontend routing and page IDs; changing them can require rewrite/cache verification.
+- Some fields use legacy naming and behavior. Preserve backward compatibility unless a migration is approved.
+- Build output is committed in this repo, but build commands should not be run by the agent without explicit approval.
+- `.agents/` is ignored in this repo; repo-local agent docs should live under `docs/agents/`.
+
+## Recommended Change Strategy
+
+- Prefer SCSS-only changes for pure visual polish.
+- Prefer template-level Vue changes when layout needs to move but state/data does not.
+- Reuse existing field types and layout definitions for new settings.
+- Ask before adding a field type, changing payload structure, or changing `show-if` logic.
+- Ask before changing defaults for existing option keys.
+- For setting-key work, check and update `references/settings-option-catalog.md`.

--- a/docs/agents/directorist-settings-panel/references/settings-option-catalog.md
+++ b/docs/agents/directorist-settings-panel/references/settings-option-catalog.md
@@ -1,0 +1,375 @@
+# Settings Option Catalog
+
+Last reviewed: 2026-06-04
+
+Source of truth reviewed:
+
+- Direct core settings: `includes/classes/class-settings-panel.php`, especially `ATBDP_Settings_Panel::prepare_settings()` and the `$this->layouts` map.
+- Core filter-injected review settings: `includes/review/class-settings-screen.php`.
+- Core filter-injected schema settings: `includes/classes/class-schema.php`.
+
+This catalog is for agents planning settings-panel redesigns or feature work. It groups settings by the admin settings navigation and explains what each area controls. It is not a replacement for source inspection; filters can add, remove, or move fields at runtime.
+
+## How To Use This Catalog
+
+- Before changing a setting key, find its current area here and then verify it in source with `rg`.
+- Before adding a new key, choose the closest existing area and check related frontend/admin readers.
+- After a confirmed key change, update this catalog in the same task.
+- Treat page, permalink, map, payment, email, and save-contract options as higher risk because they affect runtime behavior outside the settings UI.
+- Distinguish direct core settings, core filter-injected settings, and extension-provided settings before planning a redesign.
+- For extension-specific settings, inspect the installed/active extension source before documenting or redesigning those settings.
+
+## Listings
+
+Purpose: global listing behavior, listing archive display, single listing behavior, taxonomy display, maps, and badges.
+
+Source: most Listings settings are direct core settings from `class-settings-panel.php`. The Review submenu is a core filter-injected section from `includes/review/class-settings-screen.php`.
+
+### General
+
+- `enable_multi_directory`: enables multi-directory mode and exposes directory type workflows.
+- `guest_listings`: allows listing submission by non-logged-in visitors.
+- `guest_email_label`, `guest_email_placeholder`: customize guest email field copy on listing submission.
+- `new_user_registration`: controls whether registration is enabled from Directorist flows.
+- `enable_email_verification`: requires users to verify email during registration.
+- `count_loggedin_user`: controls whether logged-in visits count toward listing views.
+- `dynamic_view_count_cache`: controls dynamic/cache behavior for view counts.
+- `g_currency_note`, `g_currency`, `g_currency_position`: listing price currency display used outside checkout/payment order formatting.
+- `email_to_expire_day`, `email_renewal_day`: timing for expiration/renewal notifications.
+- `delete_expired_listing_permanently`, `delete_expired_listings_after`: expired listing cleanup behavior.
+- `enable_archive_template`: enables Directorist taxonomy archive template behavior.
+- `category_base`, `location_base`, `tag_base`: taxonomy URL slugs when archive templates are enabled.
+
+### All Listings
+
+- `all_listing_layout`: archive/search listing layout mode.
+- `all_listing_columns`: grid column count for all listings.
+- `all_listing_page_items`: listing count per page.
+- `pagination_type`: pagination behavior.
+- `listing_hide_top_search_bar`: hides the top search bar on all listings.
+- `listings_sidebar_filter_text`: sidebar filter label.
+- `listings_reset_text`, `listings_sidebar_reset_text`, `listings_apply_text`: filter action copy.
+- `display_listings_header`: toggles archive header area.
+- `listing_filters_button`, `listings_filter_button_text`: filter button visibility and copy.
+- `display_listings_count`: shows total listing count.
+- `all_listing_title`: archive title copy.
+- `listings_view_as_items`, `default_listing_view`: available listing view modes and default mode.
+- `display_sort_by`, `sort_by_text`, `listings_sort_by_items`: sorting UI visibility, label, and choices.
+- `preview_image_quality`: image size/quality used for listing cards.
+- `way_to_show_preview`: preview image fit/crop behavior.
+- `crop_width`, `crop_height`: preview image dimensions.
+- `prv_container_size_by`: unit mode for preview image container sizing.
+- `prv_background_type`, `prv_background_color`: preview image empty/background display.
+
+### Single Listing
+
+- `single_listing_template`: selected single listing template.
+- `disable_single_listing`: disables single listing page access/display.
+- `restrict_single_listing_for_logged_in_user`: restricts single listing access to logged-in users.
+- `atbdp_listing_slug`: base slug for single listing URLs.
+- `single_listing_slug_with_directory_type`: adds directory type into single listing permalink when multi-directory is enabled.
+- `submission_confirmation`: toggles post-submit confirmation messaging.
+- `pending_confirmation_msg`, `publish_confirmation_msg`: confirmation messages for pending and published submissions.
+- `dsiplay_slider_single_page`: toggles image slider on single listing pages.
+- `single_slider_image_size`: image size for single listing slider.
+- `single_slider_background_type`, `single_slider_background_color`: slider background behavior.
+- `gallery_crop_width`, `gallery_crop_height`: gallery image crop dimensions.
+
+### Category And Location
+
+- `display_categories_as`, `categories_column_number`, `categories_depth_number`: category page layout, columns, and hierarchy depth.
+- `order_category_by`, `sort_category_by`: category ordering field and direction.
+- `display_listing_count`, `hide_empty_categories`: category listing counts and empty category visibility.
+- `display_locations_as`, `locations_column_number`, `locations_depth_number`: location page layout, columns, and hierarchy depth.
+- `order_location_by`, `sort_location_by`: location ordering field and direction.
+- `display_location_listing_count`, `hide_empty_locations`: location listing counts and empty location visibility.
+
+### Map
+
+- `select_listing_map`: map provider selection.
+- `map_api_key`: provider API key, especially for Google maps.
+- `marker_clustering`: clusters markers for Google map views.
+- `country_restriction`, `restricted_countries`: restricts autocomplete/geocoding to selected countries.
+- `default_latitude`, `default_longitude`: default map center.
+- `use_def_lat_long`: forces default coordinates in all-listings map behavior.
+- `map_zoom_level`, `map_view_zoom_level`: default zoom levels for form/map views.
+- `listings_map_height`: all-listings map height.
+- `display_map_info`: toggles map info windows.
+- `display_image_map`, `display_favorite_badge_map`, `display_user_avatar_map`: info window media/badge/avatar visibility.
+- `display_title_map`, `display_review_map`, `display_price_map`, `display_address_map`, `display_direction_map`, `display_phone_map`: info window field visibility.
+
+### Badges
+
+- `badge_display_type`: controls how badges are displayed.
+- `new_badge_text`, `new_listing_day`, `new_back_color`: new badge label, age threshold, and color.
+- `popular_badge_text`, `listing_popular_by`, `views_for_popular`, `average_review_for_popular`, `popular_back_color`: popular badge label, popularity rule, thresholds, and color.
+- `feature_badge_text`, `featured_back_color`: featured badge label and color.
+
+### Review
+
+Source: core filter-injected settings from `includes/review/class-settings-screen.php`, added through `atbdp_listing_type_settings_layout` and `atbdp_listing_type_settings_field_list`.
+
+- `enable_review`: enables listing reviews.
+- `enable_owner_review`: allows listing owners to review their own listings when reviews are enabled.
+- `guest_review`: allows non-logged-in visitors to submit reviews when reviews are enabled.
+- `review_enable_reply`: allows replies to reviews/comments when reviews are enabled.
+- `approve_immediately`: auto-approves submitted reviews instead of requiring moderation.
+- `review_num`: reviews displayed per page.
+
+Related read points include `includes/review/directorist-review-functions.php`, `includes/review/init.php`, `includes/model/SingleListing.php`, and review REST/localized data paths.
+
+Runtime-read but not active UI fields in the reviewed settings screen:
+
+- `review_approval_text`: read by localized review data, but currently commented out in the Review settings screen.
+- `enable_reviewer_content`: read by localized review data and AJAX review submission validation, but currently commented out in the Review settings screen.
+- `required_reviewer_content`: read by AJAX review submission validation, but currently commented out in the Review settings screen.
+
+Treat these as compatibility-sensitive legacy options if a redesign or feature asks to expose, rename, or remove review content controls.
+
+## Page Setup
+
+Purpose: maps Directorist workflows to WordPress pages and regenerates/upgrades required pages.
+
+- `regenerate_pages`: AJAX action field to upgrade/regenerate Directorist pages.
+- `add_listing_page`: page used for listing submission.
+- `all_listing_page`: page used for all listings archive.
+- `user_dashboard`: user dashboard page.
+- `signin_signup_page`: sign-in/sign-up page.
+- `author_profile_page`: author profile page.
+- `all_categories_page`, `single_category_page`: category index and single category pages.
+- `all_locations_page`, `single_location_page`: location index and single location pages.
+- `single_tag_page`: single tag page.
+- `search_listing`, `search_result_page`: search form and search results pages.
+- `checkout_page`, `payment_receipt_page`, `transaction_failure_page`: monetization checkout result pages.
+- `privacy_policy`, `terms_conditions`: legal pages linked from submission/registration flows.
+
+## Search
+
+Purpose: search form copy/filter behavior and search result page layout.
+
+### Search Listing
+
+- `search_title`, `search_subtitle`, `search_listing_text`: search form heading and input copy.
+- `search_more_filter`, `search_more_filters`: more-filter toggle behavior/copy.
+- `search_filters`: visible search form filters.
+- `search_reset_text`, `search_apply_filter`: filter action copy.
+- `show_popular_category`, `popular_cat_title`, `popular_cat_num`: popular category display in search.
+
+### Search Result
+
+- `search_result_layout`: search result layout mode.
+- `search_listing_columns`: grid column count for search results.
+- `search_posts_num`: listings per search result page.
+- `search_result_hide_top_search_bar`: hides search bar above search results.
+- `search_result_sidebar_filter_text`: sidebar filter label.
+- `sresult_reset_text`, `sresult_sidebar_reset_text`, `sresult_apply_text`: search result filter action copy.
+- `search_header`: toggles search result header.
+- `search_result_filters_button_display`, `search_result_filter_button_text`: filter button visibility and copy.
+- `display_search_result_listings_count`: shows listing count on search results.
+- `search_result_listing_title`: search result title copy.
+- `search_view_as_items`: available search result view modes.
+- `search_sort_by`, `search_sortby_text`, `search_sort_by_items`: search sorting visibility, label, and choices.
+
+## User
+
+Purpose: registration/login form labels and visibility, dashboard tabs, author dashboard behavior, and all-authors display.
+
+### Registration Form
+
+- `reg_username`, `reg_email`: username and email label/copy.
+- `display_password_reg`, `reg_password`, `require_password_reg`: password field visibility, label, and requirement.
+- `display_website_reg`, `reg_website`, `require_website_reg`: website field visibility, label, and requirement.
+- `display_fname_reg`, `reg_fname`, `require_fname_reg`: first name field visibility, label, and requirement.
+- `display_lname_reg`, `reg_lname`, `require_lname_reg`: last name field visibility, label, and requirement.
+- `display_bio_reg`, `reg_bio`, `require_bio_reg`: bio field visibility, label, and requirement.
+- `display_user_type`: shows user type selection during registration.
+- `registration_privacy`, `registration_privacy_label`, `registration_privacy_label_link`: privacy policy checkbox and label/link.
+- `regi_terms_condition`, `regi_terms_label`, `regi_terms_label_link`: terms checkbox and label/link.
+- `reg_signup`: sign-up button copy.
+- `display_login`, `login_text`, `log_linkingmsg`: login prompt shown on registration form.
+- `auto_login`, `redirection_after_reg`: post-registration login and redirect behavior.
+
+### Login Form
+
+- `log_username`, `log_password`: login username/password labels.
+- `display_rememberme`, `log_rememberme`: remember-me visibility and label.
+- `log_button`: login button copy.
+- `display_signup`, `reg_text`, `reg_linktxt`: sign-up prompt visibility and copy.
+- `display_recpass`, `recpass_text`, `recpass_desc`, `recpass_username`, `recpass_placeholder`, `recpass_button`: password recovery visibility and copy.
+- `redirection_after_login`: post-login redirect behavior.
+
+### Dashboard
+
+- `my_profile_tab`, `my_profile_tab_text`: profile tab visibility and label.
+- `fav_listings_tab`, `fav_listings_tab_text`: favorite listings tab visibility and label.
+- `my_listing_tab`, `my_listing_tab_text`: author listings tab visibility and label.
+- `user_listings_pagination`, `user_listings_per_page`: author dashboard listing pagination.
+- `submit_listing_button`: submit listing button copy.
+- `become_author_button`, `become_author_button_text`: become-author CTA visibility and copy.
+
+### All Authors
+
+- `all_authors_columns`: author grid column count.
+- `all_authors_sorting`: author sorting behavior.
+- `all_authors_image`, `all_authors_name`, `all_authors_contact`, `all_authors_description`, `all_authors_social_info`: author card field visibility.
+- `all_authors_select_role`: roles included on all-authors page.
+- `all_authors_description_limit`: author bio excerpt length.
+- `all_authors_button`, `all_authors_button_text`: author card button visibility and copy.
+- `all_authors_pagination`, `all_authors_per_page`: all-authors pagination behavior.
+
+## Email
+
+Purpose: sender identity, notification recipients/events, email template content, and placeholder guidance.
+
+### General
+
+- `email_from_name`, `email_from_email`: sender name and sender email.
+- `disable_email_notification`: disables Directorist email notifications.
+- `admin_email_lists`: admin recipient list.
+- `notify_admin`, `notify_user`: event lists for admin/user notifications.
+
+### Templates
+
+- `allow_email_header`, `email_header_color`: email header visibility and color.
+- `email_note`: placeholder note shown in template settings.
+- `email_sub_new_listing`, `email_tmpl_new_listing`: new listing email subject/body.
+- `email_sub_pub_listing`, `email_tmpl_pub_listing`: approved/published listing subject/body.
+- `email_sub_edit_listing`, `email_tmpl_edit_listing`: edited listing subject/body.
+- `email_sub_to_expire_listing`, `email_tmpl_to_expire_listing`: about-to-expire listing subject/body.
+- `email_sub_expired_listing`, `email_tmpl_expired_listing`: expired listing subject/body.
+- `email_sub_to_renewal_listing`, `email_tmpl_to_renewal_listing`: renewal reminder subject/body.
+- `email_sub_renewed_listing`, `email_tmpl_renewed_listing`: renewed listing subject/body.
+- `email_sub_deleted_listing`, `email_tmpl_deleted_listing`: deleted/trashed listing subject/body.
+- `email_sub_new_order`, `email_tmpl_new_order`: new order subject/body.
+- `email_sub_offline_new_order`, `email_tmpl_offline_new_order`: offline bank-transfer order subject/body.
+- `email_sub_completed_order`, `email_tmpl_completed_order`: completed order subject/body.
+- `email_sub_listing_contact_email`, `email_tmpl_listing_contact_email`: listing contact email subject/body.
+- `email_sub_registration_confirmation`, `email_tmpl_registration_confirmation`: registration confirmation subject/body.
+- `email_sub_email_verification`, `email_tmpl_email_verification`: email verification subject/body.
+
+## Monetization
+
+Purpose: paid listing behavior, featured listings, payment gateways, payment currency display, and offline gateway copy.
+
+Source: direct core settings from `includes/classes/class-settings-panel.php`.
+
+### General And Currency
+
+- `enable_monetization`: enables paid listing/payment features.
+- `payment_currency_note`: explanatory note for payment currency settings.
+- `payment_currency`: 3-letter payment currency code.
+- `payment_thousand_separator`, `payment_decimal_separator`: payment number formatting.
+- `payment_currency_position`: payment currency symbol position.
+
+### Featured Listings
+
+- `enable_featured_listing`: enables paid featured listing purchases.
+- `featured_listing_desc`: checkout description for featured listing purchase.
+- `featured_listing_price`: featured listing fee.
+- `featured_listing_time`: featured listing duration in days.
+
+### Payment Gateways And Bank Transfer
+
+- `default_gateway`: selected default checkout gateway.
+- `active_gateways`: enabled checkout gateways.
+- `offline_payment_note`: note explaining manual bank-transfer order handling.
+- `bank_transfer_title`, `bank_transfer_description`, `bank_transfer_instruction`: offline gateway title, customer description, and bank instructions.
+
+Bank Transfer is the built-in offline gateway in core Directorist settings. It is not extension-only. Other gateways may be extension-provided and can extend `active_gateways`, `default_gateway`, and related gateway settings through filters or extension code.
+
+## Personalization
+
+Purpose: visual branding colors for Directorist frontend/admin output controlled by settings.
+
+- `brand_color`: primary brand color.
+- `button_type`: chooses which button style group is being edited.
+- `button_primary_example`, `button_primary_color`, `button_primary_bg_color`: primary button preview and colors.
+- `button_secondary_example`, `button_secondary_color`, `button_secondary_bg_color`: secondary button preview and colors.
+- `marker_shape_color`, `marker_icon_color`: all-listings map marker colors.
+
+## Extensions
+
+Purpose: core extension discovery/promotion within the settings panel.
+
+Source: direct core extension menu from `class-settings-panel.php`; extension-specific settings depend on installed/active extensions.
+
+- `extension_promotion`: note linking admins to Directorist extensions.
+
+Extension-specific design rule: do not assume settings for Directorist extensions are present from core alone. If a design targets an extension, identify the exact extension, install/activate only after user approval, inspect its filters/settings/layouts, then document any confirmed extension-provided options under an extension-specific heading.
+
+## Import And Export
+
+Purpose: listing import/export actions and settings backup/restore actions.
+
+- `listing_import_button`: link/action for running listing importer.
+- `listing_export_button`: export listings data.
+- `import_settings`: import settings backup file.
+- `export_settings`: export settings backup file.
+- `restore_default_settings`: restore default settings from bundled sample data.
+
+## Advanced
+
+Purpose: SEO meta settings, cache controls, debug behavior, and uninstall cleanup.
+
+Source: SEO and miscellaneous sections are direct core settings from `class-settings-panel.php`. Schema Markup is a core filter-injected Advanced submenu from `includes/classes/class-schema.php`.
+
+### Title And Meta SEO
+
+- `atbdp_enable_seo`: enables Directorist-managed SEO title/meta fields.
+- `add_listing_page_meta_title`, `add_listing_page_meta_desc`: add listing page meta.
+- `all_listing_meta_title`, `all_listing_meta_desc`: all listings page meta.
+- `dashboard_meta_title`, `dashboard_meta_desc`: user dashboard page meta.
+- `author_profile_meta_title`, `author_page_meta_desc`: author profile page meta.
+- `category_meta_title`, `category_meta_desc`: category archive/index meta.
+- `single_category_meta_title`, `single_category_meta_desc`: single category page meta.
+- `all_locations_meta_title`, `all_locations_meta_desc`: all locations page meta.
+- `single_locations_meta_title`, `single_locations_meta_desc`: single location page meta.
+- `registration_meta_title`, `registration_meta_desc`: registration page meta.
+- `login_meta_title`, `login_meta_desc`: login page meta.
+- `homepage_meta_title`, `homepage_meta_desc`: home page meta.
+- `meta_title_for_search_result`, `search_result_meta_title`, `search_result_meta_desc`: search result meta behavior/content.
+
+### Schema Markup
+
+Source: core filter-injected settings from `includes/classes/class-schema.php`, added through `atbdp_advanced_submenu` and `atbdp_listing_type_settings_field_list`.
+
+- `enable_schema_markup`: enables JSON-LD schema output in the frontend footer.
+- `apply_schema_markup`: chooses whether one schema type applies to all directories or different schema types apply per directory.
+- `directory_schema_type_global`: global schema type when schema applies to all directories.
+- `directory_schema_type_{directory_id}`: dynamic per-directory schema type keys generated when multi-directory data exists and per-directory schema is selected.
+
+Schema output uses `Directorist\Schema::print_schema()` and `Directorist\Schema::get_schema()`. This affects frontend structured data, listing fields, rating data, address/geo/social data, and SEO behavior, so treat schema changes as high risk.
+
+### Miscellaneous
+
+- `atbdp_enable_cache`: enables Directorist cache behavior.
+- `atbdp_reset_cache`: triggers cache reset behavior.
+- `script_debugging`: loads unminified CSS/JS files for debugging.
+- `enable_uninstall`: controls data cleanup behavior on uninstall.
+
+## Filtered Or Extension-Provided Options
+
+The settings panel applies many filters around fields and layout sections. Some are core module injections, and others may be extension-provided.
+
+- `atbdp_listing_type_settings_field_list`
+- `atbdp_listing_type_settings_layout`
+- `atbdp_listing_settings_submenu`
+- `atbdp_listing_settings_review_sections`
+- `atbdp_pages_settings_fields`
+- `directorist_search_setting_sections`
+- `atbdp_user_settings_submenu`
+- `atbdp_email_templates_settings_sections`
+- `atbdp_monetization_settings_submenu`
+- `atbdp_style_settings_controls`
+- `atbdp_extension_fields`
+- `atbdp_caching_controls`
+- `atbdp_advanced_submenu`
+- `directorist_schema_controls`
+
+Before assuming this catalog is exhaustive for a live site, inspect active extensions and filter usage.
+
+## Source Type Summary
+
+- Direct core settings: settings defined and laid out directly in `includes/classes/class-settings-panel.php`.
+- Core filter-injected settings: settings provided by bundled core modules through filters, such as Review and Schema Markup.
+- Extension-provided settings: settings added only when a Directorist extension is installed/active. These must be inspected from the extension source before design or implementation work.

--- a/docs/agents/directorist-settings-panel/templates/feasibility-report.md
+++ b/docs/agents/directorist-settings-panel/templates/feasibility-report.md
@@ -1,0 +1,27 @@
+# Settings Panel Feasibility Report
+
+## Summary
+- Request:
+- Recommended approach:
+- Risk level:
+
+## Easy To Achieve
+- 
+
+## Complex Or Risky
+- 
+
+## Affected Areas
+- PHP settings builder:
+- Vue app/store:
+- SCSS/build output:
+- Saved options/data:
+- Connected frontend/admin behavior:
+
+## Questions Before Risky Work
+- 
+
+## Verification Plan
+- Static checks:
+- Browser/manual QA:
+- Build policy:


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [x] Other... Please describe:

## Summary
Adds a repo-tracked Directorist settings panel agent guide for safe settings-panel redesign and feature planning.

## Changes
- Add settings-panel agent docs under `docs/agents/directorist-settings-panel/`
- Document settings architecture, save behavior, connected systems, limitations, and report-first workflow
- Add settings option catalog covering core, filter-injected, and extension-dependent settings
- Link the settings-panel agent from `AGENTS.md` and `CLAUDE.md`
- Exclude `/docs` from plugin/package exports through `.distignore` and `.gitattributes`

## Safety
- Documentation-only change
- No runtime plugin behavior changed
- No PHP/Vue/settings save logic changed
- No npm/build commands run

## Verification
- Ran `git diff --check`
- Confirmed `docs/` is not gitignored
- Confirmed `.distignore` excludes `/docs`
- Confirmed `.gitattributes` has `/docs export-ignore`

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
