### PR TITLE
Fix single listing back button tap behavior on mobile

### DIFF
--- a/assets/src/js/public/components/general.js
+++ b/assets/src/js/public/components/general.js
@@ -1,5 +1,101 @@
 // Fix listing with no thumb if card width is less than 220px
 (function ($) {
+	let isHandlingBackButton = false;
+	let backButtonTouchStart = null;
+	const touchMoveThreshold = 10;
+
+	const getTouchPoint = (e) => {
+		const touches =
+			e.originalEvent.changedTouches || e.originalEvent.touches || [];
+
+		if (!touches.length) {
+			return null;
+		}
+
+		return {
+			x: touches[0].clientX,
+			y: touches[0].clientY,
+		};
+	};
+
+	const didTouchMove = (touchEnd) => {
+		return (
+			Math.abs(touchEnd.x - backButtonTouchStart.x) > touchMoveThreshold ||
+			Math.abs(touchEnd.y - backButtonTouchStart.y) > touchMoveThreshold
+		);
+	};
+
+	const shouldIgnoreTouchEnd = (e, element) => {
+		if (e.type !== 'touchend') {
+			return false;
+		}
+
+		const touchEnd = getTouchPoint(e);
+
+		if (
+			!backButtonTouchStart ||
+			!touchEnd ||
+			backButtonTouchStart.element !== element
+		) {
+			backButtonTouchStart = null;
+			return true;
+		}
+
+		const moved = didTouchMove(touchEnd);
+		backButtonTouchStart = null;
+
+		return moved;
+	};
+
+	const handleBackButton = function (e) {
+		if (shouldIgnoreTouchEnd(e, this)) {
+			return;
+		}
+
+		e.preventDefault();
+		e.stopImmediatePropagation();
+
+		if (isHandlingBackButton) {
+			return;
+		}
+
+		isHandlingBackButton = true;
+		const currentUrl = window.location.href;
+		const fallbackUrl = this.href;
+
+		window.history.back();
+
+		if (fallbackUrl && fallbackUrl !== '#' && fallbackUrl !== currentUrl) {
+			setTimeout(() => {
+				if (window.location.href === currentUrl) {
+					window.location.href = fallbackUrl;
+				}
+			}, 300);
+		}
+
+		setTimeout(() => {
+			isHandlingBackButton = false;
+		}, 1000);
+	};
+
+	// Back Button to go back to the previous page
+	$('body').on('touchstart', '.directorist-btn__back', function (e) {
+		const touchStart = getTouchPoint(e);
+
+		if (!touchStart) {
+			backButtonTouchStart = null;
+			return;
+		}
+
+		backButtonTouchStart = {
+			x: touchStart.x,
+			y: touchStart.y,
+			element: this,
+		};
+	});
+
+	$('body').on('click touchend', '.directorist-btn__back', handleBackButton);
+
 	window.addEventListener('load', () => {
 		if ($('.directorist-listing-no-thumb').innerWidth() <= 220) {
 			$('.directorist-listing-no-thumb').addClass(
@@ -18,10 +114,5 @@
 				'directorist-archive-grid--fix'
 			);
 		}
-
-		// Back Button to go back to the previous page
-		$('body').on('click', '.directorist-btn__back', function (e) {
-			window.history.back();
-		});
 	});
 })(jQuery);

