### PR TITLE
fix: secure custom file uploads

### DIFF
--- a/includes/classes/class-ajax-handler.php
+++ b/includes/classes/class-ajax-handler.php
@@ -949,14 +949,62 @@ if ( ! class_exists( 'ATBDP_Ajax_Handler' ) ) :
                     throw new \Exception( __( 'Invalid directory type!', 'directorist' ), 400 );
                 }
 
-                $fixed_file = ( ! empty( $_FILES[ $field_id . 'async-upload' ] ) ) ? directorist_clean( wp_unslash( $_FILES[ $field_id . 'async-upload' ] ) ) : '';
+                if ( empty( $post_id ) ) {
+                    $upload_token = isset( $_POST['upload_token'] ) ? sanitize_text_field( wp_unslash( $_POST['upload_token'] ) ) : '';
+                    $token_data   = $upload_token ? get_transient( 'directorist_file_upload_' . $upload_token ) : false;
+
+                    if (
+                        empty( $token_data )
+                        || ! is_array( $token_data )
+                        || (int) ( $token_data['directory'] ?? 0 ) !== $directory
+                        || (string) ( $token_data['field_key'] ?? '' ) !== $field_id
+                    ) {
+                        throw new \Exception( __( 'Invalid upload request!', 'directorist' ), 403 );
+                    }
+                }
+
+                if ( ! empty( $post_id ) ) {
+                    $post_type        = get_post_type( $post_id );
+                    $post_type_object = $post_type ? get_post_type_object( $post_type ) : null;
+
+                    if ( ! $post_type_object || ! current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
+                        throw new \Exception( __( 'You are not allowed to upload files for this post.', 'directorist' ), 403 );
+                    }
+                }
 
                 $form_fields  = get_term_meta( $directory, 'submission_form_fields', true );
-                $field_config = array_values( wp_list_filter( $form_fields['fields'], [ 'field_key' => $field_id ] ) );
-                $field_config = current( $field_config );
+                $field_config = [];
+
+                if ( ! empty( $form_fields['fields'] ) && is_array( $form_fields['fields'] ) ) {
+                    $field_config = array_values( wp_list_filter( $form_fields['fields'], [ 'field_key' => $field_id ] ) );
+                    $field_config = current( $field_config );
+                }
+
+                if ( empty( $field_config ) || ! is_array( $field_config ) || empty( $field_config['field_key'] ) || 'file' !== ( $field_config['type'] ?? '' ) ) {
+                    throw new \Exception( __( 'Invalid upload field!', 'directorist' ), 400 );
+                }
+
+                $field_id   = sanitize_text_field( $field_config['field_key'] );
+                $fixed_file = ( ! empty( $_FILES[ $field_id . 'async-upload' ] ) ) ? directorist_clean( wp_unslash( $_FILES[ $field_id . 'async-upload' ] ) ) : '';
+
+                if ( empty( $fixed_file ) ) {
+                    throw new \Exception( __( 'No file supplied.', 'directorist' ), 400 );
+                }
 
                 $file_type = ! empty( $field_config['file_type'] ) ? $field_config['file_type'] : 'image';
                 $file_size = ! empty( $field_config['file_size'] ) ? $field_config['file_size'] : '2mb';
+                $max_size  = wp_convert_hr_to_bytes( $file_size );
+
+                if ( $max_size > 0 && ! empty( $fixed_file['size'] ) && (int) $fixed_file['size'] > $max_size ) {
+                    throw new \Exception(
+                        sprintf(
+                            /* translators: %s: maximum file size */
+                            __( 'Uploaded file is larger than the allowed size of %s.', 'directorist' ),
+                            size_format( $max_size )
+                        ),
+                        400
+                    );
+                }
 
                 if ( in_array( $file_type, [ '', 'all_types', 'all' ], true ) ) {
                     $file_types = directorist_get_supported_file_types();

--- a/templates/listing-form/custom-fields/file.php
+++ b/templates/listing-form/custom-fields/file.php
@@ -20,6 +20,12 @@ if ( ! empty( $data['file_type'] ) ) {
 }
 
 $file_size         = ! empty( $data['file_size'] ) ? $data['file_size'] : '2mb';
+$upload_token      = wp_generate_password( 32, false );
+$upload_token_data = [
+    'directory' => (int) $data['form']->current_listing_type,
+    'field_key' => ! empty( $data['field_key'] ) ? $data['field_key'] : '',
+];
+set_transient( 'directorist_file_upload_' . $upload_token, $upload_token_data, HOUR_IN_SECONDS );
 
 // Get file type icon based on selected file type
 $file_type_icon = 'far fa-image'; // Default icon
@@ -84,6 +90,7 @@ $plupload_init = [
     'multipart_params'    => [
         '_ajax_nonce' => wp_create_nonce( 'atbdp_attachment_upload' ),   // will be added per uploader
         'action'      => 'atbdp_post_attachment_upload',                 // the ajax action name
+        'upload_token' => $upload_token,
         // Do not delete or modify 'imgid' we are running backend validation based on this id.
         'imgid'       => 0,                                              // will be added per uploader
         'directory'   => $data['form']->current_listing_type,


### PR DESCRIPTION
## Summary

- Require edit capability before uploads can update an existing post.
- Validate guest upload tokens against the requested directory and configured file field.
- Reject unknown/non-file fields and missing files.
- Enforce the configured maximum file size on the server.

## Validation

- Guest image upload: passed
- Guest PDF upload: passed
- Anonymous and subscriber arbitrary post ID attempts: blocked
- Authorized admin upload and meta update: passed
- Invalid field and oversized upload attempts: blocked
- PHP syntax and git diff checks: passed

PHPCS could not complete because the installed WordPressCS version aborts on a local PHP deprecation before inspecting the files.