### PR TITLE
fix(rest): support new pricing plans API

### DIFF
--- a/includes/rest-api/Version1/class-plans-controller.php
+++ b/includes/rest-api/Version1/class-plans-controller.php
@@ -35,8 +35,7 @@ class Plans_Controller extends Posts_Controller {
 
     /**
      * Active pricing plan plugin type.
-     * 'dpp' for the new directorist-pricing-plans, 'atbdp' for legacy
-     * directorist-pricing-plans, 'dwpp' for directorist-woocommerce-pricing-plans.
+     * 'dpp' for directorist-pricing-plans, 'dwpp' for directorist-woocommerce-pricing-plans.
      *
      * @var string
      */
@@ -89,25 +88,18 @@ class Plans_Controller extends Posts_Controller {
 
     /**
      * Get active pricing plan plugin type.
-     * Priority: new directorist-pricing-plans > legacy directorist-pricing-plans > directorist-woocommerce-pricing-plans.
+     * Priority: directorist-pricing-plans > directorist-woocommerce-pricing-plans.
      *
-     * @return string 'dpp', 'atbdp', 'dwpp' or null.
+     * @return string 'dpp' or 'dwpp' or null.
      */
     protected function get_active_plugin_type() {
         if ( null !== $this->active_plugin_type ) {
             return $this->active_plugin_type;
         }
 
-        if ( function_exists( 'directorist_pricing_plan_repository' ) && $this->is_fee_manager_enabled() && $this->new_pricing_plan_table_exists() ) {
+        if ( $this->has_pricing_plan_provider() ) {
             $this->active_plugin_type = 'dpp';
             return $this->active_plugin_type;
-        }
-
-        if ( class_exists( 'ATBDP_Pricing_Plans' ) ) {
-            if ( $this->is_fee_manager_enabled() ) {
-                $this->active_plugin_type = 'atbdp';
-                return $this->active_plugin_type;
-            }
         }
 
         if ( class_exists( 'DWPP_Pricing_Plans' ) ) {
@@ -122,35 +114,18 @@ class Plans_Controller extends Posts_Controller {
         return $this->active_plugin_type;
     }
 
-    protected function is_fee_manager_enabled() {
-        return (bool) get_directorist_option( 'fee_manager_enable', 1 );
-    }
-
-    protected function is_pricing_plan_extension_loaded() {
-        return function_exists( 'directorist_pricing_plan_repository' ) || class_exists( 'ATBDP_Pricing_Plans' ) || class_exists( 'DWPP_Pricing_Plans' );
-    }
-
-    protected function new_pricing_plan_table_exists() {
-        global $wpdb;
-
-        $table = $this->get_new_pricing_plan_table_name();
-
-        return $table === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+    protected function has_pricing_plan_provider() {
+        return (bool) apply_filters( 'directorist_rest_pricing_plans_provider_available', false );
     }
 
     public function get_items_permissions_check( $request ) {
         $plugin_type = $this->get_active_plugin_type();
-
         if ( ! $plugin_type ) {
-            $message = $this->is_pricing_plan_extension_loaded()
-                ? __( 'Pricing plan extension disabled.', 'directorist' )
-                : __( 'Pricing plan extension inactive.', 'directorist' );
-
-            return new WP_Error( 'extension_inactive', $message, array( 'status' => 400 ) );
+            return new WP_Error( 'extension_inactive', __( 'Pricing plan extension inactive.', 'directorist' ), array( 'status' => 400 ) );
         }
 
         if ( 'dpp' === $plugin_type ) {
-            return true;
+            return apply_filters( 'directorist_rest_pricing_plans_permissions_check', true, $request );
         }
 
         // Verify post type is registered
@@ -163,22 +138,17 @@ class Plans_Controller extends Posts_Controller {
             );
         }
         
-        return parent::get_items_permissions_check( $request );
+        return true;
     }
 
     public function get_item_permissions_check( $request ) {
         $plugin_type = $this->get_active_plugin_type();
-
         if ( ! $plugin_type ) {
-            $message = $this->is_pricing_plan_extension_loaded()
-                ? __( 'Pricing plan extension disabled.', 'directorist' )
-                : __( 'Pricing plan extension inactive.', 'directorist' );
-
-            return new WP_Error( 'extension_inactive', $message, array( 'status' => 400 ) );
+            return new WP_Error( 'extension_inactive', __( 'Pricing plan extension inactive.', 'directorist' ), array( 'status' => 400 ) );
         }
 
         if ( 'dpp' === $plugin_type ) {
-            return true;
+            return apply_filters( 'directorist_rest_pricing_plan_permissions_check', true, $request );
         }
 
         // Verify post type is registered
@@ -188,7 +158,7 @@ class Plans_Controller extends Posts_Controller {
             return new WP_Error( 'post_type_not_registered', sprintf( __( 'Pricing plans post type "%s" is not registered.', 'directorist' ), esc_html( $post_type ) ), array( 'status' => 500 ) );
         }
         
-        return parent::get_item_permissions_check( $request );
+        return true;
     }
 
     /**
@@ -199,7 +169,7 @@ class Plans_Controller extends Posts_Controller {
      */
     public function get_items( $request ) {
         if ( 'dpp' === $this->get_active_plugin_type() ) {
-            return $this->get_new_pricing_plan_items( $request );
+            return $this->get_pricing_plan_items_from_provider( $request );
         }
 
         $query_args = $this->prepare_objects_query( $request );
@@ -251,6 +221,16 @@ class Plans_Controller extends Posts_Controller {
         return $response;
     }
 
+    protected function get_pricing_plan_items_from_provider( $request ) {
+        $response = apply_filters( 'directorist_rest_pricing_plans_data', null, $request );
+
+        if ( null === $response ) {
+            return new WP_Error( 'extension_inactive', __( 'Pricing plan extension inactive.', 'directorist' ), array( 'status' => 400 ) );
+        }
+
+        return rest_ensure_response( $response );
+    }
+
     protected function get_plans( $query_args ) {
         $query  = new WP_Query();
         $result = $query->query( $query_args );
@@ -269,108 +249,6 @@ class Plans_Controller extends Posts_Controller {
             'total'   => (int) $total_posts,
             'pages'   => (int) ceil( $total_posts / (int) $query->query_vars['posts_per_page'] ),
         );
-    }
-
-    protected function get_new_pricing_plan_items( $request ) {
-        $query_args = $this->prepare_new_pricing_plan_query( $request );
-
-        do_action( 'directorist_rest_before_query', 'get_plan_items', $request, $query_args );
-
-        $query_results = $this->get_new_pricing_plans( $query_args );
-        $objects       = array();
-
-        foreach ( $query_results['objects'] as $object ) {
-            $data      = $this->prepare_item_for_response( $object, $request );
-            $objects[] = $this->prepare_response_for_collection( $data );
-        }
-
-        $page      = (int) $query_args['page'];
-        $max_pages = (int) $query_results['pages'];
-        $response  = rest_ensure_response( $objects );
-
-        $response->header( 'X-WP-Total', (int) $query_results['total'] );
-        $response->header( 'X-WP-TotalPages', $max_pages );
-
-        $base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
-
-        if ( $page > 1 ) {
-            $prev_page = min( $page - 1, $max_pages );
-            $response->link_header( 'prev', add_query_arg( 'page', $prev_page, $base ) );
-        }
-
-        if ( $max_pages > $page ) {
-            $response->link_header( 'next', add_query_arg( 'page', $page + 1, $base ) );
-        }
-
-        do_action( 'directorist_rest_after_query', 'get_plan_items', $request, $query_args );
-
-        return apply_filters( 'directorist_rest_response', $response, 'get_plan_items', $request, $query_args );
-    }
-
-    protected function prepare_new_pricing_plan_query( $request ) {
-        $page     = max( 1, (int) ( $request['page'] ? $request['page'] : 1 ) );
-        $per_page = max( 1, min( 100, (int) ( $request['per_page'] ? $request['per_page'] : 10 ) ) );
-
-        $args = array(
-            'directory' => $this->get_new_pricing_plan_directory_filter( $request ),
-            'page'      => $page,
-            'per_page'  => $per_page,
-            'offset'    => ( $page - 1 ) * $per_page,
-            'order'     => ( 'asc' === strtolower( (string) $request['order'] ) ) ? 'ASC' : 'DESC',
-            'orderby'   => ( 'date' === $request['orderby'] ) ? 'created_at' : 'title',
-        );
-
-        return apply_filters( 'directorist_rest_directorist_plan_object_query', $args, $request );
-    }
-
-    protected function get_new_pricing_plan_directory_filter( $request ) {
-        if ( directorist_is_multi_directory_enabled() ) {
-            return absint( $request['directory'] );
-        }
-
-        return (int) directorist_get_default_directory();
-    }
-
-    protected function get_new_pricing_plans( $query_args ) {
-        global $wpdb;
-
-        $table      = $this->get_new_pricing_plan_table_name();
-        $where      = array( 'is_published = 1' );
-        $parameters = array();
-
-        if ( ! empty( $query_args['directory'] ) ) {
-            $where[]      = 'directory_type_id = %d';
-            $parameters[] = (int) $query_args['directory'];
-        }
-
-        $where_sql = implode( ' AND ', $where );
-        $count_sql = "SELECT COUNT(*) FROM {$table} WHERE {$where_sql}";
-
-        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
-        if ( ! empty( $parameters ) ) {
-            $total = (int) $wpdb->get_var( $wpdb->prepare( $count_sql, $parameters ) );
-        } else {
-            $total = (int) $wpdb->get_var( $count_sql );
-        }
-
-        $orderby = ( 'created_at' === $query_args['orderby'] ) ? 'created_at' : 'title';
-        $order   = ( 'ASC' === $query_args['order'] ) ? 'ASC' : 'DESC';
-        $sql     = "SELECT * FROM {$table} WHERE {$where_sql} ORDER BY {$orderby} {$order}, id {$order} LIMIT %d OFFSET %d";
-        $params  = array_merge( $parameters, array( (int) $query_args['per_page'], (int) $query_args['offset'] ) );
-        $objects = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
-        // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
-
-        return array(
-            'objects' => $objects ? $objects : array(),
-            'total'   => $total,
-            'pages'   => (int) ceil( $total / (int) $query_args['per_page'] ),
-        );
-    }
-
-    protected function get_new_pricing_plan_table_name() {
-        global $wpdb;
-
-        return $wpdb->prefix . 'directorist_plans';
     }
 
     /**
@@ -447,21 +325,11 @@ class Plans_Controller extends Posts_Controller {
     public function get_item( $request ) {
         $id = (int) $request['id'];
 
-        do_action( 'directorist_rest_before_query', 'get_plan_item', $request, $id );
-
         if ( 'dpp' === $this->get_active_plugin_type() ) {
-            $plan = $this->get_new_pricing_plan( $id );
-
-            if ( ! $plan ) {
-                return new WP_Error( "directorist_rest_invalid_{$this->post_type}_id", __( 'Invalid ID.', 'directorist' ), array( 'status' => 404 ) );
-            }
-
-            $response = $this->prepare_item_for_response( $plan, $request );
-
-            do_action( 'directorist_rest_after_query', 'get_plan_item', $request, (int) $plan->id );
-
-            return apply_filters( 'directorist_rest_response', $response, 'get_plan_item', $request, (int) $plan->id );
+            return $this->get_pricing_plan_item_from_provider( $request, $id );
         }
+
+        do_action( 'directorist_rest_before_query', 'get_plan_item', $request, $id );
 
         $post               = get_post( $id );
         $plugin_type        = $this->get_active_plugin_type();
@@ -489,35 +357,14 @@ class Plans_Controller extends Posts_Controller {
         return $response;
     }
 
-    protected function get_new_pricing_plan( $id ) {
-        global $wpdb;
+    protected function get_pricing_plan_item_from_provider( $request, $id ) {
+        $response = apply_filters( 'directorist_rest_pricing_plan_data', null, $request, $id );
 
-        $id = $this->get_new_pricing_plan_id( $id );
-
-        if ( ! $id ) {
-            return null;
+        if ( null === $response ) {
+            return new WP_Error( "directorist_rest_invalid_{$this->post_type}_id", __( 'Invalid ID.', 'directorist' ), array( 'status' => 404 ) );
         }
 
-        $table = $this->get_new_pricing_plan_table_name();
-
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is constructed from the WP prefix and a known extension table.
-        $plan = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d AND is_published = 1", $id ) );
-
-        return $plan ? $plan : null;
-    }
-
-    protected function get_new_pricing_plan_id( $id ) {
-        $id = absint( $id );
-
-        if ( ! $id ) {
-            return 0;
-        }
-
-        if ( function_exists( 'directorist_pricing_plans_legacy_plan_id' ) ) {
-            return absint( directorist_pricing_plans_legacy_plan_id( $id ) );
-        }
-
-        return $id;
+        return rest_ensure_response( $response );
     }
 
     /**
@@ -606,10 +453,6 @@ class Plans_Controller extends Posts_Controller {
      * @return array
      */
     protected function get_plan_data( $plan, $request, $context = 'view' ) {
-        if ( 'dpp' === $this->get_active_plugin_type() ) {
-            return $this->get_new_pricing_plan_data( $plan, $request );
-        }
-
         $fields = $this->get_fields_for_response( $request );
 
         $base_data = array();
@@ -721,403 +564,6 @@ class Plans_Controller extends Posts_Controller {
         }
 
         return $base_data;
-    }
-
-    protected function get_new_pricing_plan_data( $plan, $request ) {
-        $fields = $this->get_fields_for_response( $request );
-        $data   = array();
-
-        foreach ( $fields as $field ) {
-            switch ( $field ) {
-                case 'id':
-                    $data['id'] = (int) $plan->id;
-                    break;
-                case 'name':
-                    $data['name'] = (string) $plan->title;
-                    break;
-                case 'slug':
-                    $data['slug'] = sanitize_title( $plan->title );
-                    break;
-                case 'date_created':
-                    $data['date_created'] = $this->format_new_pricing_plan_date( isset( $plan->created_at ) ? $plan->created_at : '', false );
-                    break;
-                case 'date_created_gmt':
-                    $data['date_created_gmt'] = $this->format_new_pricing_plan_date( isset( $plan->created_at ) ? $plan->created_at : '', true );
-                    break;
-                case 'date_modified':
-                    $data['date_modified'] = $this->format_new_pricing_plan_date( isset( $plan->updated_at ) ? $plan->updated_at : '', false );
-                    break;
-                case 'date_modified_gmt':
-                    $data['date_modified_gmt'] = $this->format_new_pricing_plan_date( isset( $plan->updated_at ) ? $plan->updated_at : '', true );
-                    break;
-                case 'description':
-                    $data['description'] = (string) ( isset( $plan->description ) ? $plan->description : '' );
-                    break;
-                case 'hide_description_from_plan':
-                    $data['hide_description_from_plan'] = false;
-                    break;
-                case 'directory':
-                    $data['directory'] = (int) $plan->directory_type_id;
-                    break;
-                case 'status':
-                    $data['status'] = ! empty( $plan->is_published ) ? 'publish' : 'draft';
-                    break;
-                case 'is_recommended':
-                    $data['is_recommended'] = (bool) $plan->is_marked_as_recommended;
-                    break;
-                case 'is_hidden':
-                    $data['is_hidden'] = (bool) $plan->is_hidden_from_plans_list;
-                    break;
-                case 'type':
-                    $data['type'] = $this->get_new_pricing_plan_type( $plan );
-                    break;
-                case 'type_label':
-                    $data['type_label'] = ( 'package' === $this->get_new_pricing_plan_type( $plan ) ) ? esc_html__( 'Per Package', 'directorist' ) : esc_html__( 'Per Listing', 'directorist' );
-                    break;
-                case 'currency':
-                    $data['currency'] = atbdp_get_payment_currency();
-                    break;
-                case 'currency_symbol':
-                    $data['currency_symbol'] = html_entity_decode( atbdp_currency_symbol( atbdp_get_payment_currency() ) );
-                    break;
-                case 'is_free':
-                    $data['is_free'] = ( 'free' === ( isset( $plan->fee_type ) ? $plan->fee_type : '' ) );
-                    break;
-                case 'price':
-                    $data['price'] = ( 'free' === ( isset( $plan->fee_type ) ? $plan->fee_type : '' ) ) ? 0 : (float) $plan->price;
-                    break;
-                case 'is_taxable':
-                    $data['is_taxable'] = (bool) $plan->is_taxable;
-                    break;
-                case 'tax_type':
-                    $data['tax_type'] = ( 'percent' === ( isset( $plan->tax_type ) ? $plan->tax_type : '' ) ) ? 'percentage' : 'fixed';
-                    break;
-                case 'tax':
-                    $data['tax'] = (float) $plan->tax_rate;
-                    break;
-                case 'validity_period':
-                    $data['validity_period'] = ( 'lifetime' === ( isset( $plan->interval_type ) ? $plan->interval_type : '' ) ) ? 0 : (int) $plan->interval_count;
-                    break;
-                case 'validity_period_unit':
-                    $data['validity_period_unit'] = $this->get_new_pricing_plan_validity_period_unit( $plan );
-                    break;
-                case 'validity_period_label':
-                    $data['validity_period_label'] = $this->get_new_pricing_plan_validity_period_label( $plan );
-                    break;
-                case 'is_non_expiring':
-                    $data['is_non_expiring'] = ( 'lifetime' === ( isset( $plan->interval_type ) ? $plan->interval_type : '' ) );
-                    break;
-                case 'playstore_product_id':
-                case 'playstore_product_price':
-                case 'appstore_product_id':
-                case 'appstore_product_price':
-                    $data[ $field ] = $this->get_new_pricing_plan_app_configuration_value( (int) $plan->id, $field );
-                    break;
-                case 'features':
-                    $data['features'] = $this->get_new_pricing_plan_features_data( $plan );
-                    break;
-                case 'fields':
-                    $data['fields'] = $this->get_new_pricing_plan_fields_data( $plan );
-                    break;
-            }
-        }
-
-        return $data;
-    }
-
-    protected function format_new_pricing_plan_date( $date, $gmt ) {
-        if ( '' === $date || '0000-00-00 00:00:00' === $date ) {
-            return null;
-        }
-
-        return directorist_rest_prepare_date_response( $date, $gmt );
-    }
-
-    protected function get_new_pricing_plan_type( $plan ) {
-        return ( 'pay_per_listing' === ( isset( $plan->type ) ? $plan->type : '' ) ) ? 'pay_per_listing' : 'package';
-    }
-
-    protected function get_new_pricing_plan_validity_period_unit( $plan ) {
-        $unit = (string) ( isset( $plan->interval_type ) ? $plan->interval_type : 'day' );
-
-        return in_array( $unit, array( 'day', 'week', 'month', 'year' ), true ) ? $unit : 'day';
-    }
-
-    protected function get_new_pricing_plan_validity_period_label( $plan ) {
-        if ( 'lifetime' === ( isset( $plan->interval_type ) ? $plan->interval_type : '' ) ) {
-            return esc_html__( 'Lifetime', 'directorist' );
-        }
-
-        $validity_period = max( 0, (int) $plan->interval_count );
-        $translations    = array(
-            /* translators: %d: Number of days */
-            'day'   => _n( '%d day', '%d days', $validity_period, 'directorist' ),
-            /* translators: %d: Number of weeks */
-            'week'  => _n( '%d week', '%d weeks', $validity_period, 'directorist' ),
-            /* translators: %d: Number of months */
-            'month' => _n( '%d month', '%d months', $validity_period, 'directorist' ),
-            /* translators: %d: Number of years */
-            'year'  => _n( '%d year', '%d years', $validity_period, 'directorist' ),
-        );
-
-        return sprintf( $translations[ $this->get_new_pricing_plan_validity_period_unit( $plan ) ], $validity_period );
-    }
-
-    protected function get_new_pricing_plan_app_configuration_value( $plan_id, $field ) {
-        static $cache = array();
-
-        if ( ! isset( $cache[ $plan_id ] ) ) {
-            $cache[ $plan_id ] = $this->get_new_pricing_plan_app_configurations( $plan_id );
-        }
-
-        $field_map = array(
-            'playstore_product_id'    => array( 'playstore', 'product_id' ),
-            'playstore_product_price' => array( 'playstore', 'product_price' ),
-            'appstore_product_id'     => array( 'appstore', 'product_id' ),
-            'appstore_product_price'  => array( 'appstore', 'product_price' ),
-        );
-
-        if ( ! isset( $field_map[ $field ] ) ) {
-            return '';
-        }
-
-        list( $type, $property ) = $field_map[ $field ];
-
-        foreach ( $cache[ $plan_id ] as $configuration ) {
-            if ( $type === ( isset( $configuration->type ) ? $configuration->type : '' ) ) {
-                return isset( $configuration->$property ) ? $configuration->$property : '';
-            }
-        }
-
-        return '';
-    }
-
-    protected function get_new_pricing_plan_app_configurations( $plan_id ) {
-        global $wpdb;
-
-        $table = $wpdb->prefix . 'directorist_plan_app_configurations';
-
-        if ( $table !== $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) ) {
-            return array();
-        }
-
-        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is constructed from the WP prefix and a known extension table.
-        $configurations = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE plan_id = %d", $plan_id ) );
-
-        return $configurations ? $configurations : array();
-    }
-
-    protected function get_new_pricing_plan_features_data( $plan ) {
-        $features = array(
-            array(
-                'key'            => 'auto_renewal',
-                'label'          => esc_html__( 'Auto renewing', 'directorist' ),
-                'is_active'      => (bool) $plan->is_subscription_enabled,
-                'hide_from_plan' => false,
-            ),
-        );
-
-        if ( 'package' === $this->get_new_pricing_plan_type( $plan ) ) {
-            $features[] = array(
-                'key'            => 'regular_listings',
-                'label'          => $this->get_new_pricing_plan_listing_limit_label( 'regular', (int) $plan->allowed_listings, (bool) $plan->is_allowed_unlimited_listings ),
-                'is_active'      => true,
-                'hide_from_plan' => false,
-                'limit'          => (bool) $plan->is_allowed_unlimited_listings ? -1 : (int) $plan->allowed_listings,
-            );
-            $features[] = array(
-                'key'            => 'featured_listings',
-                'label'          => $this->get_new_pricing_plan_listing_limit_label( 'featured', (int) $plan->allowed_featured_listings, (bool) $plan->is_allowed_unlimited_featured_listings ),
-                'is_active'      => true,
-                'hide_from_plan' => false,
-                'limit'          => (bool) $plan->is_allowed_unlimited_featured_listings ? -1 : (int) $plan->allowed_featured_listings,
-            );
-        } else {
-            $features[] = array(
-                'key'            => 'featured_listing',
-                'label'          => esc_html__( 'Listing as featured', 'directorist' ),
-                'is_active'      => (bool) $plan->is_featured,
-                'hide_from_plan' => false,
-            );
-        }
-
-        return array_merge( $features, $this->get_new_pricing_plan_extra_features_data( $plan ) );
-    }
-
-    protected function get_new_pricing_plan_extra_features_data( $plan ) {
-        $features = array();
-        $map      = array(
-            'contact_listings_owner'  => array( 'contact_listing_owner', esc_html__( 'Contact Owner', 'directorist' ) ),
-            'review'                  => array( 'reviews_allowed', esc_html__( 'Allow Customer Review', 'directorist' ) ),
-            'claim_listing'           => array( 'claim_badge_included', esc_html__( 'Claim Badge Included', 'directorist' ) ),
-            'bdb'                     => array( 'booking_included', esc_html__( 'Booking Included', 'directorist' ) ),
-            'live_chat'               => array( 'live_chat_included', esc_html__( 'Live Chat Included', 'directorist' ) ),
-            'sold_badge'              => array( 'mark_as_sold_included', esc_html__( 'Mark as Sold Included', 'directorist' ) ),
-            'admin_category_select[]' => array( 'categories_included', esc_html__( 'All Categories', 'directorist' ) ),
-        );
-
-        foreach ( $this->get_new_pricing_plan_features( $plan ) as $feature ) {
-            $key = (string) ( isset( $feature->key ) ? $feature->key : '' );
-
-            if ( ! isset( $map[ $key ] ) ) {
-                continue;
-            }
-
-            $features[] = array(
-                'key'            => $map[ $key ][0],
-                'label'          => $map[ $key ][1],
-                'is_active'      => (bool) ( isset( $feature->is_enabled ) ? $feature->is_enabled : false ),
-                'hide_from_plan' => ! (bool) ( isset( $feature->is_show_in_pricing_table ) ? $feature->is_show_in_pricing_table : false ),
-            );
-        }
-
-        return $features;
-    }
-
-    protected function get_new_pricing_plan_listing_limit_label( $type, $count, $unlimited ) {
-        if ( 'regular' === $type ) {
-            return $unlimited
-                ? __( 'Unlimited Regular Listings', 'directorist' )
-                : sprintf( _n( '%s Regular Listing', '%s Regular Listings', $count, 'directorist' ), $count );
-        }
-
-        return $unlimited
-            ? __( 'Unlimited Featured Listings', 'directorist' )
-            : sprintf( _n( '%s Featured Listing', '%s Featured Listings', $count, 'directorist' ), $count );
-    }
-
-    protected function get_new_pricing_plan_fields_data( $plan ) {
-        $field_data = array();
-        $skip_keys  = array( 'review', 'contact_listings_owner', 'claim_listing', 'bdb', 'live_chat', 'sold_badge' );
-
-        foreach ( $this->get_new_pricing_plan_features( $plan ) as $feature ) {
-            $key = (string) ( isset( $feature->key ) ? $feature->key : '' );
-
-            if ( in_array( $key, $skip_keys, true ) ) {
-                continue;
-            }
-
-            $data = array(
-                'key'            => $key,
-                'label'          => (string) ( isset( $feature->name ) ? $feature->name : $key ),
-                'is_preset'      => $this->is_new_pricing_plan_preset_field( $key ),
-                'is_active'      => (bool) ( isset( $feature->is_enabled ) ? $feature->is_enabled : false ),
-                'hide_from_plan' => ! (bool) ( isset( $feature->is_show_in_pricing_table ) ? $feature->is_show_in_pricing_table : false ),
-            );
-
-            $feature_data = array();
-            if ( isset( $feature->data ) ) {
-                $feature_data = is_array( $feature->data ) ? $feature->data : (array) $feature->data;
-            }
-
-            if ( ! empty( $feature_data['is_unlimited'] ) ) {
-                $data['label'] = sprintf( __( '%s (unlimited)', 'directorist' ), $data['label'] );
-                $data['limit'] = -1;
-            } elseif ( isset( $feature_data['limit'] ) && '' !== $feature_data['limit'] ) {
-                $data['limit'] = (int) $feature_data['limit'];
-            }
-
-            $field_data[] = $data;
-        }
-
-        return $field_data;
-    }
-
-    protected function get_new_pricing_plan_features( $plan ) {
-        static $cache = array();
-
-        $plan_id = (int) $plan->id;
-
-        if ( isset( $cache[ $plan_id ] ) ) {
-            return $cache[ $plan_id ];
-        }
-
-        $cache[ $plan_id ] = $this->get_new_pricing_plan_features_from_repository( $plan );
-
-        if ( null === $cache[ $plan_id ] ) {
-            $cache[ $plan_id ] = $this->get_new_pricing_plan_features_from_table( $plan );
-        }
-
-        return $cache[ $plan_id ];
-    }
-
-    protected function get_new_pricing_plan_features_from_repository( $plan ) {
-        if ( ! function_exists( 'directorist_pricing_plans_singleton' ) || ! class_exists( 'DirectoristPricingPlan\App\Repositories\Admin\PlanFeatureRepository' ) ) {
-            return null;
-        }
-
-        try {
-            $repository = directorist_pricing_plans_singleton( 'DirectoristPricingPlan\App\Repositories\Admin\PlanFeatureRepository' );
-
-            if ( is_object( $repository ) && method_exists( $repository, 'get' ) ) {
-                return $repository->get( $plan );
-            }
-        } catch ( \Throwable $exception ) {
-            return null;
-        }
-
-        return null;
-    }
-
-    protected function get_new_pricing_plan_features_from_table( $plan ) {
-        global $wpdb;
-
-        $registered_features = $this->get_new_pricing_plan_registered_features( (int) $plan->directory_type_id );
-        $features            = array();
-        $table               = $wpdb->prefix . 'directorist_plan_features';
-
-        if ( $table === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) ) {
-            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is constructed from the WP prefix and a known extension table.
-            $db_features = $wpdb->get_results( $wpdb->prepare( "SELECT feature_key, is_enabled, is_show_in_pricing_table, data FROM {$table} WHERE plan_id = %d ORDER BY sort_order ASC, id ASC", (int) $plan->id ) );
-
-            foreach ( $db_features as $feature ) {
-                $key  = (string) $feature->feature_key;
-                $data = isset( $registered_features[ $key ] ) ? (object) $registered_features[ $key ] : new \stdClass();
-
-                $data->key                      = $key;
-                $data->name                     = isset( $data->name ) ? $data->name : $key;
-                $data->is_enabled               = (bool) $feature->is_enabled;
-                $data->is_show_in_pricing_table = (bool) $feature->is_show_in_pricing_table;
-                $data->data                     = ! empty( $feature->data ) ? json_decode( $feature->data, true ) : array();
-                $features[]                     = $data;
-
-                unset( $registered_features[ $key ] );
-            }
-        }
-
-        foreach ( $registered_features as $key => $feature ) {
-            $data      = (object) $feature;
-            $data->key = (string) $key;
-
-            $features[] = $data;
-        }
-
-        return $features;
-    }
-
-    protected function get_new_pricing_plan_registered_features( $directory_id ) {
-        if ( function_exists( 'directorist_plan_registered_features' ) ) {
-            return directorist_plan_registered_features( $directory_id );
-        }
-
-        return array();
-    }
-
-    protected function is_new_pricing_plan_preset_field( $key ) {
-        return in_array(
-            $key,
-            array(
-                'tax_input[at_biz_dir-location][]',
-                'admin_category_select[]',
-                'tax_input[at_biz_dir-tags][]',
-                'listing_content',
-                'excerpt',
-                'listing_img',
-                'price',
-                'price_range',
-            ),
-            true
-        );
     }
 
     protected function get_validity_period_label( $plan ) {
@@ -1381,11 +827,9 @@ class Plans_Controller extends Posts_Controller {
      * @return array Links for the given post.
      */
     protected function prepare_links( $object, $request ) {
-        $object_id = isset( $object->ID ) ? (int) $object->ID : (int) $object->id;
-
         $links = array(
             'self'       => array(
-				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $object_id ) ),  // @codingStandardsIgnoreLine.
+				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $object->ID ) ),  // @codingStandardsIgnoreLine.
             ),
             'collection' => array(
 				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),  // @codingStandardsIgnoreLine.

--- a/includes/rest-api/Version1/class-plans-controller.php
+++ b/includes/rest-api/Version1/class-plans-controller.php
@@ -96,7 +96,7 @@ class Plans_Controller extends Posts_Controller {
             return $this->active_plugin_type;
         }
 
-        if ( $this->has_pricing_plan_provider() ) {
+        if ( $this->is_active_pricing_plans() ) {
             $this->active_plugin_type = 'dpp';
             return $this->active_plugin_type;
         }
@@ -113,7 +113,7 @@ class Plans_Controller extends Posts_Controller {
         return $this->active_plugin_type;
     }
 
-    protected function has_pricing_plan_provider() {
+    protected function is_active_pricing_plans() {
         return (bool) apply_filters( 'directorist_is_active_pricing_plans', false );
     }
 

--- a/includes/rest-api/Version1/class-plans-controller.php
+++ b/includes/rest-api/Version1/class-plans-controller.php
@@ -13,7 +13,6 @@ defined( 'ABSPATH' ) || exit;
 use WP_Error;
 use WP_Query;
 use WP_REST_Server;
-use Directorist\Helper;
 
 /**
  * Plans controller class.
@@ -115,11 +114,12 @@ class Plans_Controller extends Posts_Controller {
     }
 
     protected function has_pricing_plan_provider() {
-        return (bool) apply_filters( 'directorist_rest_pricing_plans_provider_available', false );
+        return (bool) apply_filters( 'directorist_is_active_pricing_plans', false );
     }
 
     public function get_items_permissions_check( $request ) {
         $plugin_type = $this->get_active_plugin_type();
+
         if ( ! $plugin_type ) {
             return new WP_Error( 'extension_inactive', __( 'Pricing plan extension inactive.', 'directorist' ), array( 'status' => 400 ) );
         }
@@ -130,6 +130,7 @@ class Plans_Controller extends Posts_Controller {
 
         // Verify post type is registered
         $post_type = ( 'dwpp' === $plugin_type ) ? 'product' : $this->post_type;
+
         if ( ! post_type_exists( $post_type ) ) {
             return new WP_Error( 
                 'post_type_not_registered', 
@@ -143,6 +144,7 @@ class Plans_Controller extends Posts_Controller {
 
     public function get_item_permissions_check( $request ) {
         $plugin_type = $this->get_active_plugin_type();
+
         if ( ! $plugin_type ) {
             return new WP_Error( 'extension_inactive', __( 'Pricing plan extension inactive.', 'directorist' ), array( 'status' => 400 ) );
         }
@@ -153,6 +155,7 @@ class Plans_Controller extends Posts_Controller {
 
         // Verify post type is registered
         $post_type = ( 'dwpp' === $plugin_type ) ? 'product' : $this->post_type;
+
         if ( ! post_type_exists( $post_type ) ) {
             /* translators: %s: Post type name */
             return new WP_Error( 'post_type_not_registered', sprintf( __( 'Pricing plans post type "%s" is not registered.', 'directorist' ), esc_html( $post_type ) ), array( 'status' => 500 ) );

--- a/includes/rest-api/Version1/class-plans-controller.php
+++ b/includes/rest-api/Version1/class-plans-controller.php
@@ -35,7 +35,8 @@ class Plans_Controller extends Posts_Controller {
 
     /**
      * Active pricing plan plugin type.
-     * 'atbdp' for directorist-pricing-plans, 'dwpp' for directorist-woocommerce-pricing-plans
+     * 'dpp' for the new directorist-pricing-plans, 'atbdp' for legacy
+     * directorist-pricing-plans, 'dwpp' for directorist-woocommerce-pricing-plans.
      *
      * @var string
      */
@@ -88,30 +89,27 @@ class Plans_Controller extends Posts_Controller {
 
     /**
      * Get active pricing plan plugin type.
-     * Priority: directorist-pricing-plans > directorist-woocommerce-pricing-plans
-     * 
-     * Note: Plugins are mutually exclusive - only one can be active at a time.
-     * This method checks both class existence and admin settings.
+     * Priority: new directorist-pricing-plans > legacy directorist-pricing-plans > directorist-woocommerce-pricing-plans.
      *
-     * @return string 'atbdp' or 'dwpp' or null
+     * @return string 'dpp', 'atbdp', 'dwpp' or null.
      */
     protected function get_active_plugin_type() {
         if ( null !== $this->active_plugin_type ) {
             return $this->active_plugin_type;
         }
 
-        // Priority: directorist-pricing-plans first
-        // Check class exists AND admin setting is enabled
+        if ( function_exists( 'directorist_pricing_plan_repository' ) && $this->is_fee_manager_enabled() && $this->new_pricing_plan_table_exists() ) {
+            $this->active_plugin_type = 'dpp';
+            return $this->active_plugin_type;
+        }
+
         if ( class_exists( 'ATBDP_Pricing_Plans' ) ) {
-            $fee_manager_enabled = get_directorist_option( 'fee_manager_enable', 1 );
-            if ( $fee_manager_enabled ) {
+            if ( $this->is_fee_manager_enabled() ) {
                 $this->active_plugin_type = 'atbdp';
                 return $this->active_plugin_type;
             }
         }
 
-        // Fallback to WooCommerce pricing plans
-        // Check class exists AND admin setting is enabled
         if ( class_exists( 'DWPP_Pricing_Plans' ) ) {
             $woo_pricing_plans_enabled = get_directorist_option( 'woo_pricing_plans_enable', 1 );
             if ( $woo_pricing_plans_enabled ) {
@@ -124,14 +122,35 @@ class Plans_Controller extends Posts_Controller {
         return $this->active_plugin_type;
     }
 
+    protected function is_fee_manager_enabled() {
+        return (bool) get_directorist_option( 'fee_manager_enable', 1 );
+    }
+
+    protected function is_pricing_plan_extension_loaded() {
+        return function_exists( 'directorist_pricing_plan_repository' ) || class_exists( 'ATBDP_Pricing_Plans' ) || class_exists( 'DWPP_Pricing_Plans' );
+    }
+
+    protected function new_pricing_plan_table_exists() {
+        global $wpdb;
+
+        $table = $this->get_new_pricing_plan_table_name();
+
+        return $table === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+    }
+
     public function get_items_permissions_check( $request ) {
-        if ( ! is_fee_manager_active() ) {
-            return new WP_Error( 'extension_inactive', __( 'Pricing plan extension disabled.', 'directorist' ), array( 'status' => 400 ) );
-        }
-        
         $plugin_type = $this->get_active_plugin_type();
+
         if ( ! $plugin_type ) {
-            return new WP_Error( 'extension_inactive', __( 'Pricing plan extension inactive.', 'directorist' ), array( 'status' => 400 ) );
+            $message = $this->is_pricing_plan_extension_loaded()
+                ? __( 'Pricing plan extension disabled.', 'directorist' )
+                : __( 'Pricing plan extension inactive.', 'directorist' );
+
+            return new WP_Error( 'extension_inactive', $message, array( 'status' => 400 ) );
+        }
+
+        if ( 'dpp' === $plugin_type ) {
+            return true;
         }
 
         // Verify post type is registered
@@ -148,13 +167,18 @@ class Plans_Controller extends Posts_Controller {
     }
 
     public function get_item_permissions_check( $request ) {
-        if ( ! is_fee_manager_active() ) {
-            return new WP_Error( 'extension_inactive', __( 'Pricing plan extension disabled.', 'directorist' ), array( 'status' => 400 ) );
-        }
-        
         $plugin_type = $this->get_active_plugin_type();
+
         if ( ! $plugin_type ) {
-            return new WP_Error( 'extension_inactive', __( 'Pricing plan extension inactive.', 'directorist' ), array( 'status' => 400 ) );
+            $message = $this->is_pricing_plan_extension_loaded()
+                ? __( 'Pricing plan extension disabled.', 'directorist' )
+                : __( 'Pricing plan extension inactive.', 'directorist' );
+
+            return new WP_Error( 'extension_inactive', $message, array( 'status' => 400 ) );
+        }
+
+        if ( 'dpp' === $plugin_type ) {
+            return true;
         }
 
         // Verify post type is registered
@@ -174,22 +198,26 @@ class Plans_Controller extends Posts_Controller {
      * @return WP_Error|WP_REST_Response
      */
     public function get_items( $request ) {
+        if ( 'dpp' === $this->get_active_plugin_type() ) {
+            return $this->get_new_pricing_plan_items( $request );
+        }
+
         $query_args = $this->prepare_objects_query( $request );
 
         do_action( 'directorist_rest_before_query', 'get_plan_items', $request, $query_args );
 
         $query_results = $this->get_plans( $query_args );
 
-        $objects = array();
+        $objects     = array();
         $plugin_type = $this->get_active_plugin_type();
-        $post_type = ( 'dwpp' === $plugin_type ) ? 'product' : $this->post_type;
+        $post_type   = ( 'dwpp' === $plugin_type ) ? 'product' : $this->post_type;
         
         foreach ( $query_results['objects'] as $object ) {
             if ( ! $this->check_post_permissions( $post_type, 'read', $object->ID ) ) {
                 continue;
             }
 
-            $data = $this->prepare_item_for_response( $object, $request );
+            $data      = $this->prepare_item_for_response( $object, $request );
             $objects[] = $this->prepare_response_for_collection( $data );
         }
 
@@ -243,6 +271,108 @@ class Plans_Controller extends Posts_Controller {
         );
     }
 
+    protected function get_new_pricing_plan_items( $request ) {
+        $query_args = $this->prepare_new_pricing_plan_query( $request );
+
+        do_action( 'directorist_rest_before_query', 'get_plan_items', $request, $query_args );
+
+        $query_results = $this->get_new_pricing_plans( $query_args );
+        $objects       = array();
+
+        foreach ( $query_results['objects'] as $object ) {
+            $data      = $this->prepare_item_for_response( $object, $request );
+            $objects[] = $this->prepare_response_for_collection( $data );
+        }
+
+        $page      = (int) $query_args['page'];
+        $max_pages = (int) $query_results['pages'];
+        $response  = rest_ensure_response( $objects );
+
+        $response->header( 'X-WP-Total', (int) $query_results['total'] );
+        $response->header( 'X-WP-TotalPages', $max_pages );
+
+        $base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
+
+        if ( $page > 1 ) {
+            $prev_page = min( $page - 1, $max_pages );
+            $response->link_header( 'prev', add_query_arg( 'page', $prev_page, $base ) );
+        }
+
+        if ( $max_pages > $page ) {
+            $response->link_header( 'next', add_query_arg( 'page', $page + 1, $base ) );
+        }
+
+        do_action( 'directorist_rest_after_query', 'get_plan_items', $request, $query_args );
+
+        return apply_filters( 'directorist_rest_response', $response, 'get_plan_items', $request, $query_args );
+    }
+
+    protected function prepare_new_pricing_plan_query( $request ) {
+        $page     = max( 1, (int) ( $request['page'] ? $request['page'] : 1 ) );
+        $per_page = max( 1, min( 100, (int) ( $request['per_page'] ? $request['per_page'] : 10 ) ) );
+
+        $args = array(
+            'directory' => $this->get_new_pricing_plan_directory_filter( $request ),
+            'page'      => $page,
+            'per_page'  => $per_page,
+            'offset'    => ( $page - 1 ) * $per_page,
+            'order'     => ( 'asc' === strtolower( (string) $request['order'] ) ) ? 'ASC' : 'DESC',
+            'orderby'   => ( 'date' === $request['orderby'] ) ? 'created_at' : 'title',
+        );
+
+        return apply_filters( 'directorist_rest_directorist_plan_object_query', $args, $request );
+    }
+
+    protected function get_new_pricing_plan_directory_filter( $request ) {
+        if ( directorist_is_multi_directory_enabled() ) {
+            return absint( $request['directory'] );
+        }
+
+        return (int) directorist_get_default_directory();
+    }
+
+    protected function get_new_pricing_plans( $query_args ) {
+        global $wpdb;
+
+        $table      = $this->get_new_pricing_plan_table_name();
+        $where      = array( 'is_published = 1' );
+        $parameters = array();
+
+        if ( ! empty( $query_args['directory'] ) ) {
+            $where[]      = 'directory_type_id = %d';
+            $parameters[] = (int) $query_args['directory'];
+        }
+
+        $where_sql = implode( ' AND ', $where );
+        $count_sql = "SELECT COUNT(*) FROM {$table} WHERE {$where_sql}";
+
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+        if ( ! empty( $parameters ) ) {
+            $total = (int) $wpdb->get_var( $wpdb->prepare( $count_sql, $parameters ) );
+        } else {
+            $total = (int) $wpdb->get_var( $count_sql );
+        }
+
+        $orderby = ( 'created_at' === $query_args['orderby'] ) ? 'created_at' : 'title';
+        $order   = ( 'ASC' === $query_args['order'] ) ? 'ASC' : 'DESC';
+        $sql     = "SELECT * FROM {$table} WHERE {$where_sql} ORDER BY {$orderby} {$order}, id {$order} LIMIT %d OFFSET %d";
+        $params  = array_merge( $parameters, array( (int) $query_args['per_page'], (int) $query_args['offset'] ) );
+        $objects = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
+        // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+
+        return array(
+            'objects' => $objects ? $objects : array(),
+            'total'   => $total,
+            'pages'   => (int) ceil( $total / (int) $query_args['per_page'] ),
+        );
+    }
+
+    protected function get_new_pricing_plan_table_name() {
+        global $wpdb;
+
+        return $wpdb->prefix . 'directorist_plans';
+    }
+
     /**
      * Prepare objects query.
      *
@@ -251,7 +381,7 @@ class Plans_Controller extends Posts_Controller {
      */
     protected function prepare_objects_query( $request ) {
         $plugin_type = $this->get_active_plugin_type();
-        $post_type = ( 'dwpp' === $plugin_type ) ? 'product' : $this->post_type;
+        $post_type   = ( 'dwpp' === $plugin_type ) ? 'product' : $this->post_type;
 
         $args                   = [];
         $args['order']          = $request['order'];
@@ -271,12 +401,12 @@ class Plans_Controller extends Posts_Controller {
         }
 
         if ( directorist_is_multi_directory_enabled() && ! empty( $request['directory'] ) ) {
-            $args['meta_key'] = '_assign_to_directory';
+            $args['meta_key']   = '_assign_to_directory';
             $args['meta_value'] = $request['directory'];
         }
 
         if ( ! directorist_is_multi_directory_enabled() ) {
-            $args['meta_key'] = '_assign_to_directory';
+            $args['meta_key']   = '_assign_to_directory';
             $args['meta_value'] = directorist_get_default_directory();
         }
 
@@ -319,8 +449,22 @@ class Plans_Controller extends Posts_Controller {
 
         do_action( 'directorist_rest_before_query', 'get_plan_item', $request, $id );
 
-        $post = get_post( $id );
-        $plugin_type = $this->get_active_plugin_type();
+        if ( 'dpp' === $this->get_active_plugin_type() ) {
+            $plan = $this->get_new_pricing_plan( $id );
+
+            if ( ! $plan ) {
+                return new WP_Error( "directorist_rest_invalid_{$this->post_type}_id", __( 'Invalid ID.', 'directorist' ), array( 'status' => 404 ) );
+            }
+
+            $response = $this->prepare_item_for_response( $plan, $request );
+
+            do_action( 'directorist_rest_after_query', 'get_plan_item', $request, (int) $plan->id );
+
+            return apply_filters( 'directorist_rest_response', $response, 'get_plan_item', $request, (int) $plan->id );
+        }
+
+        $post               = get_post( $id );
+        $plugin_type        = $this->get_active_plugin_type();
         $expected_post_type = ( 'dwpp' === $plugin_type ) ? 'product' : $this->post_type;
 
         if ( empty( $id ) || empty( $post->ID ) || $post->post_type !== $expected_post_type ) {
@@ -335,7 +479,7 @@ class Plans_Controller extends Posts_Controller {
             }
         }
 
-        $data = $this->prepare_item_for_response( $post, $request );
+        $data     = $this->prepare_item_for_response( $post, $request );
         $response = rest_ensure_response( $data );
 
         do_action( 'directorist_rest_after_query', 'get_plan_item', $request, $id );
@@ -343,6 +487,37 @@ class Plans_Controller extends Posts_Controller {
         $response = apply_filters( 'directorist_rest_response', $response, 'get_plan_item', $request, $id );
 
         return $response;
+    }
+
+    protected function get_new_pricing_plan( $id ) {
+        global $wpdb;
+
+        $id = $this->get_new_pricing_plan_id( $id );
+
+        if ( ! $id ) {
+            return null;
+        }
+
+        $table = $this->get_new_pricing_plan_table_name();
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is constructed from the WP prefix and a known extension table.
+        $plan = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d AND is_published = 1", $id ) );
+
+        return $plan ? $plan : null;
+    }
+
+    protected function get_new_pricing_plan_id( $id ) {
+        $id = absint( $id );
+
+        if ( ! $id ) {
+            return 0;
+        }
+
+        if ( function_exists( 'directorist_pricing_plans_legacy_plan_id' ) ) {
+            return absint( directorist_pricing_plans_legacy_plan_id( $id ) );
+        }
+
+        return $id;
     }
 
     /**
@@ -358,8 +533,8 @@ class Plans_Controller extends Posts_Controller {
         $this->request = $request;
         $data          = $this->get_plan_data( $object, $request, $context );
 
-        $data     = $this->add_additional_fields_to_object( $data, $request );
-        $data     = $this->filter_response_by_context( $data, $context );
+        $data = $this->add_additional_fields_to_object( $data, $request );
+        $data = $this->filter_response_by_context( $data, $context );
 
         $response = rest_ensure_response( $data );
         $response->add_links( $this->prepare_links( $object, $request ) );
@@ -392,8 +567,8 @@ class Plans_Controller extends Posts_Controller {
      */
     protected function get_plan_meta( $plan, $meta_key, $dwpp_meta_key = null, $default = '' ) {
         $plugin_type = $this->get_active_plugin_type();
-        $key = ( 'dwpp' === $plugin_type && null !== $dwpp_meta_key ) ? $dwpp_meta_key : $meta_key;
-        $value = get_post_meta( $plan->ID, $key, true );
+        $key         = ( 'dwpp' === $plugin_type && null !== $dwpp_meta_key ) ? $dwpp_meta_key : $meta_key;
+        $value       = get_post_meta( $plan->ID, $key, true );
         return ( '' !== $value ) ? $value : $default;
     }
 
@@ -431,7 +606,11 @@ class Plans_Controller extends Posts_Controller {
      * @return array
      */
     protected function get_plan_data( $plan, $request, $context = 'view' ) {
-        $fields  = $this->get_fields_for_response( $request );
+        if ( 'dpp' === $this->get_active_plugin_type() ) {
+            return $this->get_new_pricing_plan_data( $plan, $request );
+        }
+
+        $fields = $this->get_fields_for_response( $request );
 
         $base_data = array();
         foreach ( $fields as $field ) {
@@ -490,7 +669,7 @@ class Plans_Controller extends Posts_Controller {
                 case 'is_free':
                     $plugin_type = $this->get_active_plugin_type();
                     if ( 'dwpp' === $plugin_type ) {
-                        $product = wc_get_product( $plan->ID );
+                        $product              = wc_get_product( $plan->ID );
                         $base_data['is_free'] = $product ? ( (float) $product->get_price() <= 0 ) : false;
                     } else {
                         $base_data['is_free'] = (bool) $this->get_plan_meta( $plan, 'free_plan' );
@@ -544,6 +723,403 @@ class Plans_Controller extends Posts_Controller {
         return $base_data;
     }
 
+    protected function get_new_pricing_plan_data( $plan, $request ) {
+        $fields = $this->get_fields_for_response( $request );
+        $data   = array();
+
+        foreach ( $fields as $field ) {
+            switch ( $field ) {
+                case 'id':
+                    $data['id'] = (int) $plan->id;
+                    break;
+                case 'name':
+                    $data['name'] = (string) $plan->title;
+                    break;
+                case 'slug':
+                    $data['slug'] = sanitize_title( $plan->title );
+                    break;
+                case 'date_created':
+                    $data['date_created'] = $this->format_new_pricing_plan_date( isset( $plan->created_at ) ? $plan->created_at : '', false );
+                    break;
+                case 'date_created_gmt':
+                    $data['date_created_gmt'] = $this->format_new_pricing_plan_date( isset( $plan->created_at ) ? $plan->created_at : '', true );
+                    break;
+                case 'date_modified':
+                    $data['date_modified'] = $this->format_new_pricing_plan_date( isset( $plan->updated_at ) ? $plan->updated_at : '', false );
+                    break;
+                case 'date_modified_gmt':
+                    $data['date_modified_gmt'] = $this->format_new_pricing_plan_date( isset( $plan->updated_at ) ? $plan->updated_at : '', true );
+                    break;
+                case 'description':
+                    $data['description'] = (string) ( isset( $plan->description ) ? $plan->description : '' );
+                    break;
+                case 'hide_description_from_plan':
+                    $data['hide_description_from_plan'] = false;
+                    break;
+                case 'directory':
+                    $data['directory'] = (int) $plan->directory_type_id;
+                    break;
+                case 'status':
+                    $data['status'] = ! empty( $plan->is_published ) ? 'publish' : 'draft';
+                    break;
+                case 'is_recommended':
+                    $data['is_recommended'] = (bool) $plan->is_marked_as_recommended;
+                    break;
+                case 'is_hidden':
+                    $data['is_hidden'] = (bool) $plan->is_hidden_from_plans_list;
+                    break;
+                case 'type':
+                    $data['type'] = $this->get_new_pricing_plan_type( $plan );
+                    break;
+                case 'type_label':
+                    $data['type_label'] = ( 'package' === $this->get_new_pricing_plan_type( $plan ) ) ? esc_html__( 'Per Package', 'directorist' ) : esc_html__( 'Per Listing', 'directorist' );
+                    break;
+                case 'currency':
+                    $data['currency'] = atbdp_get_payment_currency();
+                    break;
+                case 'currency_symbol':
+                    $data['currency_symbol'] = html_entity_decode( atbdp_currency_symbol( atbdp_get_payment_currency() ) );
+                    break;
+                case 'is_free':
+                    $data['is_free'] = ( 'free' === ( isset( $plan->fee_type ) ? $plan->fee_type : '' ) );
+                    break;
+                case 'price':
+                    $data['price'] = ( 'free' === ( isset( $plan->fee_type ) ? $plan->fee_type : '' ) ) ? 0 : (float) $plan->price;
+                    break;
+                case 'is_taxable':
+                    $data['is_taxable'] = (bool) $plan->is_taxable;
+                    break;
+                case 'tax_type':
+                    $data['tax_type'] = ( 'percent' === ( isset( $plan->tax_type ) ? $plan->tax_type : '' ) ) ? 'percentage' : 'fixed';
+                    break;
+                case 'tax':
+                    $data['tax'] = (float) $plan->tax_rate;
+                    break;
+                case 'validity_period':
+                    $data['validity_period'] = ( 'lifetime' === ( isset( $plan->interval_type ) ? $plan->interval_type : '' ) ) ? 0 : (int) $plan->interval_count;
+                    break;
+                case 'validity_period_unit':
+                    $data['validity_period_unit'] = $this->get_new_pricing_plan_validity_period_unit( $plan );
+                    break;
+                case 'validity_period_label':
+                    $data['validity_period_label'] = $this->get_new_pricing_plan_validity_period_label( $plan );
+                    break;
+                case 'is_non_expiring':
+                    $data['is_non_expiring'] = ( 'lifetime' === ( isset( $plan->interval_type ) ? $plan->interval_type : '' ) );
+                    break;
+                case 'playstore_product_id':
+                case 'playstore_product_price':
+                case 'appstore_product_id':
+                case 'appstore_product_price':
+                    $data[ $field ] = $this->get_new_pricing_plan_app_configuration_value( (int) $plan->id, $field );
+                    break;
+                case 'features':
+                    $data['features'] = $this->get_new_pricing_plan_features_data( $plan );
+                    break;
+                case 'fields':
+                    $data['fields'] = $this->get_new_pricing_plan_fields_data( $plan );
+                    break;
+            }
+        }
+
+        return $data;
+    }
+
+    protected function format_new_pricing_plan_date( $date, $gmt ) {
+        if ( '' === $date || '0000-00-00 00:00:00' === $date ) {
+            return null;
+        }
+
+        return directorist_rest_prepare_date_response( $date, $gmt );
+    }
+
+    protected function get_new_pricing_plan_type( $plan ) {
+        return ( 'pay_per_listing' === ( isset( $plan->type ) ? $plan->type : '' ) ) ? 'pay_per_listing' : 'package';
+    }
+
+    protected function get_new_pricing_plan_validity_period_unit( $plan ) {
+        $unit = (string) ( isset( $plan->interval_type ) ? $plan->interval_type : 'day' );
+
+        return in_array( $unit, array( 'day', 'week', 'month', 'year' ), true ) ? $unit : 'day';
+    }
+
+    protected function get_new_pricing_plan_validity_period_label( $plan ) {
+        if ( 'lifetime' === ( isset( $plan->interval_type ) ? $plan->interval_type : '' ) ) {
+            return esc_html__( 'Lifetime', 'directorist' );
+        }
+
+        $validity_period = max( 0, (int) $plan->interval_count );
+        $translations    = array(
+            /* translators: %d: Number of days */
+            'day'   => _n( '%d day', '%d days', $validity_period, 'directorist' ),
+            /* translators: %d: Number of weeks */
+            'week'  => _n( '%d week', '%d weeks', $validity_period, 'directorist' ),
+            /* translators: %d: Number of months */
+            'month' => _n( '%d month', '%d months', $validity_period, 'directorist' ),
+            /* translators: %d: Number of years */
+            'year'  => _n( '%d year', '%d years', $validity_period, 'directorist' ),
+        );
+
+        return sprintf( $translations[ $this->get_new_pricing_plan_validity_period_unit( $plan ) ], $validity_period );
+    }
+
+    protected function get_new_pricing_plan_app_configuration_value( $plan_id, $field ) {
+        static $cache = array();
+
+        if ( ! isset( $cache[ $plan_id ] ) ) {
+            $cache[ $plan_id ] = $this->get_new_pricing_plan_app_configurations( $plan_id );
+        }
+
+        $field_map = array(
+            'playstore_product_id'    => array( 'playstore', 'product_id' ),
+            'playstore_product_price' => array( 'playstore', 'product_price' ),
+            'appstore_product_id'     => array( 'appstore', 'product_id' ),
+            'appstore_product_price'  => array( 'appstore', 'product_price' ),
+        );
+
+        if ( ! isset( $field_map[ $field ] ) ) {
+            return '';
+        }
+
+        list( $type, $property ) = $field_map[ $field ];
+
+        foreach ( $cache[ $plan_id ] as $configuration ) {
+            if ( $type === ( isset( $configuration->type ) ? $configuration->type : '' ) ) {
+                return isset( $configuration->$property ) ? $configuration->$property : '';
+            }
+        }
+
+        return '';
+    }
+
+    protected function get_new_pricing_plan_app_configurations( $plan_id ) {
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'directorist_plan_app_configurations';
+
+        if ( $table !== $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) ) {
+            return array();
+        }
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is constructed from the WP prefix and a known extension table.
+        $configurations = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE plan_id = %d", $plan_id ) );
+
+        return $configurations ? $configurations : array();
+    }
+
+    protected function get_new_pricing_plan_features_data( $plan ) {
+        $features = array(
+            array(
+                'key'            => 'auto_renewal',
+                'label'          => esc_html__( 'Auto renewing', 'directorist' ),
+                'is_active'      => (bool) $plan->is_subscription_enabled,
+                'hide_from_plan' => false,
+            ),
+        );
+
+        if ( 'package' === $this->get_new_pricing_plan_type( $plan ) ) {
+            $features[] = array(
+                'key'            => 'regular_listings',
+                'label'          => $this->get_new_pricing_plan_listing_limit_label( 'regular', (int) $plan->allowed_listings, (bool) $plan->is_allowed_unlimited_listings ),
+                'is_active'      => true,
+                'hide_from_plan' => false,
+                'limit'          => (bool) $plan->is_allowed_unlimited_listings ? -1 : (int) $plan->allowed_listings,
+            );
+            $features[] = array(
+                'key'            => 'featured_listings',
+                'label'          => $this->get_new_pricing_plan_listing_limit_label( 'featured', (int) $plan->allowed_featured_listings, (bool) $plan->is_allowed_unlimited_featured_listings ),
+                'is_active'      => true,
+                'hide_from_plan' => false,
+                'limit'          => (bool) $plan->is_allowed_unlimited_featured_listings ? -1 : (int) $plan->allowed_featured_listings,
+            );
+        } else {
+            $features[] = array(
+                'key'            => 'featured_listing',
+                'label'          => esc_html__( 'Listing as featured', 'directorist' ),
+                'is_active'      => (bool) $plan->is_featured,
+                'hide_from_plan' => false,
+            );
+        }
+
+        return array_merge( $features, $this->get_new_pricing_plan_extra_features_data( $plan ) );
+    }
+
+    protected function get_new_pricing_plan_extra_features_data( $plan ) {
+        $features = array();
+        $map      = array(
+            'contact_listings_owner'  => array( 'contact_listing_owner', esc_html__( 'Contact Owner', 'directorist' ) ),
+            'review'                  => array( 'reviews_allowed', esc_html__( 'Allow Customer Review', 'directorist' ) ),
+            'claim_listing'           => array( 'claim_badge_included', esc_html__( 'Claim Badge Included', 'directorist' ) ),
+            'bdb'                     => array( 'booking_included', esc_html__( 'Booking Included', 'directorist' ) ),
+            'live_chat'               => array( 'live_chat_included', esc_html__( 'Live Chat Included', 'directorist' ) ),
+            'sold_badge'              => array( 'mark_as_sold_included', esc_html__( 'Mark as Sold Included', 'directorist' ) ),
+            'admin_category_select[]' => array( 'categories_included', esc_html__( 'All Categories', 'directorist' ) ),
+        );
+
+        foreach ( $this->get_new_pricing_plan_features( $plan ) as $feature ) {
+            $key = (string) ( isset( $feature->key ) ? $feature->key : '' );
+
+            if ( ! isset( $map[ $key ] ) ) {
+                continue;
+            }
+
+            $features[] = array(
+                'key'            => $map[ $key ][0],
+                'label'          => $map[ $key ][1],
+                'is_active'      => (bool) ( isset( $feature->is_enabled ) ? $feature->is_enabled : false ),
+                'hide_from_plan' => ! (bool) ( isset( $feature->is_show_in_pricing_table ) ? $feature->is_show_in_pricing_table : false ),
+            );
+        }
+
+        return $features;
+    }
+
+    protected function get_new_pricing_plan_listing_limit_label( $type, $count, $unlimited ) {
+        if ( 'regular' === $type ) {
+            return $unlimited
+                ? __( 'Unlimited Regular Listings', 'directorist' )
+                : sprintf( _n( '%s Regular Listing', '%s Regular Listings', $count, 'directorist' ), $count );
+        }
+
+        return $unlimited
+            ? __( 'Unlimited Featured Listings', 'directorist' )
+            : sprintf( _n( '%s Featured Listing', '%s Featured Listings', $count, 'directorist' ), $count );
+    }
+
+    protected function get_new_pricing_plan_fields_data( $plan ) {
+        $field_data = array();
+        $skip_keys  = array( 'review', 'contact_listings_owner', 'claim_listing', 'bdb', 'live_chat', 'sold_badge' );
+
+        foreach ( $this->get_new_pricing_plan_features( $plan ) as $feature ) {
+            $key = (string) ( isset( $feature->key ) ? $feature->key : '' );
+
+            if ( in_array( $key, $skip_keys, true ) ) {
+                continue;
+            }
+
+            $data = array(
+                'key'            => $key,
+                'label'          => (string) ( isset( $feature->name ) ? $feature->name : $key ),
+                'is_preset'      => $this->is_new_pricing_plan_preset_field( $key ),
+                'is_active'      => (bool) ( isset( $feature->is_enabled ) ? $feature->is_enabled : false ),
+                'hide_from_plan' => ! (bool) ( isset( $feature->is_show_in_pricing_table ) ? $feature->is_show_in_pricing_table : false ),
+            );
+
+            $feature_data = array();
+            if ( isset( $feature->data ) ) {
+                $feature_data = is_array( $feature->data ) ? $feature->data : (array) $feature->data;
+            }
+
+            if ( ! empty( $feature_data['is_unlimited'] ) ) {
+                $data['label'] = sprintf( __( '%s (unlimited)', 'directorist' ), $data['label'] );
+                $data['limit'] = -1;
+            } elseif ( isset( $feature_data['limit'] ) && '' !== $feature_data['limit'] ) {
+                $data['limit'] = (int) $feature_data['limit'];
+            }
+
+            $field_data[] = $data;
+        }
+
+        return $field_data;
+    }
+
+    protected function get_new_pricing_plan_features( $plan ) {
+        static $cache = array();
+
+        $plan_id = (int) $plan->id;
+
+        if ( isset( $cache[ $plan_id ] ) ) {
+            return $cache[ $plan_id ];
+        }
+
+        $cache[ $plan_id ] = $this->get_new_pricing_plan_features_from_repository( $plan );
+
+        if ( null === $cache[ $plan_id ] ) {
+            $cache[ $plan_id ] = $this->get_new_pricing_plan_features_from_table( $plan );
+        }
+
+        return $cache[ $plan_id ];
+    }
+
+    protected function get_new_pricing_plan_features_from_repository( $plan ) {
+        if ( ! function_exists( 'directorist_pricing_plans_singleton' ) || ! class_exists( 'DirectoristPricingPlan\App\Repositories\Admin\PlanFeatureRepository' ) ) {
+            return null;
+        }
+
+        try {
+            $repository = directorist_pricing_plans_singleton( 'DirectoristPricingPlan\App\Repositories\Admin\PlanFeatureRepository' );
+
+            if ( is_object( $repository ) && method_exists( $repository, 'get' ) ) {
+                return $repository->get( $plan );
+            }
+        } catch ( \Throwable $exception ) {
+            return null;
+        }
+
+        return null;
+    }
+
+    protected function get_new_pricing_plan_features_from_table( $plan ) {
+        global $wpdb;
+
+        $registered_features = $this->get_new_pricing_plan_registered_features( (int) $plan->directory_type_id );
+        $features            = array();
+        $table               = $wpdb->prefix . 'directorist_plan_features';
+
+        if ( $table === $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) ) {
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is constructed from the WP prefix and a known extension table.
+            $db_features = $wpdb->get_results( $wpdb->prepare( "SELECT feature_key, is_enabled, is_show_in_pricing_table, data FROM {$table} WHERE plan_id = %d ORDER BY sort_order ASC, id ASC", (int) $plan->id ) );
+
+            foreach ( $db_features as $feature ) {
+                $key  = (string) $feature->feature_key;
+                $data = isset( $registered_features[ $key ] ) ? (object) $registered_features[ $key ] : new \stdClass();
+
+                $data->key                      = $key;
+                $data->name                     = isset( $data->name ) ? $data->name : $key;
+                $data->is_enabled               = (bool) $feature->is_enabled;
+                $data->is_show_in_pricing_table = (bool) $feature->is_show_in_pricing_table;
+                $data->data                     = ! empty( $feature->data ) ? json_decode( $feature->data, true ) : array();
+                $features[]                     = $data;
+
+                unset( $registered_features[ $key ] );
+            }
+        }
+
+        foreach ( $registered_features as $key => $feature ) {
+            $data      = (object) $feature;
+            $data->key = (string) $key;
+
+            $features[] = $data;
+        }
+
+        return $features;
+    }
+
+    protected function get_new_pricing_plan_registered_features( $directory_id ) {
+        if ( function_exists( 'directorist_plan_registered_features' ) ) {
+            return directorist_plan_registered_features( $directory_id );
+        }
+
+        return array();
+    }
+
+    protected function is_new_pricing_plan_preset_field( $key ) {
+        return in_array(
+            $key,
+            array(
+                'tax_input[at_biz_dir-location][]',
+                'admin_category_select[]',
+                'tax_input[at_biz_dir-tags][]',
+                'listing_content',
+                'excerpt',
+                'listing_img',
+                'price',
+                'price_range',
+            ),
+            true
+        );
+    }
+
     protected function get_validity_period_label( $plan ) {
         $is_non_expiring = (bool) $this->get_plan_meta( $plan, 'fm_length_unl', 'fm_length_unl' );
 
@@ -593,13 +1169,13 @@ class Plans_Controller extends Posts_Controller {
     }
 
     protected function get_features_data( $plan ) {
-        $features = array();
+        $features    = array();
         $plugin_type = $this->get_active_plugin_type();
 
         // Auto renewal
-        $recurring_key = ( 'dwpp' === $plugin_type ) ? '_enable_subscription' : '_atpp_recurring';
+        $recurring_key      = ( 'dwpp' === $plugin_type ) ? '_enable_subscription' : '_atpp_recurring';
         $hide_recurring_key = ( 'dwpp' === $plugin_type ) ? '_hide_subscription' : 'hide_recurring';
-        $features[] = array(
+        $features[]         = array(
             'key'            => 'auto_renewal',
             'label'          => esc_html__( 'Auto renewing', 'directorist' ),
             'is_active'      => (bool) $this->get_plan_meta( $plan, '_atpp_recurring', $recurring_key ),
@@ -607,7 +1183,7 @@ class Plans_Controller extends Posts_Controller {
         );
 
         if ( $this->get_plan_type( $plan ) === 'package' ) {
-            $regular_listing_count = (int) $this->get_plan_meta( $plan, 'num_regular', 'num_regular', 0 );
+            $regular_listing_count      = (int) $this->get_plan_meta( $plan, 'num_regular', 'num_regular', 0 );
             $unlimited_regular_listings = (bool) $this->get_plan_meta( $plan, 'num_regular_unl', 'num_regular_unl' );
 
             if ( $unlimited_regular_listings ) {
@@ -617,7 +1193,7 @@ class Plans_Controller extends Posts_Controller {
             }
 
             $hide_listings_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_listings' : 'hide_listings';
-            $features[] = array(
+            $features[]        = array(
                 'key'            => 'regular_listings',
                 'label'          => $regular_listing_label,
                 'is_active'      => true,
@@ -625,7 +1201,7 @@ class Plans_Controller extends Posts_Controller {
                 'limit'          => $unlimited_regular_listings ? -1 : $regular_listing_count,
             );
 
-            $featured_listing_count = (int) $this->get_plan_meta( $plan, 'num_featured', 'num_featured', 0 );
+            $featured_listing_count      = (int) $this->get_plan_meta( $plan, 'num_featured', 'num_featured', 0 );
             $unlimited_featured_listings = (bool) $this->get_plan_meta( $plan, 'num_featured_unl', 'num_featured_unl' );
 
             if ( $unlimited_featured_listings ) {
@@ -635,7 +1211,7 @@ class Plans_Controller extends Posts_Controller {
             }
 
             $hide_featured_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_featured' : 'hide_featured';
-            $features[] = array(
+            $features[]        = array(
                 'key'            => 'featured_listings',
                 'label'          => $featured_listing_label,
                 'is_active'      => true,
@@ -644,7 +1220,7 @@ class Plans_Controller extends Posts_Controller {
             );
         } else {
             $hide_listing_featured_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_listing_featured' : 'hide_listing_featured';
-            $features[] = array(
+            $features[]                = array(
                 'key'            => 'featured_listing',
                 'label'          => esc_html__( 'Listing as featured', 'directorist' ),
                 'is_active'      => (bool) $this->get_plan_meta( $plan, 'is_featured_listing', 'is_featured_listing' ),
@@ -653,7 +1229,7 @@ class Plans_Controller extends Posts_Controller {
         }
 
         $hide_cl_owner_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_cl_owner' : 'hide_Cowner';
-        $features[] = array(
+        $features[]        = array(
             'key'            => 'contact_listing_owner',
             'label'          => esc_html__( 'Contact Owner', 'directorist' ),
             'is_active'      => (bool) $this->get_plan_meta( $plan, 'cf_owner', 'cf_owner' ),
@@ -661,7 +1237,7 @@ class Plans_Controller extends Posts_Controller {
         );
 
         $hide_customer_review_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_customer_review' : 'hide_review';
-        $features[] = array(
+        $features[]               = array(
             'key'            => 'reviews_allowed',
             'label'          => esc_html__( 'Allow Customer Review', 'directorist' ),
             'is_active'      => (bool) $this->get_plan_meta( $plan, 'fm_cs_review', 'fm_cs_review' ),
@@ -669,7 +1245,7 @@ class Plans_Controller extends Posts_Controller {
         );
 
         $hide_claim_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_claim' : '_hide_claim';
-        $features[] = array(
+        $features[]     = array(
             'key'            => 'claim_badge_included',
             'label'          => esc_html__( 'Claim Badge Included', 'directorist' ),
             'is_active'      => (bool) $this->get_plan_meta( $plan, '_fm_claim', '_fm_claim' ),
@@ -677,7 +1253,7 @@ class Plans_Controller extends Posts_Controller {
         );
 
         $hide_booking_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_booking' : '_hide_booking';
-        $features[] = array(
+        $features[]       = array(
             'key'            => 'booking_included',
             'label'          => esc_html__( 'Booking Included', 'directorist' ),
             'is_active'      => (bool) $this->get_plan_meta( $plan, '_fm_booking', '_fm_booking' ),
@@ -685,7 +1261,7 @@ class Plans_Controller extends Posts_Controller {
         );
 
         $hide_live_chat_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_live_chat' : '_hide_live_chat';
-        $features[] = array(
+        $features[]         = array(
             'key'            => 'live_chat_included',
             'label'          => esc_html__( 'Live Chat Included', 'directorist' ),
             'is_active'      => (bool) $this->get_plan_meta( $plan, '_fm_live_chat', '_fm_live_chat' ),
@@ -693,7 +1269,7 @@ class Plans_Controller extends Posts_Controller {
         );
 
         $hide_mark_as_sold_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_mark_as_sold' : '_hide_mark_as_sold';
-        $features[] = array(
+        $features[]            = array(
             'key'            => 'mark_as_sold_included',
             'label'          => esc_html__( 'Mark as Sold Included', 'directorist' ),
             'is_active'      => (bool) $this->get_plan_meta( $plan, '_fm_mark_as_sold', '_fm_mark_as_sold' ),
@@ -701,7 +1277,7 @@ class Plans_Controller extends Posts_Controller {
         );
 
         $hide_category_key = ( 'dwpp' === $plugin_type ) ? '_dwpp_hide_category' : 'hide_categories';
-        $features[] = array(
+        $features[]        = array(
             'key'            => 'categories_included',
             'label'          => esc_html__( 'All Categories', 'directorist' ),
             'is_active'      => (bool) $this->get_plan_meta( $plan, 'exclude_cat', 'exclude_cat' ),
@@ -723,8 +1299,8 @@ class Plans_Controller extends Posts_Controller {
             'excerpt'      => _n_noop( '%s (maximum %d character)', '%s (maximum %d characters)', 'directorist' ),
             'image_upload' => _n_noop( '%s (maximum %d item)', '%s (maximum %d items)', 'directorist' ),
         );
-        $fields     = array_keys( $translations );
-        $field_data = array();
+        $fields       = array_keys( $translations );
+        $field_data   = array();
 
         foreach ( $form_fields as $form_field ) {
             $field_key = $form_field['field_key'];
@@ -749,19 +1325,19 @@ class Plans_Controller extends Posts_Controller {
                 continue;
             }
 
-            $plugin_type = $this->get_active_plugin_type();
-            $active_key = '_' . $field_key;
-            $hide_key = '_hide_' . $field_key;
+            $plugin_type   = $this->get_active_plugin_type();
+            $active_key    = '_' . $field_key;
+            $hide_key      = '_hide_' . $field_key;
             $unlimited_key = '_unlimited_' . $field_key;
-            $max_key = '_max_' . $field_key;
+            $max_key       = '_max_' . $field_key;
             
             // For WooCommerce, check if it uses _dwpp_ prefix
             if ( 'dwpp' === $plugin_type ) {
                 // Try _dwpp_ prefix first, fallback to regular
                 $dwpp_active = get_post_meta( $plan->ID, '_dwpp_' . $field_key, true );
-                $dwpp_hide = get_post_meta( $plan->ID, '_dwpp_hide_' . $field_key, true );
-                $active_key = ( '' !== $dwpp_active || '' !== $dwpp_hide ) ? '_dwpp_' . $field_key : $active_key;
-                $hide_key = ( '' !== $dwpp_hide ) ? '_dwpp_hide_' . $field_key : $hide_key;
+                $dwpp_hide   = get_post_meta( $plan->ID, '_dwpp_hide_' . $field_key, true );
+                $active_key  = ( '' !== $dwpp_active || '' !== $dwpp_hide ) ? '_dwpp_' . $field_key : $active_key;
+                $hide_key    = ( '' !== $dwpp_hide ) ? '_dwpp_hide_' . $field_key : $hide_key;
             }
 
             $data = array(
@@ -805,9 +1381,11 @@ class Plans_Controller extends Posts_Controller {
      * @return array Links for the given post.
      */
     protected function prepare_links( $object, $request ) {
+        $object_id = isset( $object->ID ) ? (int) $object->ID : (int) $object->id;
+
         $links = array(
             'self'       => array(
-				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $object->ID ) ),  // @codingStandardsIgnoreLine.
+				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $object_id ) ),  // @codingStandardsIgnoreLine.
             ),
             'collection' => array(
 				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),  // @codingStandardsIgnoreLine.
@@ -823,142 +1401,142 @@ class Plans_Controller extends Posts_Controller {
      * @return array
      */
     public function get_item_schema() {
-        $schema         = array(
+        $schema = array(
             '$schema'    => 'http://json-schema.org/draft-04/schema#',
             'title'      => $this->post_type,
             'type'       => 'object',
             'properties' => array(
-                'id'                    => array(
+                'id'                         => array(
                     'description' => __( 'Unique identifier for the resource.', 'directorist' ),
                     'type'        => 'integer',
                     'context'     => array( 'view', 'edit' ),
                     'readonly'    => true,
                 ),
-                'name'                  => array(
+                'name'                       => array(
                     'description' => __( 'plan name.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'date_created'          => array(
+                'date_created'               => array(
                     'description' => __( "The date the plan was created, in the site's timezone.", 'directorist' ),
                     'type'        => 'date-time',
                     'context'     => array( 'view', 'edit' ),
                     'readonly'    => true,
                 ),
-                'date_modified'         => array(
+                'date_modified'              => array(
                     'description' => __( "The date the plan was last modified, in the site's timezone.", 'directorist' ),
                     'type'        => 'date-time',
                     'context'     => array( 'view', 'edit' ),
                     'readonly'    => true,
                 ),
-                'description'           => array(
+                'description'                => array(
                     'description' => __( 'Plan description.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'hide_description_from_plan'           => array(
+                'hide_description_from_plan' => array(
                     'description' => __( 'Hide description from plan.', 'directorist' ),
                     'type'        => 'boolean',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'directory' => array(
+                'directory'                  => array(
                     'description' => __( 'Directory id.', 'directorist' ),
                     'type'        => 'integer',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'status'     => array(
+                'status'                     => array(
                     'description' => __( 'Plan status.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'is_recommended'     => array(
+                'is_recommended'             => array(
                     'description' => __( 'Plan recommendation status.', 'directorist' ),
                     'type'        => 'boolean',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'is_hidden'     => array(
+                'is_hidden'                  => array(
                     'description' => __( 'Plan hidden during plan selection.', 'directorist' ),
                     'type'        => 'boolean',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'type'     => array(
+                'type'                       => array(
                     'description' => __( 'Plan type.', 'directorist' ),
                     'type'        => 'string',
                     'enum'        => array( 'package', 'pay_per_listing' ),
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'type_label'     => array(
+                'type_label'                 => array(
                     'description' => __( 'Plan type label.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'currency'     => array(
+                'currency'                   => array(
                     'description' => __( 'Plan currency.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'currency_symbol'     => array(
+                'currency_symbol'            => array(
                     'description' => __( 'Plan currency symbol.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'is_free'     => array(
+                'is_free'                    => array(
                     'description' => __( 'Is plan free?.', 'directorist' ),
                     'type'        => 'boolean',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'price'     => array(
+                'price'                      => array(
                     'description' => __( 'Plan price.', 'directorist' ),
                     'type'        => 'float',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'is_taxable'     => array(
+                'is_taxable'                 => array(
                     'description' => __( 'Is plan taxable?', 'directorist' ),
                     'type'        => 'boolean',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'tax_type'     => array(
+                'tax_type'                   => array(
                     'description' => __( 'Plan tax type', 'directorist' ),
                     'type'        => 'string',
                     'enum'        => array( 'fixed', 'percentage' ),
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'tax'     => array(
+                'tax'                        => array(
                     'description' => __( 'Plan tax amount.', 'directorist' ),
                     'type'        => 'float',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'validity_period'     => array(
+                'validity_period'            => array(
                     'description' => __( 'Plan validity period.', 'directorist' ),
                     'type'        => 'integer',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'validity_period_unit'     => array(
+                'validity_period_unit'       => array(
                     'description' => __( 'Plan validity period unit.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'validity_period_label'     => array(
+                'validity_period_label'      => array(
                     'description' => __( 'Plan validity period label.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'is_non_expiring'    => array(
+                'is_non_expiring'            => array(
                     'description' => __( 'Is plan non expiring?', 'directorist' ),
                     'type'        => 'boolean',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'playstore_product_id'     => array(
+                'playstore_product_id'       => array(
                     'description' => __( 'PlayStore product Id.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'playstore_product_price'     => array(
+                'playstore_product_price'    => array(
                     'description' => __( 'PlayStore product price.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'appstore_product_id'     => array(
+                'appstore_product_id'        => array(
                     'description' => __( 'AppStore product Id.', 'directorist' ),
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
@@ -968,25 +1546,25 @@ class Plans_Controller extends Posts_Controller {
                     'type'        => 'string',
                     'context'     => array( 'view', 'edit' ),
                 ),
-                'features'             => array(
+                'features'                   => array(
                     'description' => __( 'Features data.', 'directorist' ),
                     'type'        => 'array',
                     'context'     => array( 'view', 'edit' ),
                     'items'       => array(
                         'type'       => 'object',
                         'properties' => array(
-                            'key'    => array(
+                            'key'            => array(
                                 'description' => __( 'Feature key.', 'directorist' ),
                                 'type'        => 'string',
                                 'context'     => array( 'view', 'edit' ),
                                 'readonly'    => true,
                             ),
-                            'label' => array(
+                            'label'          => array(
                                 'description' => __( 'Feature label.', 'directorist' ),
                                 'type'        => 'string',
                                 'context'     => array( 'view', 'edit' ),
                             ),
-                            'is_active' => array(
+                            'is_active'      => array(
                                 'description' => __( 'Feature active status.', 'directorist' ),
                                 'type'        => 'bool',
                                 'context'     => array( 'view', 'edit' ),
@@ -996,7 +1574,7 @@ class Plans_Controller extends Posts_Controller {
                                 'type'        => 'bool',
                                 'context'     => array( 'view', 'edit' ),
                             ),
-                            'limit' => array(
+                            'limit'          => array(
                                 'description' => __( 'Feature limited to number of times (-1 indicates unlimited).', 'directorist' ),
                                 'type'        => 'number',
                                 'context'     => array( 'view', 'edit' ),
@@ -1004,30 +1582,30 @@ class Plans_Controller extends Posts_Controller {
                         ),
                     ),
                 ),
-                'fields'             => array(
+                'fields'                     => array(
                     'description' => __( 'Fields data.', 'directorist' ),
                     'type'        => 'array',
                     'context'     => array( 'view', 'edit' ),
                     'items'       => array(
                         'type'       => 'object',
                         'properties' => array(
-                            'key'    => array(
+                            'key'            => array(
                                 'description' => __( 'Field key.', 'directorist' ),
                                 'type'        => 'string',
                                 'context'     => array( 'view', 'edit' ),
                                 'readonly'    => true,
                             ),
-                            'label' => array(
+                            'label'          => array(
                                 'description' => __( 'Field label.', 'directorist' ),
                                 'type'        => 'string',
                                 'context'     => array( 'view', 'edit' ),
                             ),
-                            'is_preset' => array(
+                            'is_preset'      => array(
                                 'description' => __( 'Preset or custom field status.', 'directorist' ),
                                 'type'        => 'bool',
                                 'context'     => array( 'view', 'edit' ),
                             ),
-                            'is_active' => array(
+                            'is_active'      => array(
                                 'description' => __( 'Field active status.', 'directorist' ),
                                 'type'        => 'bool',
                                 'context'     => array( 'view', 'edit' ),
@@ -1037,7 +1615,7 @@ class Plans_Controller extends Posts_Controller {
                                 'type'        => 'bool',
                                 'context'     => array( 'view', 'edit' ),
                             ),
-                            'limit' => array(
+                            'limit'          => array(
                                 'description' => __( 'Feature limited to number of times (-1 indicates unlimited).', 'directorist' ),
                                 'type'        => 'number',
                                 'context'     => array( 'view', 'edit' ),
@@ -1061,26 +1639,26 @@ class Plans_Controller extends Posts_Controller {
 
         $params['context']['default'] = 'view';
 
-        $params['order'] = array(
-            'default'            => 'desc',
-            'description'        => __( 'Order sort attribute ascending or descending.', 'directorist' ),
-            'enum'               => array( 'asc', 'desc' ),
-            'type'               => 'string',
-            'sanitize_callback'  => 'sanitize_key',
+        $params['order']   = array(
+            'default'           => 'desc',
+            'description'       => __( 'Order sort attribute ascending or descending.', 'directorist' ),
+            'enum'              => array( 'asc', 'desc' ),
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_key',
         );
         $params['orderby'] = array(
-            'description'        => __( 'Sort collection by object attribute.', 'directorist' ),
-            'enum'               => array_keys( $this->get_orderby_possibles() ),
-            'default'            => 'title',
-            'type'               => 'string',
-            'sanitize_callback'  => 'sanitize_key',
+            'description'       => __( 'Sort collection by object attribute.', 'directorist' ),
+            'enum'              => array_keys( $this->get_orderby_possibles() ),
+            'default'           => 'title',
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_key',
         );
 
         if ( directorist_is_multi_directory_enabled() ) {
             $params['directory'] = array(
-                'description'        => __( 'Query plans by directory id.', 'directorist' ),
-                'type'               => 'integer',
-                'sanitize_callback'  => 'absint',
+                'description'       => __( 'Query plans by directory id.', 'directorist' ),
+                'type'              => 'integer',
+                'sanitize_callback' => 'absint',
             );
         }
 
@@ -1089,8 +1667,8 @@ class Plans_Controller extends Posts_Controller {
 
     protected function get_orderby_possibles() {
         return array(
-            'title'   => 'title',
-            'date'    => 'date',
+            'title' => 'title',
+            'date'  => 'date',
         );
     }
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [x] Bugfix
- [ ] Security fix
- [x] Improvement
- [ ] New Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
Why this PR is needed:

The current `Plans_Controller` still depends on the legacy `ATBDP_Pricing_Plans` / `atbdp_pricing_plans` implementation and checks fee-manager or plan storage details in Directorist core. That makes the `/directorist/v1/plans` endpoint incompatible with the new Directorist Pricing Plans extension, where plan data is owned by the extension instead of the legacy pricing-plan post type.

What has been done:

1. Removed legacy `ATBDP_Pricing_Plans` / `atbdp_pricing_plans` detection from `Plans_Controller`.
2. Removed core-side fee-manager and new-pricing-plan table checks.
3. Added the `directorist_is_active_pricing_plans` filter to detect the new Pricing Plans extension.
4. Delegated Pricing Plans collection, single-plan data, and permission checks to extension-provided REST filters.
5. Kept the existing WooCommerce pricing plans fallback path intact.

How to test the changes:

1. Install and activate Directorist with the companion Pricing Plans extension PR: https://github.com/sovware/directorist-pricing-plans-new/pull/87
2. Create/publish one or more pricing plans in the new Pricing Plans extension.
3. Request `/wp-json/directorist/v1/plans` and confirm the endpoint returns the extension-provided plan collection.
4. Request `/wp-json/directorist/v1/plans/{id}` for a published plan and confirm it returns the single plan response.
5. Confirm the WooCommerce pricing plans flow still works when the WooCommerce pricing plans extension is active instead.

## Any linked issues
Fixes #

Companion PR: https://github.com/sovware/directorist-pricing-plans-new/pull/87

## Checklist

- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