--- a/assets/src/js/public/search-form.js
+++ b/assets/src/js/public/search-form.js
@@ -1493,11 +1493,104 @@ document.addEventListener('DOMContentLoaded', () => {
 
 		initSearchCategoryCustomFields($);
 
+		let isHandlingBackButton = false;
+		let backButtonTouchStart = null;
+		const touchMoveThreshold = 10;
+
+		const getTouchPoint = (e) => {
+			const touches =
+				e.originalEvent.changedTouches || e.originalEvent.touches || [];
+
+			if (!touches.length) {
+				return null;
+			}
+
+			return {
+				x: touches[0].clientX,
+				y: touches[0].clientY,
+			};
+		};
+
+		const didTouchMove = (touchEnd) => {
+			return (
+				Math.abs(touchEnd.x - backButtonTouchStart.x) >
+					touchMoveThreshold ||
+				Math.abs(touchEnd.y - backButtonTouchStart.y) >
+					touchMoveThreshold
+			);
+		};
+
+		const shouldIgnoreTouchEnd = (e, element) => {
+			if (e.type !== 'touchend') {
+				return false;
+			}
+
+			const touchEnd = getTouchPoint(e);
+
+			if (
+				!backButtonTouchStart ||
+				!touchEnd ||
+				backButtonTouchStart.element !== element
+			) {
+				backButtonTouchStart = null;
+				return true;
+			}
+
+			const moved = didTouchMove(touchEnd);
+			backButtonTouchStart = null;
+
+			return moved;
+		};
+
 		// Back Button to go back to the previous page
-		$('body').on('click', '.directorist-btn__back', function (e) {
+		$('body').on('touchstart', '.directorist-btn__back', function (e) {
+			const touchStart = getTouchPoint(e);
+
+			if (!touchStart) {
+				backButtonTouchStart = null;
+				return;
+			}
+
+			backButtonTouchStart = {
+				x: touchStart.x,
+				y: touchStart.y,
+				element: this,
+			};
+		});
+
+		$('body').on('click touchend', '.directorist-btn__back', function (e) {
+			if (shouldIgnoreTouchEnd(e, this)) {
+				return;
+			}
+
 			e.preventDefault();
+			e.stopImmediatePropagation();
+
+			if (isHandlingBackButton) {
+				return;
+			}
+
+			isHandlingBackButton = true;
+			const currentUrl = window.location.href;
+			const fallbackUrl = this.href;
 
 			window.history.back();
+
+			if (
+				fallbackUrl &&
+				fallbackUrl !== '#' &&
+				fallbackUrl !== currentUrl
+			) {
+				setTimeout(() => {
+					if (window.location.href === currentUrl) {
+						window.location.href = fallbackUrl;
+					}
+				}, 300);
+			}
+
+			setTimeout(() => {
+				isHandlingBackButton = false;
+			}, 1000);
 		});
 
 		// Radius Search Field Hide on Empty Location Field

--- a/templates/single/top-actions.php
+++ b/templates/single/top-actions.php
@@ -10,12 +10,15 @@ use \Directorist\Directorist_Single_Listing;
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 $listing = Directorist_Single_Listing::instance();
+$default_back_link = ATBDP_Permalink::get_directorist_listings_page_link();
+$back_link         = wp_get_referer();
+$back_link         = $back_link ? wp_validate_redirect( $back_link, $default_back_link ) : $default_back_link;
 ?>
 
 <div class="directorist-single-listing-top directorist-flex directorist-align-center directorist-justify-content-between">
     <?php if ( $listing->display_back_link() ) : ?>
 
-    <a href="javascript:history.back()" class="directorist-single-listing-action directorist-return-back directorist-btn__back directorist-btn directorist-btn-sm directorist-btn-light"><?php directorist_icon( 'las la-arrow-left' ); ?> <span class="directorist-single-listing-action__text"><?php esc_html_e( 'Go Back', 'directorist' ); ?></span> </a>
+    <a href="<?php echo esc_url( $back_link ); ?>" class="directorist-single-listing-action directorist-return-back directorist-btn__back directorist-btn directorist-btn-sm directorist-btn-light" aria-label="<?php esc_attr_e( 'Go Back', 'directorist' ); ?>"><?php directorist_icon( 'las la-arrow-left' ); ?> <span class="directorist-single-listing-action__text"><?php esc_html_e( 'Go Back', 'directorist' ); ?></span> </a>
 
     <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- Fixes the single listing top Back button requiring two taps on real mobile/tablet devices.
- Removes the fragile `javascript:history.back()` URL from the rendered link.
- Adds a real, safe fallback URL so the Back button still works when browser history is unavailable or does not move.
- Handles touch and click events through one guarded back-button flow to prevent duplicate navigation.

## Problem
On the single listing page, the Back button was rendered with `href="javascript:history.back()"` while the shared `.directorist-btn__back` JavaScript also called `window.history.back()`.

That combination is fragile on touch browsers because a physical tap can produce `touchstart`, `touchend`, focus/hover state changes, and then a synthetic click. In some mobile/tablet cases the first tap appeared to select/focus the button and the second tap performed the navigation.

## What Changed
- The single listing Back button now renders a normal URL instead of a `javascript:` URL.
- The fallback URL uses the validated referrer when available, otherwise it falls back to the configured All Listings page.
- Added `aria-label="Go Back"` so the compact mobile icon-only button has an accessible name.
- The shared Back button handler now listens for `touchstart`, `touchend`, and `click`.
- Added a movement threshold so scroll-like touches on the button do not accidentally navigate back.
- Added duplicate-call protection so `touchend` plus the follow-up synthetic click only runs one back action.
- Added a fallback redirect to the rendered link URL if `window.history.back()` does not change the current URL.

## Verification
- `node --check assets/src/js/public/components/general.js`
- `node --check assets/src/js/public/search-form.js`
- `php -l templates/single/top-actions.php`
- `git diff --check -- assets/src/js/public/components/general.js assets/src/js/public/search-form.js templates/single/top-actions.php`
- Agent Browser check on `https://directorist-core.local/directory/business/sultans-tent-and-cafe/` confirmed:
  - the Back link no longer uses a `javascript:` URL;
  - the Back link has `aria-label="Go Back"`;
  - entering the listing from `/all-listings/` and pressing Back returns to `/all-listings/`;
  - synthetic mobile tap only triggers one back action;
  - scroll-like touch movement does not trigger navigation.

## Build Note
Generated build assets are not included in this PR because the local working copy already contains broad unrelated generated asset churn. This PR keeps the source/template fix isolated so a clean legacy build can be produced without mixing unrelated generated output.
