### PR TITLE
Fix empty basic search form field warnings

### DIFF
--- a/templates/archive/basic-search-form.php
+++ b/templates/archive/basic-search-form.php
@@ -2,7 +2,7 @@
 /**
  * @author  wpWax
  * @since   7.2.2
- * @version 8.5
+ * @version 8.8.6
  */
 
 use \Directorist\Helper;
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         <div class="directorist-search-form-top directorist-flex directorist-align-center directorist-search-form-inline directorist-search-form__top">
             <input type="hidden" name='directory_type' value='<?php echo esc_attr( $listings->get_directory_type_slug() ); ?>'>
             <?php
-            foreach ( $searchform->form_data[0]['fields'] as $field ) {
+            foreach ( $searchform->get_basic_fields() as $field ) {
                 $searchform->field_template( $field );
             }
             ?>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
How to reproduce the issue or how to test the changes

This fixes PHP warnings from the archive basic search form when Directorist cannot resolve configured search fields for the current directory type.

The archive template directly iterated over `$searchform->form_data[0]['fields']`. On multilingual sites, a translated listing archive can resolve without matching Directory Builder metadata—for example, when the translated directory term or its builder configuration has not been created. In that state, `form_data` is empty and the direct access produces:

- `Undefined array key 0`
- `Trying to access array offset on value of type null`
- `foreach() argument must be of type array|object, null given`

Directorist already provides `SearchForm::get_basic_fields()`, which returns the configured fields when they are a valid array and safely returns an empty array otherwise. The archive template now uses that existing API instead of accessing the internal array directly.

This is intentionally a narrow robustness fix. It prevents the PHP warnings but does not fabricate missing multilingual Directory Builder configuration; translated directory terms still need their correct builder data for search inputs to appear.

### How to reproduce

1. Install and activate Directorist and Polylang.
2. Configure a directory and its search form in the source language.
3. Open a translated All Listings archive without a matching translated directory configuration/Builder metadata.
4. Enable `WP_DEBUG` and `WP_DEBUG_DISPLAY`.
5. Before this change, observe the warnings from `templates/archive/basic-search-form.php`.
6. After this change, confirm the form renders without PHP warnings.
7. Confirm a normally configured directory still renders all basic search fields.

### Performance impact

None expected. The fix uses an existing constant-time getter and adds no database queries, hooks, AJAX requests, scripts, or frontend assets.

### Verification

- `php -l templates/archive/basic-search-form.php`
- Focused regression smoke with empty `form_data`: passed with no warnings
- Focused regression smoke with populated basic fields: passed and rendered every field
- `git diff --check`

## Any linked issues

Related support ticket: https://team.sovware.com/support/cmrjuw4wl00aowds6dpphtlcr

## Screenshot

Not applicable; this fixes server-side PHP warnings without changing the UI.

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)