### PR TITLE
fix: skip hidden conditional fields during submission

### DIFF
--- a/includes/classes/class-add-listing.php
+++ b/includes/classes/class-add-listing.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || die( 'Direct access is not allowed.' );
 
 use Directorist\Helper;
 use Directorist\Fields\Fields;
+use Directorist\Fields\Conditional_Logic;
 
 if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 
@@ -257,7 +258,9 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
                         continue;
                     }
 
-                    // Removed: should_ignore_category_custom_field check (assign_to feature removed)
+                    if ( self::should_ignore_conditional_logic_field( $field, $posted_data ) ) {
+                        continue;
+                    }
 
                     switch ( $field->get_internal_key() ) {
                         case 'title':
@@ -886,10 +889,18 @@ if ( ! class_exists( 'ATBDP_Add_Listing' ) ) :
 
         // Removed: should_ignore_category_custom_field method (assign_to feature removed)
 
+        public static function should_ignore_conditional_logic_field( $field, $posted_data ) {
+            return ! Conditional_Logic::should_show_field( $field->get_props(), $posted_data );
+        }
+
         public static function validate_field( $field, $posted_data ) {
             $should_validate = (bool) apply_filters( 'atbdp_add_listing_form_validation_logic', true, $field->get_props(), $posted_data );
 
             // Removed: should_ignore_category_custom_field check (assign_to feature removed)
+
+            if ( self::should_ignore_conditional_logic_field( $field, $posted_data ) ) {
+                $should_validate = false;
+            }
 
             if ( ! $should_validate ) {
                 return [

--- a/includes/classes/class-submission-controller.php
+++ b/includes/classes/class-submission-controller.php
@@ -9,6 +9,7 @@ use WP_Error;
 use Exception;
 use ATBDP_Permalink;
 use Directorist\Helper;
+use Directorist\Fields\Conditional_Logic;
 use Directorist\Fields\Fields;
 
 class SubmissionController {
@@ -44,6 +45,10 @@ class SubmissionController {
         return ( $field->is_category_only() && ( is_null( self::$selected_categories ) || ! in_array( $field->get_assigned_category(), self::$selected_categories, true ) ) );
     }
 
+    protected static function should_ignore_conditional_logic_field( &$field, &$posted_data ) {
+        return ! Conditional_Logic::should_show_field( $field->get_props(), $posted_data );
+    }
+
     protected static function is_field_submission_empty( &$field, &$posted_data ) {
         return $field->is_value_empty( $posted_data );
     }
@@ -52,6 +57,10 @@ class SubmissionController {
         $should_validate = (bool) apply_filters( 'atbdp_add_listing_form_validation_logic', true, $field->get_props(), $posted_data );
 
         if ( self::should_ignore_category_custom_field( $field ) ) {
+            $should_validate = false;
+        }
+
+        if ( self::should_ignore_conditional_logic_field( $field, $posted_data ) ) {
             $should_validate = false;
         }
 
@@ -611,7 +620,7 @@ class SubmissionController {
                 continue;
             }
 
-            if ( self::should_ignore_category_custom_field( $field ) ) {
+            if ( self::should_ignore_category_custom_field( $field ) || self::should_ignore_conditional_logic_field( $field, $posted_data ) ) {
                 continue;
             }
 

--- a/includes/fields/class-directorist-conditional-logic.php
+++ b/includes/fields/class-directorist-conditional-logic.php
@@ -1,0 +1,400 @@
+<?php
+/**
+ * Directorist conditional logic evaluator.
+ *
+ */
+namespace Directorist\Fields;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Conditional_Logic {
+    public static function should_show_field( array $field_props, array $posted_data ) {
+        $conditional_logic = self::extract_conditional_logic( $field_props );
+
+        if ( empty( $conditional_logic ) || ! is_array( $conditional_logic ) ) {
+            return true;
+        }
+
+        if ( ! self::is_enabled( isset( $conditional_logic['enabled'] ) ? $conditional_logic['enabled'] : false ) ) {
+            return true;
+        }
+
+        if ( empty( $conditional_logic['groups'] ) || ! is_array( $conditional_logic['groups'] ) ) {
+            return true;
+        }
+
+        $group_results = [];
+
+        foreach ( $conditional_logic['groups'] as $group ) {
+            if ( empty( $group['conditions'] ) || ! is_array( $group['conditions'] ) ) {
+                continue;
+            }
+
+            $condition_results = [];
+
+            foreach ( $group['conditions'] as $condition ) {
+                if ( empty( $condition['field'] ) || empty( $condition['operator'] ) ) {
+                    continue;
+                }
+
+                $field_key           = self::normalize_field_key( $condition['field'] );
+                $field_value         = self::get_posted_field_value( $field_key, $posted_data );
+                $condition_results[] = self::evaluate_condition( $condition, $field_value );
+            }
+
+            if ( empty( $condition_results ) ) {
+                continue;
+            }
+
+            $group_operator = self::normalize_operator( isset( $group['operator'] ) ? $group['operator'] : '', 'AND' );
+            $group_results[] = 'OR' === $group_operator ? in_array( true, $condition_results, true ) : ! in_array( false, $condition_results, true );
+        }
+
+        if ( empty( $group_results ) ) {
+            $result = true;
+        } else {
+            $global_operator = self::normalize_operator( isset( $conditional_logic['globalOperator'] ) ? $conditional_logic['globalOperator'] : '', 'OR' );
+            $result          = 'AND' === $global_operator ? ! in_array( false, $group_results, true ) : in_array( true, $group_results, true );
+        }
+
+        return ( isset( $conditional_logic['action'] ) && 'hide' === $conditional_logic['action'] ) ? ! $result : $result;
+    }
+
+    private static function extract_conditional_logic( array $field_props ) {
+        if ( ! empty( $field_props['conditional_logic_data'] ) ) {
+            if ( is_string( $field_props['conditional_logic_data'] ) ) {
+                $decoded = json_decode( $field_props['conditional_logic_data'], true );
+                if ( is_array( $decoded ) ) {
+                    return $decoded;
+                }
+            } elseif ( is_array( $field_props['conditional_logic_data'] ) ) {
+                return $field_props['conditional_logic_data'];
+            }
+        }
+
+        if ( ! empty( $field_props['options']['conditional_logic']['value'] ) && is_array( $field_props['options']['conditional_logic']['value'] ) ) {
+            return $field_props['options']['conditional_logic']['value'];
+        }
+
+        if ( ! empty( $field_props['options']['conditional_logic'] ) && is_array( $field_props['options']['conditional_logic'] ) ) {
+            if ( ! isset( $field_props['options']['conditional_logic']['value'] ) ) {
+                return $field_props['options']['conditional_logic'];
+            }
+        }
+
+        if ( ! empty( $field_props['conditional_logic'] ) && is_array( $field_props['conditional_logic'] ) ) {
+            return $field_props['conditional_logic'];
+        }
+
+        return null;
+    }
+
+    private static function is_enabled( $value ) {
+        return true === $value || 1 === $value || '1' === $value || 'true' === $value;
+    }
+
+    private static function normalize_field_key( $field_key ) {
+        $field_key = is_scalar( $field_key ) ? trim( (string) $field_key ) : '';
+
+        $map = [
+            'title'                          => 'listing_title',
+            'description'                    => 'listing_content',
+            'content'                        => 'listing_content',
+            'categories'                     => 'category',
+            'admin_category_select[]'        => 'category',
+            'tax_input[at_biz_dir-category][]' => 'category',
+            'in_cat'                         => 'category',
+            'tags'                           => 'tag',
+            'tax_input[at_biz_dir-tags][]'   => 'tag',
+            'in_tag[]'                       => 'tag',
+            'locations'                      => 'location',
+            'tax_input[at_biz_dir-location][]' => 'location',
+            'in_loc'                         => 'location',
+            'image_upload'                   => 'listing_img',
+        ];
+
+        return isset( $map[ $field_key ] ) ? $map[ $field_key ] : $field_key;
+    }
+
+    private static function get_posted_field_value( $field_key, array $posted_data ) {
+        $taxonomy_value = self::get_taxonomy_field_value( $field_key, $posted_data );
+        if ( null !== $taxonomy_value ) {
+            return $taxonomy_value;
+        }
+
+        $keys = self::get_field_key_aliases( $field_key );
+
+        foreach ( $keys as $key ) {
+            if ( isset( $posted_data[ $key ] ) ) {
+                return $posted_data[ $key ];
+            }
+        }
+
+        if ( ! empty( $posted_data['custom_field'] ) && is_array( $posted_data['custom_field'] ) ) {
+            foreach ( $keys as $key ) {
+                if ( isset( $posted_data['custom_field'][ $key ] ) ) {
+                    return $posted_data['custom_field'][ $key ];
+                }
+            }
+        }
+
+        if ( 'privacy_policy' === $field_key ) {
+            return '';
+        }
+
+        if ( 'listing_img' === $field_key ) {
+            foreach ( [ 'listing_img_old', 'listing_img' ] as $key ) {
+                if ( ! empty( $posted_data[ $key ] ) ) {
+                    return 'uploaded';
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static function get_taxonomy_field_value( $field_key, array $posted_data ) {
+        $taxonomy_map = [
+            'category' => defined( 'ATBDP_CATEGORY' ) ? ATBDP_CATEGORY : 'at_biz_dir-category',
+            'tag'      => defined( 'ATBDP_TAGS' ) ? ATBDP_TAGS : 'at_biz_dir-tags',
+            'location' => defined( 'ATBDP_LOCATION' ) ? ATBDP_LOCATION : 'at_biz_dir-location',
+        ];
+
+        if ( ! isset( $taxonomy_map[ $field_key ] ) ) {
+            return null;
+        }
+
+        $taxonomy = $taxonomy_map[ $field_key ];
+
+        if ( ! empty( $posted_data['tax_input'][ $taxonomy ] ) ) {
+            return $posted_data['tax_input'][ $taxonomy ];
+        }
+
+        return null;
+    }
+
+    private static function get_field_key_aliases( $field_key ) {
+        $aliases = [ $field_key ];
+
+        $map = [
+            'listing_title'   => [ 'post_title', 'title', 'q' ],
+            'listing_content' => [ 'content', 'description' ],
+            'category'        => [ 'categories', 'admin_category_select', 'admin_category_select[]', 'in_cat' ],
+            'tag'             => [ 'tags', 'in_tag', 'in_tag[]' ],
+            'location'        => [ 'locations', 'in_loc', 'address' ],
+            'listing_img'     => [ 'image_upload', 'listing_img[]' ],
+        ];
+
+        if ( isset( $map[ $field_key ] ) ) {
+            $aliases = array_merge( $aliases, $map[ $field_key ] );
+        }
+
+        if ( 0 !== strpos( $field_key, 'custom-' ) ) {
+            $aliases[] = 'custom-' . $field_key;
+            $aliases[] = 'custom-' . str_replace( '_', '-', $field_key );
+        }
+
+        return array_values( array_unique( $aliases ) );
+    }
+
+    private static function evaluate_condition( array $condition, $field_value ) {
+        $operator        = strtolower( trim( (string) $condition['operator'] ) );
+        $condition_value = isset( $condition['value'] ) ? $condition['value'] : '';
+
+        if ( is_scalar( $condition_value ) && 'uploaded' === strtolower( (string) $condition_value ) ) {
+            if ( in_array( $operator, [ 'is', '==', '=' ], true ) ) {
+                return 'uploaded' === $field_value || true === $field_value;
+            }
+
+            if ( in_array( $operator, [ 'is not', '!=', 'not' ], true ) ) {
+                return 'uploaded' !== $field_value && true !== $field_value && self::is_empty( $field_value );
+            }
+
+            if ( 'empty' === $operator ) {
+                return self::is_empty( $field_value ) || 'uploaded' !== $field_value;
+            }
+
+            if ( 'not empty' === $operator ) {
+                return ! self::is_empty( $field_value ) && 'uploaded' === $field_value;
+            }
+        }
+
+        if ( in_array( $operator, [ 'empty', 'is empty' ], true ) ) {
+            return self::is_empty( $field_value );
+        }
+
+        if ( in_array( $operator, [ 'not empty', 'is not empty' ], true ) ) {
+            return ! self::is_empty( $field_value );
+        }
+
+        if ( is_array( $field_value ) ) {
+            return self::evaluate_array_condition( $field_value, $condition_value, $operator );
+        }
+
+        $field_value     = self::normalize_comparable_value( $field_value );
+        $condition_value = self::normalize_comparable_value( $condition_value );
+
+        switch ( $operator ) {
+            case 'is':
+            case '==':
+            case '=':
+                return (string) $field_value === (string) $condition_value;
+            case 'is not':
+            case '!=':
+            case 'not':
+                return (string) $field_value !== (string) $condition_value;
+            case 'contains':
+                return false !== strpos( (string) $field_value, (string) $condition_value );
+            case 'does not contain':
+                return false === strpos( (string) $field_value, (string) $condition_value );
+            case 'greater than':
+            case '>':
+                return (float) $field_value > (float) $condition_value;
+            case 'less than':
+            case '<':
+                return (float) $field_value < (float) $condition_value;
+            case 'greater than or equal':
+            case '>=':
+                return (float) $field_value >= (float) $condition_value;
+            case 'less than or equal':
+            case '<=':
+                return (float) $field_value <= (float) $condition_value;
+            case 'starts with':
+                return 0 === strpos( (string) $field_value, (string) $condition_value );
+            case 'ends with':
+                $condition_value = (string) $condition_value;
+                if ( '' === $condition_value ) {
+                    return true;
+                }
+
+                return substr( (string) $field_value, -strlen( $condition_value ) ) === $condition_value;
+            default:
+                return false;
+        }
+    }
+
+    private static function evaluate_array_condition( array $field_value, $condition_value, $operator ) {
+        $field_value = array_values( array_filter( array_map( [ __CLASS__, 'normalize_comparable_value' ], $field_value ), [ __CLASS__, 'is_not_empty_string' ] ) );
+
+        if ( empty( $field_value ) ) {
+            if ( in_array( $operator, [ 'empty', 'is empty' ], true ) ) {
+                return true;
+            }
+
+            if ( in_array( $operator, [ 'not empty', 'is not empty', 'is', '==', '=' ], true ) ) {
+                return false;
+            }
+
+            if ( in_array( $operator, [ 'is not', '!=', 'not' ], true ) ) {
+                return true;
+            }
+
+            return false;
+        }
+
+        $condition_value = self::normalize_comparable_value( $condition_value );
+
+        switch ( $operator ) {
+            case 'is':
+            case '==':
+            case '=':
+                return in_array( $condition_value, $field_value, true ) && count( array_unique( $field_value ) ) === 1;
+            case 'contains':
+                foreach ( $field_value as $value ) {
+                    if ( $value === $condition_value || false !== strpos( $value, $condition_value ) ) {
+                        return true;
+                    }
+                }
+
+                return false;
+            case 'is not':
+            case '!=':
+            case 'not':
+            case 'does not contain':
+                foreach ( $field_value as $value ) {
+                    if ( $value === $condition_value || false !== strpos( $value, $condition_value ) ) {
+                        return false;
+                    }
+                }
+
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static function normalize_comparable_value( $value ) {
+        if ( is_array( $value ) ) {
+            if ( isset( $value['button_text'] ) || isset( $value['button_url_label'] ) ) {
+                $value = ! empty( $value['button_text'] ) ? $value['button_text'] : ( isset( $value['button_url_label'] ) ? $value['button_url_label'] : '' );
+            } elseif ( isset( $value['button_url'] ) ) {
+                $value = $value['button_url'];
+            } elseif ( isset( $value['name'] ) ) {
+                $value = $value['name'];
+            } elseif ( isset( $value['label'] ) ) {
+                $value = $value['label'];
+            } elseif ( isset( $value['value'] ) ) {
+                $value = $value['value'];
+            } elseif ( isset( $value['id'] ) ) {
+                $value = $value['id'];
+            } else {
+                $value = implode( ',', self::flatten_scalar_values( $value ) );
+            }
+        }
+
+        return is_scalar( $value ) ? strtolower( trim( (string) $value ) ) : '';
+    }
+
+    private static function flatten_scalar_values( array $values ) {
+        $flattened = [];
+
+        foreach ( $values as $value ) {
+            if ( is_array( $value ) ) {
+                $flattened = array_merge( $flattened, self::flatten_scalar_values( $value ) );
+                continue;
+            }
+
+            if ( is_scalar( $value ) ) {
+                $value = trim( (string) $value );
+
+                if ( '' !== $value ) {
+                    $flattened[] = $value;
+                }
+            }
+        }
+
+        return $flattened;
+    }
+
+    private static function is_empty( $value ) {
+        if ( null === $value ) {
+            return true;
+        }
+
+        if ( is_string( $value ) && '' === trim( $value ) ) {
+            return true;
+        }
+
+        if ( is_array( $value ) && empty( array_filter( $value, [ __CLASS__, 'is_not_empty_value' ] ) ) ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static function is_not_empty_value( $value ) {
+        return ! self::is_empty( $value );
+    }
+
+    private static function is_not_empty_string( $value ) {
+        return '' !== $value;
+    }
+
+    private static function normalize_operator( $operator, $default ) {
+        $operator = strtoupper( trim( (string) $operator ) );
+
+        return in_array( $operator, [ 'AND', 'OR' ], true ) ? $operator : $default;
+    }
+}

--- a/includes/fields/init.php
+++ b/includes/fields/init.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/class-directorist-fields.php';
 require_once __DIR__ . '/class-directorist-base-field.php';
+require_once __DIR__ . '/class-directorist-conditional-logic.php';
 require_once __DIR__ . '/class-directorist-text-field.php';
 require_once __DIR__ . '/class-directorist-textarea-field.php';
 require_once __DIR__ . '/class-directorist-html-field.php';


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [ ] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Fixes a listing submission validation issue where required fields hidden by conditional logic were still validated on the backend.

### Directorist version
Reported from support on Directorist Core 8.8.3.

### Environment
- Local verification target: `https://directorist-core.local/`
- Add Listing page is login-gated on the local site, so the browser-level submit flow could not be completed without credentials.
- Code-level validation was done against the current development-based branch.

### Issue
When a listing submission form has required fields controlled by conditional logic, a hidden required field can block submission.

Example:
1. A selector field has Option 1 and Option 2.
2. Option 1 shows required Text Field 1 and hides required Text Field 2.
3. Option 2 shows required Text Field 2 and hides required Text Field 1.
4. Submitting with Option 1 and Text Field 1 filled still returns a required error for hidden Text Field 2.
5. Submitting with Option 2 and Text Field 2 filled still returns a required error for hidden Text Field 1.

### Root cause
The frontend conditional logic hides fields and disables their inputs, so hidden field values are not submitted by the browser. The backend submission validators still looped through every configured form field and applied required validation without evaluating whether the field should be visible for the submitted values.

### Fix
- Added a server-side conditional logic evaluator for submission fields.
- Skipped validation for fields that evaluate as hidden.
- Skipped saving hidden conditional fields, matching the frontend disabled-input behavior.
- Applied the behavior to both submission paths:
  - `Directorist\AddListingForm\SubmissionController`
  - legacy `ATBDP_Add_Listing`
- Preserved the existing `atbdp_add_listing_form_validation_logic` filter behavior.

### How to reproduce
1. Create a listing submission form with a selector field containing Option 1 and Option 2.
2. Add required Text Field 1 and configure conditional logic to show it only when Option 1 is selected.
3. Add required Text Field 2 and configure conditional logic to show it only when Option 2 is selected.
4. Open the Add Listing form.
5. Select Option 1, fill Text Field 1, and leave Text Field 2 hidden/empty.
6. Submit the listing.
7. Before this fix, submission fails because hidden Text Field 2 is treated as required.
8. After this fix, submission passes that hidden field validation.
9. Repeat with Option 2 and Text Field 2 to confirm hidden Text Field 1 no longer blocks submission.

### How to test the changes
1. Verify Option 1 + filled Text Field 1 passes without requiring hidden Text Field 2.
2. Verify Option 2 + filled Text Field 2 passes without requiring hidden Text Field 1.
3. Verify Option 1 + empty visible Text Field 1 still fails required validation.
4. Verify Option 2 + empty visible Text Field 2 still fails required validation.
5. Verify both the current `SubmissionController::submit()` path and the legacy AJAX add-listing path use the same conditional visibility skip.

### Validation performed
- `php -l includes/fields/class-directorist-conditional-logic.php`
- `php -l includes/fields/init.php`
- `php -l includes/classes/class-submission-controller.php`
- `php -l includes/classes/class-add-listing.php`
- `git diff --check`
- Focused PHP probes for:
  - Option 1 shows Text Field 1 and hides Text Field 2.
  - Option 2 shows Text Field 2 and hides Text Field 1.
  - `action: hide` conditional logic.
  - array values, numeric comparison, and nested taxonomy submitted values.
  - nested submitted arrays do not trigger PHP array-to-string warnings.
- Synthetic evaluator performance probe with an intentionally oversized conditional-logic payload stayed within a small request-time cost.

Note: `composer phpcs` could not be completed in this workspace because `vendor/bin/phpcs` is not installed.

## Any linked issues
Fixes #

## Checklist

- [ ] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
